### PR TITLE
refactor limb conversion: update GenericLimbConversion to BigInt (incl. BigInt<8> support)

### DIFF
--- a/mopro-msm/src/msm/metal_msm/host/shader.rs
+++ b/mopro-msm/src/msm/metal_msm/host/shader.rs
@@ -111,6 +111,7 @@ pub fn write_constants(
 ) {
     let two_pow_word_size = 2u32.pow(log_limb_size);
     let mask = two_pow_word_size - 1u32;
+    let slack = num_limbs as u32 * log_limb_size - BaseField::MODULUS_BIT_SIZE;
     let num_limbs_wide = num_limbs + 1;
     let basefield_modulus = BaseField::MODULUS.to_limbs(num_limbs, log_limb_size);
     let r = calc_mont_radix(num_limbs, log_limb_size);
@@ -132,6 +133,7 @@ pub fn write_constants(
     data += format!("#define MASK {}\n", mask).as_str();
     data += format!("#define N0 {}\n", n0).as_str();
     data += format!("#define NSAFE {}\n", nsafe).as_str();
+    data += format!("#define SLACK {}\n", slack).as_str();
 
     write_constant_array!(
         data,
@@ -182,7 +184,6 @@ pub fn write_constants(
     );
 
     let p: BigUint = BaseField::MODULUS.try_into().unwrap();
-    let (rinv, n0) = calc_rinv_and_n0(&p, &r, log_limb_size);
     let (bn254_zero_xr_limbs, bn254_zero_yr_limbs, bn254_zero_zr_limbs) = {
         let bn254_zero_x: BigUint = bn254_zero.x.into();
         let bn254_zero_y: BigUint = bn254_zero.y.into();

--- a/mopro-msm/src/msm/metal_msm/utils/limbs_conversion.rs
+++ b/mopro-msm/src/msm/metal_msm/utils/limbs_conversion.rs
@@ -333,4 +333,25 @@ mod tests {
         // Check if the original and reconstructed values are equal
         assert_eq!(r_bigint384, r_reconstructed);
     }
+
+    #[test]
+    fn test_within_bigint512() {
+        let num_limbs = 16;
+        let num_limbs_extra_wide = num_limbs * 2;
+        let log_limb_size = 16;
+
+        let mut rng = rand::thread_rng();
+        let p: BigUint = BaseField::MODULUS.try_into().unwrap();
+        let a = rng.gen_biguint_below(&p); // a has at most 254 bits
+        let r = calc_mont_radix(num_limbs, log_limb_size); // r has 257 bits
+
+        let mont_a = &a * &r; // mont_a has at most 511 bits
+
+        let mont_a_bigint512: BigInt<8> = mont_a.try_into().unwrap();
+        let mont_a_limbs = mont_a_bigint512.to_limbs(num_limbs_extra_wide, log_limb_size);
+        let mont_a_reconstructed = BigInt::<8>::from_limbs(&mont_a_limbs, log_limb_size);
+
+        // Check if the original and reconstructed values are equal
+        assert_eq!(mont_a_bigint512, mont_a_reconstructed);
+    }
 }


### PR DESCRIPTION
This pull request includes changes to the `mopro-msm` project, specifically focusing on the `metal_msm` module. The main updates involve adding the `slack` variable to the `write_constants` function, modifying the `GenericLimbConversion` trait implementations to use `BigInt` instead of `BigInteger`, and adding support for `BigInt<8>`. Additionally, new tests have been introduced to verify the functionality of these changes.

### Updates to `write_constants` function:

* Added the `slack` variable to account for the difference between the number of limbs and the modulus bit size. (`mopro-msm/src/msm/metal_msm/host/shader.rs`, [mopro-msm/src/msm/metal_msm/host/shader.rsR114](diffhunk://#diff-7e8b6b5206ea3569cff11dd982bf176abd658108e493123eadab9041967ee833R114))
* Included the `slack` variable in the generated constants. (`mopro-msm/src/msm/metal_msm/host/shader.rs`, [mopro-msm/src/msm/metal_msm/host/shader.rsR136](diffhunk://#diff-7e8b6b5206ea3569cff11dd982bf176abd658108e493123eadab9041967ee833R136))

### Changes to `GenericLimbConversion` trait:

* Replaced `BigInteger256` and `BigInteger384` with `BigInt<4>` and `BigInt<6>` respectively in the `GenericLimbConversion` trait implementations. (`mopro-msm/src/msm/metal_msm/utils/limbs_conversion.rs`, [[1]](diffhunk://#diff-90ef2f0bf1e3024e195fa7f9722a120da26ac70c2b97b79a2e2fa6126ba40672L1-R6) [[2]](diffhunk://#diff-90ef2f0bf1e3024e195fa7f9722a120da26ac70c2b97b79a2e2fa6126ba40672L29-R34) [[3]](diffhunk://#diff-90ef2f0bf1e3024e195fa7f9722a120da26ac70c2b97b79a2e2fa6126ba40672L84-R94) [[4]](diffhunk://#diff-90ef2f0bf1e3024e195fa7f9722a120da26ac70c2b97b79a2e2fa6126ba40672L119-R123) [[5]](diffhunk://#diff-90ef2f0bf1e3024e195fa7f9722a120da26ac70c2b97b79a2e2fa6126ba40672L175-R185) [[6]](diffhunk://#diff-90ef2f0bf1e3024e195fa7f9722a120da26ac70c2b97b79a2e2fa6126ba40672L209-R298)
* Added a new implementation for `BigInt<8>` to the `GenericLimbConversion` trait. (`mopro-msm/src/msm/metal_msm/utils/limbs_conversion.rs`, [mopro-msm/src/msm/metal_msm/utils/limbs_conversion.rsR309-R317](diffhunk://#diff-90ef2f0bf1e3024e195fa7f9722a120da26ac70c2b97b79a2e2fa6126ba40672R309-R317))

### New tests:

* Added tests to verify the correctness of the `GenericLimbConversion` trait implementations for `BigInt<4>`, `BigInt<6>`, and `BigInt<8>`. (`mopro-msm/src/msm/metal_msm/utils/limbs_conversion.rs`, [[1]](diffhunk://#diff-90ef2f0bf1e3024e195fa7f9722a120da26ac70c2b97b79a2e2fa6126ba40672R309-R317) [[2]](diffhunk://#diff-90ef2f0bf1e3024e195fa7f9722a120da26ac70c2b97b79a2e2fa6126ba40672L241-R356)