### PR TITLE
ci(metal_msm): Temporarily disable GPU benchmarks

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -31,18 +31,19 @@ jobs:
             - name: Check formatting
               run: cargo fmt --all -- --check
 
-    gpu-benchmarks:
-        runs-on: macos-latest
-        steps:
-            - uses: actions/checkout@v4
-            - name: Install Rust toolchain
-              uses: actions-rs/toolchain@v1
-              with:
-                  toolchain: "1.77"
-                  override: true
-            - name: Run sccache-cache
-              uses: mozilla-actions/sccache-action@v0.0.3
-            - name: Run GPU Benchmarks tests
-              run: |
-                  cd mopro-msm
-                  cargo test --release test_msm_correctness -- --nocapture
+# TODO: Temporarily disable GPU benchmarks since it's under refactoring
+    # gpu-benchmarks:
+    #     runs-on: macos-latest
+    #     steps:
+    #         - uses: actions/checkout@v4
+    #         - name: Install Rust toolchain
+    #           uses: actions-rs/toolchain@v1
+    #           with:
+    #               toolchain: "1.77"
+    #               override: true
+    #         - name: Run sccache-cache
+    #           uses: mozilla-actions/sccache-action@v0.0.3
+    #         - name: Run GPU Benchmarks tests
+    #           run: |
+    #               cd mopro-msm
+    #               cargo test --release test_msm_correctness -- --nocapture


### PR DESCRIPTION
This pull request includes a temporary change to the `.github/workflows/build-and-test.yml` file. The GPU benchmarks job has been disabled as it is currently under refactoring.

Changes in GitHub Actions workflow:

* [`.github/workflows/build-and-test.yml`](diffhunk://#diff-bc668a2c9f2299cef15b222055b4b4d5311646caec2e7610e540cee18ae9b948L34-R49): Commented out the `gpu-benchmarks` job to temporarily disable it.