### PR TITLE
Feat/utils/limbs conversion

### DIFF
--- a/mopro-msm/src/msm/metal_msm/host/shader.rs
+++ b/mopro-msm/src/msm/metal_msm/host/shader.rs
@@ -12,7 +12,7 @@
  * xcrun -sdk macosx metallib <path.ir> -o <path.metallib>
  */
 
-use crate::msm::metal_msm::utils::limbs_conversion::ToLimbs;
+use crate::msm::metal_msm::utils::limbs_conversion::GenericLimbConversion;
 use ark_bn254::Fq as BaseField;
 use ark_ff::PrimeField;
 use std::fs;

--- a/mopro-msm/src/msm/metal_msm/tests/bigint/bigint_add_unsafe.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/bigint/bigint_add_unsafe.rs
@@ -4,7 +4,7 @@ use crate::msm::metal_msm::host::gpu::{
     create_buffer, create_empty_buffer, get_default_device, read_buffer,
 };
 use crate::msm::metal_msm::host::shader::{compile_metal, write_constants};
-use crate::msm::metal_msm::utils::limbs_conversion::{FromLimbs, ToLimbs};
+use crate::msm::metal_msm::utils::limbs_conversion::GenericLimbConversion;
 use ark_ff::{BigInt, BigInteger, UniformRand};
 use ark_std::rand;
 use metal::*;
