### PR TITLE
Fix mont_mul_cios with 16-limbs inputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 target/
 vectors/
 graph.bin
+**/*.metallib

--- a/mopro-msm/src/msm/metal_msm/shader/bigint/bigint.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/bigint/bigint.metal
@@ -117,6 +117,24 @@ bool is_bigint_zero(BigInt x) {
     return true;
 }
 
+// Conversion functions
+BigIntWide bigint_to_wide(BigInt x) {
+    BigIntWide res = bigint_zero_wide();
+    for (uint i = 0; i < NUM_LIMBS; i++) {
+        res.limbs[i] = x.limbs[i];
+    }
+    return res;
+}
+
+BigInt bigint_from_wide(BigIntWide x) {
+    BigInt res = bigint_zero();
+    // ignore the last limb
+    for (uint i = 0; i < NUM_LIMBS; i++) {
+        res.limbs[i] = x.limbs[i];
+    }
+    return res;
+}
+
 // Overload Operators
 constexpr BigInt operator+(const BigInt lhs, const BigInt rhs) {
     return bigint_add_unsafe(lhs, rhs).value;

--- a/mopro-msm/src/msm/metal_msm/shader/cuzk/barrett_reduction.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/cuzk/barrett_reduction.metal
@@ -5,11 +5,11 @@ using namespace metal;
 #include <metal_math>
 #include "../field/ff.metal"
 
-BigIntExtraWide mul(BigInt a, BigInt b) {
+BigIntExtraWide mul(BigIntWide a, BigIntWide b) {
     BigIntExtraWide res = bigint_zero_extra_wide();
     
-    for (uint i = 0; i < NUM_LIMBS; i++) {
-        for (uint j = 0; j < NUM_LIMBS; j++) {
+    for (uint i = 0; i < NUM_LIMBS_WIDE; i++) {
+        for (uint j = 0; j < NUM_LIMBS_WIDE; j++) {
             ulong c = (ulong)a.limbs[i] * (ulong)b.limbs[j];
             res.limbs[i+j] += c & MASK;
             res.limbs[i+j+1] += c >> LOG_LIMB_SIZE;
@@ -68,9 +68,9 @@ BigInt barrett_reduce(BigIntExtraWide a) {
     BigInt mu = get_mu();
 
     BigInt a_hi = get_higher_with_slack(a);
-    BigIntExtraWide l = mul(a_hi, mu);
+    BigIntExtraWide l = mul(bigint_to_wide(a_hi), bigint_to_wide(mu));
     BigInt l_hi = get_higher_with_slack(l);
-    BigIntExtraWide lp = mul(l_hi, p);
+    BigIntExtraWide lp = mul(bigint_to_wide(l_hi), bigint_to_wide(p));
 
     // Subtract lp from original a
     BigIntResultExtraWide sub_result = sub_512(a, lp);
@@ -90,7 +90,7 @@ BigInt barrett_reduce(BigIntExtraWide a) {
     return ff_reduce(r, p);
 }
 
-BigInt field_mul(BigInt a, BigInt b) {
+BigInt field_mul(BigIntWide a, BigIntWide b) {
     BigIntExtraWide xy = mul(a, b);
     return barrett_reduce(xy);
 }

--- a/mopro-msm/src/msm/metal_msm/shader/cuzk/kernel_field_mul.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/cuzk/kernel_field_mul.metal
@@ -4,8 +4,8 @@ using namespace metal;
 #include "barrett_reduction.metal"
 
 kernel void run(
-    device BigInt* a [[ buffer(0) ]],
-    device BigInt* b [[ buffer(1) ]],
+    device BigIntWide* a [[ buffer(0) ]],
+    device BigIntWide* b [[ buffer(1) ]],
     device BigInt* res [[ buffer(2) ]],
     uint gid [[ thread_position_in_grid ]]
 ) {

--- a/mopro-msm/src/msm/metal_msm/shader/misc/get_constant.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/misc/get_constant.metal
@@ -25,9 +25,9 @@ BigInt get_n0() {
     return n0;
 }
 
-BigInt get_r() {
-    BigInt r;
-    for (uint i = 0; i < NUM_LIMBS; i++) {
+BigIntWide get_r() {
+    BigIntWide r;
+    for (uint i = 0; i < NUM_LIMBS_WIDE; i++) {
         r.limbs[i] = MONT_RADIX[i];
     }
     return r;

--- a/mopro-msm/src/msm/metal_msm/shader/misc/test_get_constant.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/misc/test_get_constant.metal
@@ -10,7 +10,7 @@ kernel void test_get_n0(device BigInt* result) {
     *result = get_n0();
 }
 
-kernel void test_get_r(device BigInt* result) {
+kernel void test_get_r(device BigIntWide* result) {
     *result = get_r();
 }
 

--- a/mopro-msm/src/msm/metal_msm/tests/misc/get_constant.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/misc/get_constant.rs
@@ -132,6 +132,7 @@ pub fn test_get_p() {
     assert_eq!(result, expected);
 }
 
+/// for 16-bit limbs, r has 257 bits
 #[test]
 pub fn test_get_r() {
     prepare_constants(NUM_LIMBS, LOG_LIMB_SIZE);
@@ -182,9 +183,9 @@ pub fn test_get_r() {
     command_buffer.wait_until_completed();
 
     let result_limbs: Vec<u32> = read_buffer(&result_buf, NUM_LIMBS_WIDE);
-    let result = BigInt::from_limbs(&result_limbs, LOG_LIMB_SIZE);
+    let result = BigInt::<6>::from_limbs(&result_limbs, LOG_LIMB_SIZE);
 
-    let expected: BigInt<4> = calc_mont_radix(NUM_LIMBS, LOG_LIMB_SIZE)
+    let expected: BigInt<6> = calc_mont_radix(NUM_LIMBS, LOG_LIMB_SIZE)
         .try_into()
         .unwrap();
     let expected_limbs = expected.to_limbs(NUM_LIMBS_WIDE, LOG_LIMB_SIZE);

--- a/mopro-msm/src/msm/metal_msm/utils/limbs_conversion.rs
+++ b/mopro-msm/src/msm/metal_msm/utils/limbs_conversion.rs
@@ -349,9 +349,9 @@ mod tests {
         let mut rng = rand::thread_rng();
         let p: BigUint = BaseField::MODULUS.try_into().unwrap();
         let a = rng.gen_biguint_below(&p); // a has at most 254 bits
-        let r = calc_mont_radix(num_limbs, log_limb_size); // r has 255 bits
+        let r = calc_mont_radix(num_limbs, log_limb_size); // r has 257 bits
 
-        let mont_a = &a * &r; // mont_a has at most 509 bits
+        let mont_a = &a * &r; // mont_a has at most 511 bits
 
         let mont_a_bigint512: BigInt<8> = mont_a.try_into().unwrap();
         let mont_a_limbs = mont_a_bigint512.to_limbs(num_limbs_extra_wide, log_limb_size);

--- a/mopro-msm/src/msm/metal_msm/utils/mont_params.rs
+++ b/mopro-msm/src/msm/metal_msm/utils/mont_params.rs
@@ -29,10 +29,6 @@ pub fn calc_nsafe(log_limb_size: u32) -> usize {
 }
 
 pub fn calc_mont_radix(num_limbs: usize, log_limb_size: u32) -> BigUint {
-    // for bn254, we use 255 bits for the montgomery radix
-    if num_limbs as u32 * log_limb_size == 256 {
-        return BigUint::from(2u32).pow(255u32);
-    }
     BigUint::from(2u32).pow(num_limbs as u32 * log_limb_size)
 }
 
@@ -132,13 +128,6 @@ pub fn calc_num_limbs(log_limb_size: u32, p_bitwidth: usize) -> usize {
     while num_limbs * l <= p_bitwidth {
         num_limbs += 1;
     }
-
-    if p_bitwidth == 256 && log_limb_size == 15 {
-        return 19;
-    }
-
-    // TODO: account for cases like (15, 377) where num_limbs should be 27?
-
     num_limbs
 }
 


### PR DESCRIPTION
- close #46 

To match the Montgomery Radix (`r`) used in Arkworks, we adjust the current `r` from 256 to 257 bits. This changes introduce the following modifications:
- Extend limb conversion capability to deal with BigInt<6> (suitable for bigint in between 257 to 384 bits)
- Adopt data types used in Barrett Reduction to match 257 bits input (i.e. from `BigInt` to `BigIntWide`)
- Adjust unit tests to check the results from Metal with Arkworks' crates
- Misc changes including constant getters affected by modification of `r`

Test results are all correct after this fix.
```
running 35 tests
test msm::metal_msm::tests::bigint::bigint_add_wide::test_bigint_add_no_overflow ... ok
test msm::metal_msm::tests::bigint::bigint_add_wide::test_bigint_add_overflow ... ok
test msm::metal_msm::tests::bigint::bigint_sub::test_bigint_sub_no_underflow ... ok
test msm::metal_msm::tests::bigint::bigint_sub::test_bigint_sub_underflow ... ok
test msm::metal_msm::tests::curve::jacobian_add_2007_b1::test_jacobian_add_2007_bl ... ok
test msm::metal_msm::tests::curve::jacobian_add_2007_b1::test_jacobian_add_2007_bl_two_equals ... ok
test msm::metal_msm::tests::curve::jacobian_add_2007_b1::test_jacobian_add_2007_bl_zero ... ok
test msm::metal_msm::tests::curve::jacobian_dbl_2009_l::test_jacobian_dbl_2009_l ... ok
test msm::metal_msm::tests::curve::jacobian_scalar_mul::test_jacobian_scalar_mul ... ok
test msm::metal_msm::tests::cuzk::barrett_reduction::test_barrett_reduce_with_mont_params ... ok
test msm::metal_msm::tests::cuzk::barrett_reduction::test_field_mul_with_mont_params ... ok
test msm::metal_msm::tests::misc::get_constant::test_get_bn254_one ... ok
test msm::metal_msm::tests::bigint::bigint_add_unsafe::test_bigint_add_unsafe ... ok
test msm::metal_msm::tests::misc::get_constant::test_get_bn254_zero ... ok
test msm::metal_msm::tests::misc::get_constant::test_get_bn254_one_mont ... ok
test msm::metal_msm::tests::field::ff_add::test_ff_add ... ok
test msm::metal_msm::tests::misc::get_constant::test_get_mu ... ok
test msm::metal_msm::tests::misc::get_constant::test_get_bn254_zero_mont ... ok
test msm::metal_msm::tests::misc::get_constant::test_get_n0 ... ok
test msm::metal_msm::tests::misc::get_constant::test_get_p ... ok
test msm::metal_msm::tests::mont_backend::mont_benchmarks::all_benchmarks ... ignored
test msm::metal_msm::tests::misc::get_constant::test_get_p_wide ... ok
test msm::metal_msm::tests::curve::jacobian_madd_2007_bl::test_jacobian_add_2007_bl ... ok
test msm::metal_msm::tests::misc::get_constant::test_get_r ... ok
test msm::metal_msm::tests::field::ff_reduce::test_ff_reduce_a_greater_than_p_less_than_2p ... ok
test msm::metal_msm::tests::curve::jacobian_scalar_mul::test_jacobian_scalar_mul_random ... ok
test msm::metal_msm::tests::field::ff_reduce::test_ff_reduce_a_less_than_p ... ok
test msm::metal_msm::tests::field::ff_sub::test_ff_sub ... ok
test msm::metal_msm::tests::mont_backend::mont_mul_cios::test_mont_mul_15 ... ok
test msm::metal_msm::tests::mont_backend::mont_mul_cios::test_mont_mul_16 ... ok
test msm::metal_msm::tests::mont_backend::mont_mul_modified::test_mont_mul_14 ... ok
test msm::metal_msm::tests::mont_backend::mont_mul_modified::test_mont_mul_15 ... ok
test msm::metal_msm::tests::mont_backend::mont_mul_optimised::test_mont_mul_12 ... ok
test msm::metal_msm::tests::mont_backend::mont_mul_optimised::test_mont_mul_13 ... ok
test msm::metal_msm::tests::mont_backend::mont_mul_optimised::test_number_conversions ... ok
```