### PR TITLE
Adding `clangd` support for metal code

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,33 @@
+# Apply a config conditionally to all C files
+If:
+  PathMatch: .*\.(c|h)$
+
+---
+
+# Apply a config conditionally to all C files
+If:
+  PathMatch: .*\.(c|h)pp
+
+---
+
+If:
+  PathMatch: .*\.metal?
+
+CompileFlags:
+  Add:
+    # language settings
+    - '--std'
+    - 'c++14'
+    - '-x'
+    - 'c++'
+    # includes
+    - '-I'
+    - '/System/Library/Frameworks'
+    - '-I'
+    - '/Library/Frameworks'
+    - '-I'
+    - '/usr/local/include'
+    - '-I'
+    - '/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/metal/32023/lib/clang/32023.335/include'
+    - '-I'
+    - '/System/Library/PrivateFrameworks/GPUCompiler.framework/Versions/32023/Libraries/lib/clang/32023.401/include/metal'


### PR DESCRIPTION
It's actually the subject. 

Provided config helps `clangd` to handle metal files correctly and additionally helps it to determine where `metal` system libraries to import from.

Tested on Sublime Text but should works with VSC as well.

UPD: FWIW this hack does not provide full support of metal, since `clangd` currently incompatible with metal specific syntax like `[[kernel]]`, `constant` etc. This leads to significant number of false positives, which may confuse contributor, thus it's not the right feature to be opted-in in repo. So I'm closing this PR so far.