@@ -19,8 +19,8 @@ pub fn test_bigint_add_unsafe() {
     // Create two test numbers that do not cause overflow
     let mut rng = rand::thread_rng();
     let (a, b, expected) = loop {
-        let a = BigInt::rand(&mut rng);
-        let b = BigInt::rand(&mut rng);
+        let a = BigInt::<4>::rand(&mut rng);
+        let b = BigInt::<4>::rand(&mut rng);
 
         let mut expected = a.clone();
         let overflow = expected.add_with_carry(&b);

--- a/mopro-msm/src/msm/metal_msm/tests/bigint/bigint_add_wide.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/bigint/bigint_add_wide.rs
@@ -4,7 +4,7 @@ use crate::msm::metal_msm::host::gpu::{
     create_buffer, create_empty_buffer, get_default_device, read_buffer,
 };
 use crate::msm::metal_msm::host::shader::{compile_metal, write_constants};
-use crate::msm::metal_msm::utils::limbs_conversion::{FromLimbs, ToLimbs};
+use crate::msm::metal_msm::utils::limbs_conversion::GenericLimbConversion;
 use ark_ff::{BigInt, BigInteger, UniformRand};
 use ark_std::rand;
 use metal::*;
@@ -19,8 +19,8 @@ pub fn test_bigint_add_no_overflow() {
     // Create two test numbers that do not cause overflow
     let mut rng = rand::thread_rng();
     let (a, b, expected) = loop {
-        let a = BigInt::rand(&mut rng);
-        let b = BigInt::rand(&mut rng);
+        let a = BigInt::<4>::rand(&mut rng);
+        let b = BigInt::<4>::rand(&mut rng);
 
         let mut expected = a.clone();
         let overflow = expected.add_with_carry(&b);
@@ -107,8 +107,8 @@ pub fn test_bigint_add_overflow() {
     // Create two test numbers that cause overflow
     let mut rng = rand::thread_rng();
     let (a, b, expected) = loop {
-        let a = BigInt::rand(&mut rng);
-        let b = BigInt::rand(&mut rng);
+        let a = BigInt::<4>::rand(&mut rng);
+        let b = BigInt::<4>::rand(&mut rng);
 
         let mut expected = a.clone();
         let overflow = expected.add_with_carry(&b);

--- a/mopro-msm/src/msm/metal_msm/tests/bigint/bigint_sub.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/bigint/bigint_sub.rs
@@ -4,7 +4,7 @@ use crate::msm::metal_msm::host::gpu::{
     create_buffer, create_empty_buffer, get_default_device, read_buffer,
 };
 use crate::msm::metal_msm::host::shader::{compile_metal, write_constants};
-use crate::msm::metal_msm::utils::limbs_conversion::{FromLimbs, ToLimbs};
+use crate::msm::metal_msm::utils::limbs_conversion::GenericLimbConversion;
 use ark_ff::{BigInt, BigInteger, UniformRand};
 use ark_std::rand;
 use metal::*;
@@ -19,8 +19,8 @@ pub fn test_bigint_sub_no_underflow() {
     // Create two test numbers that do not cause underflow
     let mut rng = rand::thread_rng();
     let (a, b, expected) = loop {
-        let a = BigInt::rand(&mut rng);
-        let b = BigInt::rand(&mut rng);
+        let a = BigInt::<4>::rand(&mut rng);
+        let b = BigInt::<4>::rand(&mut rng);
 
         let mut expected = a.clone();
         let underflow = expected.sub_with_borrow(&b);
@@ -105,8 +105,8 @@ fn test_bigint_sub_underflow() {
     // Create two test numbers that cause underflow
     let mut rng = rand::thread_rng();
     let (a, b, expected) = loop {
-        let a = BigInt::rand(&mut rng);
-        let b = BigInt::rand(&mut rng);
+        let a = BigInt::<4>::rand(&mut rng);
+        let b = BigInt::<4>::rand(&mut rng);
 
         let mut expected = a.clone();
         let underflow = expected.sub_with_borrow(&b);

--- a/mopro-msm/src/msm/metal_msm/tests/curve/jacobian_add_2007_b1.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/curve/jacobian_add_2007_b1.rs
@@ -8,7 +8,7 @@ use crate::msm::metal_msm::host::gpu::{
     create_buffer, create_empty_buffer, get_default_device, read_buffer,
 };
 use crate::msm::metal_msm::host::shader::{compile_metal, write_constants};
-use crate::msm::metal_msm::utils::limbs_conversion::{FromLimbs, ToLimbs};
+use crate::msm::metal_msm::utils::limbs_conversion::GenericLimbConversion;
 use crate::msm::metal_msm::utils::mont_params::{calc_mont_radix, calc_nsafe, calc_rinv_and_n0};
 use ark_ff::{BigInt, PrimeField};
 use ark_std::{rand::thread_rng, UniformRand};
@@ -157,13 +157,13 @@ pub fn test_jacobian_add_2007_bl() {
     let result_yr_limbs: Vec<u32> = read_buffer(&result_yr_buf, num_limbs);
     let result_zr_limbs: Vec<u32> = read_buffer(&result_zr_buf, num_limbs);
 
-    let result_xr: BigUint = BigInt::from_limbs(&result_xr_limbs, log_limb_size)
+    let result_xr: BigUint = BigInt::<4>::from_limbs(&result_xr_limbs, log_limb_size)
         .try_into()
         .unwrap();
-    let result_yr: BigUint = BigInt::from_limbs(&result_yr_limbs, log_limb_size)
+    let result_yr: BigUint = BigInt::<4>::from_limbs(&result_yr_limbs, log_limb_size)
         .try_into()
         .unwrap();
-    let result_zr: BigUint = BigInt::from_limbs(&result_zr_limbs, log_limb_size)
+    let result_zr: BigUint = BigInt::<4>::from_limbs(&result_zr_limbs, log_limb_size)
         .try_into()
         .unwrap();
 

--- a/mopro-msm/src/msm/metal_msm/tests/curve/jacobian_dbl_2009_l.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/curve/jacobian_dbl_2009_l.rs
@@ -8,7 +8,7 @@ use crate::msm::metal_msm::host::gpu::{
     create_buffer, create_empty_buffer, get_default_device, read_buffer,
 };
 use crate::msm::metal_msm::host::shader::{compile_metal, write_constants};
-use crate::msm::metal_msm::utils::limbs_conversion::{FromLimbs, ToLimbs};
+use crate::msm::metal_msm::utils::limbs_conversion::GenericLimbConversion;
 use crate::msm::metal_msm::utils::mont_params::{calc_mont_radix, calc_nsafe, calc_rinv_and_n0};
 use ark_ff::{BigInt, PrimeField};
 use ark_std::{rand::thread_rng, UniformRand};
@@ -123,13 +123,13 @@ pub fn test_jacobian_dbl_2009_l() {
     let result_yr_limbs: Vec<u32> = read_buffer(&result_yr_buf, num_limbs);
     let result_zr_limbs: Vec<u32> = read_buffer(&result_zr_buf, num_limbs);
 
-    let result_xr: BigUint = BigInt::from_limbs(&result_xr_limbs, log_limb_size)
+    let result_xr: BigUint = BigInt::<4>::from_limbs(&result_xr_limbs, log_limb_size)
         .try_into()
         .unwrap();
-    let result_yr: BigUint = BigInt::from_limbs(&result_yr_limbs, log_limb_size)
+    let result_yr: BigUint = BigInt::<4>::from_limbs(&result_yr_limbs, log_limb_size)
         .try_into()
         .unwrap();
-    let result_zr: BigUint = BigInt::from_limbs(&result_zr_limbs, log_limb_size)
+    let result_zr: BigUint = BigInt::<4>::from_limbs(&result_zr_limbs, log_limb_size)
         .try_into()
         .unwrap();
 

--- a/mopro-msm/src/msm/metal_msm/tests/curve/jacobian_madd_2007_bl.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/curve/jacobian_madd_2007_bl.rs
@@ -8,7 +8,7 @@ use crate::msm::metal_msm::host::gpu::{
     create_buffer, create_empty_buffer, get_default_device, read_buffer,
 };
 use crate::msm::metal_msm::host::shader::{compile_metal, write_constants};
-use crate::msm::metal_msm::utils::limbs_conversion::{FromLimbs, ToLimbs};
+use crate::msm::metal_msm::utils::limbs_conversion::GenericLimbConversion;
 use crate::msm::metal_msm::utils::mont_params::{calc_mont_radix, calc_nsafe, calc_rinv_and_n0};
 use ark_ff::{BigInt, PrimeField};
 use ark_std::{rand::thread_rng, UniformRand};
@@ -153,13 +153,13 @@ pub fn test_jacobian_add_2007_bl() {
     let result_yr_limbs: Vec<u32> = read_buffer(&result_yr_buf, num_limbs);
     let result_zr_limbs: Vec<u32> = read_buffer(&result_zr_buf, num_limbs);
 
-    let result_xr: BigUint = BigInt::from_limbs(&result_xr_limbs, log_limb_size)
+    let result_xr: BigUint = BigInt::<4>::from_limbs(&result_xr_limbs, log_limb_size)
         .try_into()
         .unwrap();
-    let result_yr: BigUint = BigInt::from_limbs(&result_yr_limbs, log_limb_size)
+    let result_yr: BigUint = BigInt::<4>::from_limbs(&result_yr_limbs, log_limb_size)
         .try_into()
         .unwrap();
-    let result_zr: BigUint = BigInt::from_limbs(&result_zr_limbs, log_limb_size)
+    let result_zr: BigUint = BigInt::<4>::from_limbs(&result_zr_limbs, log_limb_size)
         .try_into()
         .unwrap();
 

--- a/mopro-msm/src/msm/metal_msm/tests/field/ff_add.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/field/ff_add.rs
@@ -4,7 +4,7 @@ use crate::msm::metal_msm::host::gpu::{
     create_buffer, create_empty_buffer, get_default_device, read_buffer,
 };
 use crate::msm::metal_msm::host::shader::{compile_metal, write_constants};
-use crate::msm::metal_msm::utils::limbs_conversion::{FromLimbs, ToLimbs};
+use crate::msm::metal_msm::utils::limbs_conversion::GenericLimbConversion;
 use ark_bn254::Fq as BaseField;
 use ark_ff::{BigInt, BigInteger, PrimeField, UniformRand};
 use ark_std::rand;
@@ -20,8 +20,8 @@ pub fn test_ff_add() {
     let p = BaseField::MODULUS;
 
     let mut rng = rand::thread_rng();
-    let mut a = BigInt::rand(&mut rng);
-    let mut b = BigInt::rand(&mut rng);
+    let mut a = BigInt::<4>::rand(&mut rng);
+    let mut b = BigInt::<4>::rand(&mut rng);
 
     // Reduce a and b if they are greater than or equal to the prime field modulus
     while a >= p {

--- a/mopro-msm/src/msm/metal_msm/tests/field/ff_sub.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/field/ff_sub.rs
@@ -4,7 +4,7 @@ use crate::msm::metal_msm::host::gpu::{
     create_buffer, create_empty_buffer, get_default_device, read_buffer,
 };
 use crate::msm::metal_msm::host::shader::{compile_metal, write_constants};
-use crate::msm::metal_msm::utils::limbs_conversion::{FromLimbs, ToLimbs};
+use crate::msm::metal_msm::utils::limbs_conversion::GenericLimbConversion;
 use ark_bn254::Fq as BaseField;
 use ark_ff::{BigInt, BigInteger, PrimeField, UniformRand};
 use ark_std::rand;
@@ -20,8 +20,8 @@ pub fn test_ff_sub() {
     let p = BaseField::MODULUS;
 
     let mut rng = rand::thread_rng();
-    let mut a = BigInt::rand(&mut rng);
-    let mut b = BigInt::rand(&mut rng);
+    let mut a = BigInt::<4>::rand(&mut rng);
+    let mut b = BigInt::<4>::rand(&mut rng);
 
     // Reduce a and b if they are greater than or equal to the prime field modulus
     while a >= p {

--- a/mopro-msm/src/msm/metal_msm/tests/misc/get_constant.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/misc/get_constant.rs
@@ -1,6 +1,6 @@
 use crate::msm::metal_msm::host::gpu::{create_empty_buffer, get_default_device, read_buffer};
 use crate::msm::metal_msm::host::shader::compile_metal;
-use crate::msm::metal_msm::utils::limbs_conversion::{FromLimbs, ToLimbs};
+use crate::msm::metal_msm::utils::limbs_conversion::GenericLimbConversion;
 use crate::msm::metal_msm::utils::mont_params::{calc_mont_radix, calc_rinv_and_n0};
 use ark_bn254::Fq as BaseField;
 use ark_ff::{BigInt, PrimeField};

--- a/mopro-msm/src/msm/metal_msm/tests/mont_backend/mont_benchmarks.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/mont_backend/mont_benchmarks.rs
@@ -1,6 +1,6 @@
 use crate::msm::metal_msm::host::gpu::{create_buffer, create_empty_buffer, get_default_device};
 use crate::msm::metal_msm::host::shader::{compile_metal, write_constants};
-use crate::msm::metal_msm::utils::limbs_conversion::{FromLimbs, ToLimbs};
+use crate::msm::metal_msm::utils::limbs_conversion::GenericLimbConversion;
 use crate::msm::metal_msm::utils::mont_params::{
     calc_bitwidth, calc_mont_radix, calc_nsafe, calc_num_limbs, calc_rinv_and_n0,
 };
@@ -161,7 +161,7 @@ pub fn benchmark(log_limb_size: u32, shader_file: &str) -> Result<i64, String> {
         panic!("Pointer is null");
     }
 
-    let result = BigInt::from_limbs(&result_limbs, log_limb_size);
+    let result = BigInt::<4>::from_limbs(&result_limbs, log_limb_size);
 
     // assert!(result == expected.try_into().unwrap());
     // assert!(result_limbs == expected_limbs);

--- a/mopro-msm/src/msm/metal_msm/tests/mont_backend/mont_mul_cios.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/mont_backend/mont_mul_cios.rs
@@ -4,7 +4,7 @@ use crate::msm::metal_msm::host::gpu::{
     create_buffer, create_empty_buffer, get_default_device, read_buffer,
 };
 use crate::msm::metal_msm::host::shader::{compile_metal, write_constants};
-use crate::msm::metal_msm::utils::limbs_conversion::{FromLimbs, ToLimbs};
+use crate::msm::metal_msm::utils::limbs_conversion::GenericLimbConversion;
 use crate::msm::metal_msm::utils::mont_params::{calc_mont_radix, calc_nsafe, calc_rinv_and_n0};
 use ark_bn254::Fq as BaseField;
 use ark_ff::{BigInt, PrimeField};
@@ -119,7 +119,7 @@ pub fn do_test(log_limb_size: u32) {
     command_buffer.wait_until_completed();
 
     let result_limbs: Vec<u32> = read_buffer(&result_buf, num_limbs);
-    let result = BigInt::from_limbs(&result_limbs, log_limb_size);
+    let result = BigInt::<4>::from_limbs(&result_limbs, log_limb_size);
 
     assert!(result == expected.try_into().unwrap());
     assert!(result_limbs == expected_limbs);

--- a/mopro-msm/src/msm/metal_msm/tests/mont_backend/mont_mul_modified.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/mont_backend/mont_mul_modified.rs
@@ -4,7 +4,7 @@ use crate::msm::metal_msm::host::gpu::{
     create_buffer, create_empty_buffer, get_default_device, read_buffer,
 };
 use crate::msm::metal_msm::host::shader::{compile_metal, write_constants};
-use crate::msm::metal_msm::utils::limbs_conversion::{FromLimbs, ToLimbs};
+use crate::msm::metal_msm::utils::limbs_conversion::GenericLimbConversion;
 use crate::msm::metal_msm::utils::mont_params::{calc_mont_radix, calc_nsafe, calc_rinv_and_n0};
 use ark_bn254::Fq as BaseField;
 use ark_ff::{BigInt, PrimeField};
@@ -119,7 +119,7 @@ pub fn do_test(log_limb_size: u32) {
     command_buffer.wait_until_completed();
 
     let result_limbs: Vec<u32> = read_buffer(&result_buf, num_limbs);
-    let result = BigInt::from_limbs(&result_limbs, log_limb_size);
+    let result = BigInt::<4>::from_limbs(&result_limbs, log_limb_size);
 
     assert!(result == expected.try_into().unwrap());
     assert!(result_limbs == expected_limbs);

--- a/mopro-msm/src/msm/metal_msm/tests/mont_backend/mont_mul_optimised.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/mont_backend/mont_mul_optimised.rs
@@ -7,7 +7,7 @@ use crate::msm::metal_msm::host::gpu::{
     create_buffer, create_empty_buffer, get_default_device, read_buffer,
 };
 use crate::msm::metal_msm::host::shader::{compile_metal, write_constants};
-use crate::msm::metal_msm::utils::limbs_conversion::{FromLimbs, ToLimbs};
+use crate::msm::metal_msm::utils::limbs_conversion::GenericLimbConversion;
 use crate::msm::metal_msm::utils::mont_params::{calc_mont_radix, calc_rinv_and_n0};
 use ark_bn254::Fq as BaseField;
 use ark_ff::{BigInt, PrimeField};
@@ -122,7 +122,7 @@ pub fn do_test(log_limb_size: u32) {
     command_buffer.wait_until_completed();
 
     let result_limbs: Vec<u32> = read_buffer(&result_buf, num_limbs);
-    let result = BigInt::from_limbs(&result_limbs, log_limb_size);
+    let result = BigInt::<4>::from_limbs(&result_limbs, log_limb_size);
 
     assert!(result == expected.try_into().unwrap());
     assert!(result_limbs == expected_limbs);
@@ -149,7 +149,7 @@ pub fn test_number_conversions() {
         .to_limbs(num_limbs, log_limb_size);
 
     // Convert limbs back to BigUint
-    let converted_biguint: BigUint = BigInt::from_limbs(&limbs, log_limb_size)
+    let converted_biguint: BigUint = BigInt::<4>::from_limbs(&limbs, log_limb_size)
         .try_into()
         .unwrap();
 
@@ -170,7 +170,7 @@ pub fn test_number_conversions() {
     for value in test_values {
         let scalar = BaseField::from_bigint(value.clone().try_into().unwrap()).unwrap();
         let value_limbs = scalar.into_bigint().to_limbs(num_limbs, log_limb_size);
-        let converted: BigUint = BigInt::from_limbs(&value_limbs, log_limb_size)
+        let converted: BigUint = BigInt::<4>::from_limbs(&value_limbs, log_limb_size)
             .try_into()
             .unwrap();
 

--- a/mopro-msm/src/msm/metal_msm/utils/limbs_conversion.rs
+++ b/mopro-msm/src/msm/metal_msm/utils/limbs_conversion.rs
@@ -1,25 +1,37 @@
-use ark_bn254::Fq;
 use ark_ff::biginteger::{BigInteger, BigInteger256};
+use std::convert::TryInto;
 
-use crate::msm::metal::abstraction::mont_reduction;
+/// A trait that abstracts "to/from limbs" for *any* BigInteger type
+pub trait GenericLimbConversion {
+    /// The number of 64-bit words in this BigInteger (e.g., 4 for BigInteger256)
+    const NUM_WORDS: usize;
 
-// implement to_u32_limbs and from_u32_limbs for BigInt<4>
-pub trait ToLimbs {
+    /// Convert to big-endian `u32` limbs of length `2 * NUM_WORDS`.
+    /// (Because each 64-bit word can be split into two 32-bit limbs.)
     fn to_u32_limbs(&self) -> Vec<u32>;
+
+    /// Convert to `num_limbs` (little-endian) of size `1 << log_limb_size` each.
     fn to_limbs(&self, num_limbs: usize, log_limb_size: u32) -> Vec<u32>;
-}
 
-pub trait FromLimbs {
+    /// Construct from big-endian `u32` limbs.
     fn from_u32_limbs(limbs: &[u32]) -> Self;
-    fn from_limbs(limbs: &[u32], log_limb_size: u32) -> Self;
+
+    /// Construct from little-endian `u128`.
     fn from_u128(num: u128) -> Self;
+
+    /// Construct from little-endian `u32`.
     fn from_u32(num: u32) -> Self;
+
+    /// Construct from variable-size limbs, each of size `1 << log_limb_size`.
+    fn from_limbs(limbs: &[u32], log_limb_size: u32) -> Self;
 }
 
-// convert from little endian to big endian
-impl ToLimbs for BigInteger256 {
+impl GenericLimbConversion for BigInteger256 {
+    const NUM_WORDS: usize = 4; // 4 x 64-bit words
+
     fn to_u32_limbs(&self) -> Vec<u32> {
         let mut limbs = Vec::new();
+        // BigInteger256::to_bytes_be() gives us 32 bytes in BE
         self.to_bytes_be().chunks(8).for_each(|chunk| {
             let high = u32::from_be_bytes(chunk[0..4].try_into().unwrap());
             let low = u32::from_be_bytes(chunk[4..8].try_into().unwrap());
@@ -34,13 +46,17 @@ impl ToLimbs for BigInteger256 {
         let limb_size = 1u32 << log_limb_size;
         let mask = limb_size - 1;
 
-        // Convert to little-endian representation
+        // Convert to LE
         let bytes = self.to_bytes_le();
         let mut val = 0u32;
         let mut bits = 0u32;
         let mut limb_idx = 0;
 
         for &byte in bytes.iter() {
+            // if we've already filled all limbs, discard the rest and break
+            if limb_idx >= num_limbs {
+                break;
+            }
             val |= (byte as u32) << bits;
             bits += 8;
 
@@ -51,112 +67,75 @@ impl ToLimbs for BigInteger256 {
                 limb_idx += 1;
             }
         }
-
-        // Handle any remaining bits
+        // handle leftover
         if bits > 0 && limb_idx < num_limbs {
             result[limb_idx] = val;
         }
-
         result
     }
-}
 
-// convert from little endian to big endian
-impl ToLimbs for Fq {
-    fn to_u32_limbs(&self) -> Vec<u32> {
-        let mut limbs = Vec::new();
-        self.0.to_bytes_be().chunks(8).for_each(|chunk| {
-            let high = u32::from_be_bytes(chunk[0..4].try_into().unwrap());
-            let low = u32::from_be_bytes(chunk[4..8].try_into().unwrap());
-            limbs.push(high);
-            limbs.push(low);
-        });
-        limbs
-    }
-
-    fn to_limbs(&self, num_limbs: usize, log_limb_size: u32) -> Vec<u32> {
-        self.0.to_limbs(num_limbs, log_limb_size)
-    }
-}
-
-impl FromLimbs for BigInteger256 {
-    // convert from big endian to little endian for metal
     fn from_u32_limbs(limbs: &[u32]) -> Self {
         let mut big_int = [0u64; 4];
-        for (i, limb) in limbs.chunks(2).rev().enumerate() {
-            let high = u64::from(limb[0]);
-            let low = u64::from(limb[1]);
+        // same logic from your code
+        for (i, limb_pair) in limbs.chunks(2).rev().enumerate() {
+            let high = u64::from(limb_pair[0]);
+            let low = u64::from(limb_pair[1]);
             big_int[i] = (high << 32) | low;
         }
         BigInteger256::new(big_int)
     }
-    // provide little endian u128 since arkworks use this value as well
+
     fn from_u128(num: u128) -> Self {
         let high = (num >> 64) as u64;
         let low = num as u64;
         BigInteger256::new([low, high, 0, 0])
     }
-    // provide little endian u32 since arkworks use this value as well
+
     fn from_u32(num: u32) -> Self {
         BigInteger256::new([num as u64, 0, 0, 0])
     }
 
     fn from_limbs(limbs: &[u32], log_limb_size: u32) -> Self {
         let mut result = [0u64; 4];
-        let limb_size = log_limb_size as usize;
+        let limb_bits = log_limb_size as usize;
         let mut accumulated_bits = 0;
         let mut current_u64 = 0u64;
         let mut result_idx = 0;
 
         for &limb in limbs {
-            // Add the current limb at the appropriate position
             current_u64 |= (limb as u64) << accumulated_bits;
-            accumulated_bits += limb_size;
+            accumulated_bits += limb_bits;
 
-            // If we've accumulated 64 bits or more, store the result
             while accumulated_bits >= 64 && result_idx < 4 {
                 result[result_idx] = current_u64;
-                current_u64 = limb as u64 >> (limb_size - (accumulated_bits - 64));
+                // shift out the stored bits
+                current_u64 = (limb as u64) >> (limb_bits - (accumulated_bits - 64));
                 accumulated_bits -= 64;
                 result_idx += 1;
             }
         }
-
-        // Handle any remaining bits
         if accumulated_bits > 0 && result_idx < 4 {
             result[result_idx] = current_u64;
         }
-
         BigInteger256::new(result)
     }
 }
 
-impl FromLimbs for Fq {
-    // convert from big endian to little endian for metal
-    fn from_u32_limbs(limbs: &[u32]) -> Self {
-        let mut big_int = [0u64; 4];
-        for (i, limb) in limbs.chunks(2).rev().enumerate() {
-            let high = u64::from(limb[0]);
-            let low = u64::from(limb[1]);
-            big_int[i] = (high << 32) | low;
-        }
-        Fq::new(mont_reduction::raw_reduction(BigInteger256::new(big_int)))
-    }
-    fn from_u128(num: u128) -> Self {
-        let high = (num >> 64) as u64;
-        let low = num as u64;
-        Fq::new(mont_reduction::raw_reduction(BigInteger256::new([
-            low, high, 0, 0,
-        ])))
-    }
-    fn from_u32(num: u32) -> Self {
-        Fq::new(mont_reduction::raw_reduction(BigInteger256::new([
-            num as u64, 0, 0, 0,
-        ])))
-    }
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-    fn from_limbs(limbs: &[u32], log_limb_size: u32) -> Self {
-        let bigint = BigInteger256::from_limbs(limbs, log_limb_size);
-        Fq::new(mont_reduction::raw_reduction(bigint))
+    use ark_bn254::Fq as BaseField;
+    use ark_ff::PrimeField;
+
+    #[test]
+    fn test_within_bigint256() {
+        let num_limbs = 16;
+        let log_limb_size = 16;
+
+        let p_limbs = BaseField::MODULUS.to_limbs(num_limbs, log_limb_size);
+        let p_bigint256 = BigInteger256::from_limbs(&p_limbs, log_limb_size);
+
+        assert_eq!(BaseField::MODULUS, p_bigint256);
     }
 }

--- a/mopro-msm/src/msm/metal_msm/utils/limbs_conversion.rs
+++ b/mopro-msm/src/msm/metal_msm/utils/limbs_conversion.rs
@@ -1,4 +1,4 @@
-use ark_ff::biginteger::{BigInteger, BigInteger256};
+use ark_ff::biginteger::{BigInteger, BigInteger256, BigInteger384};
 use std::convert::TryInto;
 
 /// A trait that abstracts "to/from limbs" for *any* BigInteger type
@@ -121,12 +121,103 @@ impl GenericLimbConversion for BigInteger256 {
     }
 }
 
+impl GenericLimbConversion for BigInteger384 {
+    const NUM_WORDS: usize = 6; // 6 x 64-bit words
+
+    fn to_u32_limbs(&self) -> Vec<u32> {
+        let mut limbs = Vec::new();
+        self.to_bytes_be().chunks(8).for_each(|chunk| {
+            let high = u32::from_be_bytes(chunk[0..4].try_into().unwrap());
+            let low = u32::from_be_bytes(chunk[4..8].try_into().unwrap());
+            limbs.push(high);
+            limbs.push(low);
+        });
+        limbs
+    }
+
+    fn to_limbs(&self, num_limbs: usize, log_limb_size: u32) -> Vec<u32> {
+        let mut result = vec![0u32; num_limbs];
+        let limb_size = 1u32 << log_limb_size;
+        let mask = limb_size - 1;
+
+        let bytes = self.to_bytes_le();
+        let mut val = 0u32;
+        let mut bits = 0u32;
+        let mut limb_idx = 0;
+
+        for &byte in bytes.iter() {
+            // if we've already filled all limbs, discard the rest and break
+            if limb_idx >= num_limbs {
+                break;
+            }
+            val |= (byte as u32) << bits;
+            bits += 8;
+
+            while bits >= log_limb_size && limb_idx < num_limbs {
+                result[limb_idx] = val & mask;
+                val >>= log_limb_size;
+                bits -= log_limb_size;
+                limb_idx += 1;
+            }
+        }
+        if bits > 0 && limb_idx < num_limbs {
+            result[limb_idx] = val;
+        }
+        result
+    }
+
+    fn from_u32_limbs(limbs: &[u32]) -> Self {
+        let mut big_int = [0u64; 6];
+        for (i, limb_pair) in limbs.chunks(2).rev().enumerate() {
+            let high = u64::from(limb_pair[0]);
+            let low = u64::from(limb_pair[1]);
+            big_int[i] = (high << 32) | low;
+        }
+        BigInteger384::new(big_int)
+    }
+
+    fn from_u128(num: u128) -> Self {
+        let high = (num >> 64) as u64;
+        let low = num as u64;
+        BigInteger384::new([low, high, 0, 0, 0, 0])
+    }
+
+    fn from_u32(num: u32) -> Self {
+        BigInteger384::new([num as u64, 0, 0, 0, 0, 0])
+    }
+
+    fn from_limbs(limbs: &[u32], log_limb_size: u32) -> Self {
+        let mut result = [0u64; 6];
+        let limb_bits = log_limb_size as usize;
+        let mut accumulated_bits = 0;
+        let mut current_u64 = 0u64;
+        let mut result_idx = 0;
+
+        for &limb in limbs {
+            current_u64 |= (limb as u64) << accumulated_bits;
+            accumulated_bits += limb_bits;
+
+            while accumulated_bits >= 64 && result_idx < 6 {
+                result[result_idx] = current_u64;
+                current_u64 = (limb as u64) >> (limb_bits - (accumulated_bits - 64));
+                accumulated_bits -= 64;
+                result_idx += 1;
+            }
+        }
+        if accumulated_bits > 0 && result_idx < 6 {
+            result[result_idx] = current_u64;
+        }
+        BigInteger384::new(result)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    use crate::msm::metal_msm::utils::mont_params::calc_mont_radix;
     use ark_bn254::Fq as BaseField;
-    use ark_ff::PrimeField;
+    use ark_ff::{BigInt, PrimeField};
 
     #[test]
     fn test_within_bigint256() {
@@ -137,5 +228,20 @@ mod tests {
         let p_bigint256 = BigInteger256::from_limbs(&p_limbs, log_limb_size);
 
         assert_eq!(BaseField::MODULUS, p_bigint256);
+    }
+
+    #[test]
+    fn test_within_bigint384() {
+        let num_limbs = 16;
+        let num_limbs_wide = num_limbs + 1;
+        let log_limb_size = 16;
+
+        let r = calc_mont_radix(num_limbs, log_limb_size); // r has 257 bits
+        let r_bigint384: BigInt<6> = r.try_into().unwrap();
+        let r_limbs = r_bigint384.to_limbs(num_limbs_wide, log_limb_size);
+        let r_reconstructed = BigInteger384::from_limbs(&r_limbs, log_limb_size);
+
+        // Check if the original and reconstructed values are equal
+        assert_eq!(r_bigint384, r_reconstructed);
     }
 }

--- a/mopro-msm/src/msm/metal_msm/utils/limbs_conversion.rs
+++ b/mopro-msm/src/msm/metal_msm/utils/limbs_conversion.rs
@@ -76,7 +76,6 @@ impl GenericLimbConversion for BigInteger256 {
 
     fn from_u32_limbs(limbs: &[u32]) -> Self {
         let mut big_int = [0u64; 4];
-        // same logic from your code
         for (i, limb_pair) in limbs.chunks(2).rev().enumerate() {
             let high = u64::from(limb_pair[0]);
             let low = u64::from(limb_pair[1]);


### PR DESCRIPTION
This pull request makes several changes to the `mopro-msm` project, focusing on updating the usage of limb conversion utilities and modifying the `BigInt` type instantiation. The most important changes include replacing `FromLimbs` and `ToLimbs` with `GenericLimbConversion` and specifying the size parameter for `BigInt`.

### Limb Conversion Utility Update:
* Updated imports to use `GenericLimbConversion` instead of `FromLimbs` and `ToLimbs` in multiple test files. [[1]](diffhunk://#diff-7e8b6b5206ea3569cff11dd982bf176abd658108e493123eadab9041967ee833L15-R15) [[2]](diffhunk://#diff-2f17fd548146f8ae80d8b4467a681ec3a63b4fcdbb1192dbef1fece73d05d83cL7-R7) [[3]](diffhunk://#diff-d8800cbd572836ca6d4b0be3368ca1193347d63809a64d040112ce802db12bb4L7-R7) [[4]](diffhunk://#diff-e8f40061eb53f3ae170bfa24961d818594343acfc452db91d71eb2c70232f33aL7-R7) [[5]](diffhunk://#diff-9f1dc713409fb2457c171c7c07d1601268252af8e650d28296a61e3f7be06b0cL11-R11) [[6]](diffhunk://#diff-d377acc3db50beed76322403de3b395dea1b8758c8a1e44f185a1bc2fac3b972L11-R11) [[7]](diffhunk://#diff-2f1364bd67d018c75b2112fddf361f61e8c65a79d7162eb91c8dc703fd5385cbL11-R11) [[8]](diffhunk://#diff-4b34611201ecf1629d04637b6f4b9c2e659d0647e09bac874b8fc8701910547bL7-R7) [[9]](diffhunk://#diff-26cc3782ec6049e9c3bffdd795fc0d9cdf4114999df8881eec6d14131ea3fd73L7-R7) [[10]](diffhunk://#diff-297f09b3fa91a9071374c776227cf627536aa5f1e3405649be2705eeb84957a1L3-R3) [[11]](diffhunk://#diff-b9c6b52a60b9cf181275e45d484453ab97f68daac1183b02ea8a847ff5f7bf59L3-R3) [[12]](diffhunk://#diff-c166d1d6974e4fd09f82b93f3141410bd56aeb3dfd08e504a89b08a237011febL7-R7) [[13]](diffhunk://#diff-e13ae4cb93f14e23a5c9de112287c11d7212941c2668348f489102591c3ea20bL7-R7) [[14]](diffhunk://#diff-cb90ca90e0471468e323b1de63bedba0005e9e9df5297215961d5ec4a214e420L10-R10)

### `BigInt` Type Instantiation:
* Specified the size parameter for `BigInt` in various test functions to `BigInt::<4>`. This change was applied to functions testing addition, subtraction, and other operations. [[1]](diffhunk://#diff-2f17fd548146f8ae80d8b4467a681ec3a63b4fcdbb1192dbef1fece73d05d83cL22-R23) [[2]](diffhunk://#diff-d8800cbd572836ca6d4b0be3368ca1193347d63809a64d040112ce802db12bb4L22-R23) [[3]](diffhunk://#diff-d8800cbd572836ca6d4b0be3368ca1193347d63809a64d040112ce802db12bb4L110-R111) [[4]](diffhunk://#diff-e8f40061eb53f3ae170bfa24961d818594343acfc452db91d71eb2c70232f33aL22-R23) [[5]](diffhunk://#diff-e8f40061eb53f3ae170bfa24961d818594343acfc452db91d71eb2c70232f33aL108-R109) [[6]](diffhunk://#diff-9f1dc713409fb2457c171c7c07d1601268252af8e650d28296a61e3f7be06b0cL160-R166) [[7]](diffhunk://#diff-d377acc3db50beed76322403de3b395dea1b8758c8a1e44f185a1bc2fac3b972L126-R132) [[8]](diffhunk://#diff-2f1364bd67d018c75b2112fddf361f61e8c65a79d7162eb91c8dc703fd5385cbL156-R162) [[9]](diffhunk://#diff-4b34611201ecf1629d04637b6f4b9c2e659d0647e09bac874b8fc8701910547bL23-R24) [[10]](diffhunk://#diff-26cc3782ec6049e9c3bffdd795fc0d9cdf4114999df8881eec6d14131ea3fd73L23-R24) [[11]](diffhunk://#diff-b9c6b52a60b9cf181275e45d484453ab97f68daac1183b02ea8a847ff5f7bf59L164-R164) [[12]](diffhunk://#diff-c166d1d6974e4fd09f82b93f3141410bd56aeb3dfd08e504a89b08a237011febL122-R122) [[13]](diffhunk://#diff-e13ae4cb93f14e23a5c9de112287c11d7212941c2668348f489102591c3ea20bL122-R122) [[14]](diffhunk://#diff-cb90ca90e0471468e323b1de63bedba0005e9e9df5297215961d5ec4a214e420L125-R125) [[15]](diffhunk://#diff-cb90ca90e0471468e323b1de63bedba0005e9e9df5297215961d5ec4a214e420L152-R152)