### PR TITLE
fix: add `#pragma once` as the header guard to prevent redefinition error

### DIFF
--- a/mopro-msm/src/msm/metal_msm/shader/bigint/bigint.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/bigint/bigint.metal
@@ -1,4 +1,5 @@
 // source: https://github.com/geometryxyz/msl-secp256k1
+#pragma once
 
 using namespace metal;
 #include "../misc/get_constant.metal"

--- a/mopro-msm/src/msm/metal_msm/shader/curve/jacobian.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/curve/jacobian.metal
@@ -1,5 +1,6 @@
 // source: https://github.com/geometryxyz/msl-secp256k1
 // algorithms: https://hyperelliptic.org/EFD/g1p/auto-shortw-jacobian-0.html
+#pragma once
 
 using namespace metal;
 #include <metal_stdlib>

--- a/mopro-msm/src/msm/metal_msm/shader/field/ff.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/field/ff.metal
@@ -1,4 +1,5 @@
 // source: https://github.com/geometryxyz/msl-secp256k1
+#pragma once
 
 using namespace metal;
 #include <metal_stdlib>

--- a/mopro-msm/src/msm/metal_msm/shader/misc/get_constant.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/misc/get_constant.metal
@@ -1,3 +1,5 @@
+#pragma once
+
 using namespace metal;
 #include <metal_stdlib>
 #include "../constants.metal"

--- a/mopro-msm/src/msm/metal_msm/shader/misc/types.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/misc/types.metal
@@ -1,3 +1,5 @@
+#pragma once
+
 using namespace metal;
 #include <metal_stdlib>
 

--- a/mopro-msm/src/msm/metal_msm/shader/mont_backend/mont.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/mont_backend/mont.metal
@@ -1,4 +1,5 @@
 // adapted from: https://github.com/geometryxyz/msl-secp256k1
+#pragma once
 
 using namespace metal;
 #include <metal_stdlib>


### PR DESCRIPTION
* This is a hotfix to prevent redefinition error.
* add `#pragma once` for each file to only compile once

`#pragma once` is a header guard that serves the same purpose as the traditional one `#ifndef`/ `#define` / `#endif` pattern.