### PR TITLE
Feat/cuzk/convert point coords and scalar decompose

### DIFF
--- a/mopro-msm/src/msm/metal_msm/host/shader.rs
+++ b/mopro-msm/src/msm/metal_msm/host/shader.rs
@@ -100,6 +100,49 @@ pub fn write_constants(
     let slack = num_limbs as u32 * log_limb_size - BaseField::MODULUS_BIT_SIZE;
     let num_limbs_wide = num_limbs + 1;
     let num_limbs_extra_wide = num_limbs * 2;
+
+    // MSM instance params
+    let input_size = BaseField::MODULUS_BIT_SIZE / 32;
+    let chunk_size = if input_size >= 65536 { 16 } else { 4 };
+    let num_columns = 2u32.pow(chunk_size);
+    let num_rows = (input_size as f32 / num_columns as f32).ceil() as u32;
+    let num_subtasks = (256 as f32 / chunk_size as f32).ceil() as u32;
+
+    let mut c_workgroup_size = 64;
+    let mut c_num_x_workgroups = 128;
+    let mut c_num_y_workgroups = input_size / c_workgroup_size / c_num_x_workgroups;
+    let c_num_z_workgroups = 1;
+
+    if input_size <= 256 {
+        c_workgroup_size = input_size;
+        c_num_x_workgroups = 1;
+        c_num_y_workgroups = 1;
+    } else if input_size > 256 && input_size <= 32768 {
+        c_workgroup_size = 64;
+        c_num_x_workgroups = 4;
+        c_num_y_workgroups = input_size / c_workgroup_size / c_num_x_workgroups;
+    } else if input_size > 32768 && input_size <= 65536 {
+        c_workgroup_size = 256;
+        c_num_x_workgroups = 8;
+        c_num_y_workgroups = input_size / c_workgroup_size / c_num_x_workgroups;
+    } else if input_size > 65536 && input_size <= 131072 {
+        c_workgroup_size = 256;
+        c_num_x_workgroups = 8;
+        c_num_y_workgroups = input_size / c_workgroup_size / c_num_x_workgroups;
+    } else if input_size > 131072 && input_size <= 262144 {
+        c_workgroup_size = 256;
+        c_num_x_workgroups = 32;
+        c_num_y_workgroups = input_size / c_workgroup_size / c_num_x_workgroups;
+    } else if input_size > 262144 && input_size <= 524288 {
+        c_workgroup_size = 256;
+        c_num_x_workgroups = 32;
+        c_num_y_workgroups = input_size / c_workgroup_size / c_num_x_workgroups;
+    } else if input_size > 524288 && input_size <= 1048576 {
+        c_workgroup_size = 256;
+        c_num_x_workgroups = 32;
+        c_num_y_workgroups = input_size / c_workgroup_size / c_num_x_workgroups;
+    }
+
     let basefield_modulus = BaseField::MODULUS.to_limbs(num_limbs, log_limb_size);
     let r = calc_mont_radix(num_limbs, log_limb_size);
     let p: BigUint = BaseField::MODULUS.try_into().unwrap();
@@ -124,6 +167,14 @@ pub fn write_constants(
     data += format!("#define N0 {}\n", n0).as_str();
     data += format!("#define NSAFE {}\n", nsafe).as_str();
     data += format!("#define SLACK {}\n", slack).as_str();
+    data += format!("#define CHUNK_SIZE {}\n", chunk_size).as_str();
+    data += format!("#define NUM_COLUMNS {}\n", num_columns).as_str();
+    data += format!("#define NUM_ROWS {}\n", num_rows).as_str();
+    data += format!("#define NUM_SUBTASKS {}\n", num_subtasks).as_str();
+    data += format!("#define WORKGROUP_SIZE {}\n", c_workgroup_size).as_str();
+    data += format!("#define NUM_X_WORKGROUPS {}\n", c_num_x_workgroups).as_str();
+    data += format!("#define NUM_Y_WORKGROUPS {}\n", c_num_y_workgroups).as_str();
+    data += format!("#define NUM_Z_WORKGROUPS {}\n", c_num_z_workgroups).as_str();
 
     let mu_limbs = mu_in_ark.to_limbs(num_limbs, log_limb_size);
     write_constant_array!(data, "BARRETT_MU", mu_limbs, "NUM_LIMBS");

--- a/mopro-msm/src/msm/metal_msm/shader/cuzk/convert_point_coords_and_decompose_scalars.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/cuzk/convert_point_coords_and_decompose_scalars.metal
@@ -1,0 +1,122 @@
+using namespace metal;
+#include <metal_stdlib>
+#include <metal_math>
+#include "../misc/get_constant.metal"
+#include "barrett_reduction.metal"
+#include "extract_word_from_bytes_le.metal"
+
+kernel void convert_point_coords_and_decompose_scalars(
+    device const uint * coords       [[buffer(0)]],
+    device const uint * scalars      [[buffer(1)]],
+    constant uint & input_size       [[buffer(2)]],
+    device BigInt * point_x          [[buffer(3)]],
+    device BigInt * point_y          [[buffer(4)]],
+    device uint * chunks             [[buffer(5)]],
+    uint3 gid                        [[thread_position_in_grid]]
+)
+{
+    uint gidx = gid.x;
+    uint gidy = gid.y;
+    uint id   = gidx * NUM_Y_WORKGROUPS + gidy;
+
+    // // Safety check or early return if id >= total number of points
+    // if (id >= total_points) {
+    //     return;
+    // }
+
+    // 1) Convert coords to BigInt in Montgomery form
+    // We read 16 halfwords for x and 16 halfwords for y. 
+    uint x_bytes[16];
+    uint y_bytes[16];
+
+    // offset within coords array for this point:
+    //  coords layout: [x0_32, x1_32, ..., x7_32, y0_32, y1_32, ..., y7_32]
+    //  so each point uses 16 x 32-bit = 16 indices.
+    uint base_offset = id * 16u;
+
+    for (uint i = 0u; i < 8u; i++) {
+        // coords[base_offset + i] is the i-th 32-bit chunk of x
+        // coords[base_offset + 8 + i] is the i-th 32-bit chunk of y
+        uint x_val = coords[base_offset + i];
+        uint y_val = coords[base_offset + 8u + i];
+
+        x_bytes[15 - (i * 2)]     = x_val & 0xFFFFu;
+        x_bytes[15 - (i * 2) - 1] = x_val >> 16u;
+
+        y_bytes[15 - (i * 2)]     = y_val & 0xFFFFu;
+        y_bytes[15 - (i * 2) - 1] = y_val >> 16u;
+    }
+
+    BigInt x_bigint = bigint_zero();
+    BigInt y_bigint = bigint_zero();
+
+    for (uint i = 0; i < (NUM_LIMBS - 1u); i++) {
+        x_bigint.limbs[i] = extract_word_from_bytes_le(x_bytes, i, LOG_LIMB_SIZE);
+        y_bigint.limbs[i] = extract_word_from_bytes_le(y_bytes, i, LOG_LIMB_SIZE);
+    }
+
+    uint shift = (((NUM_LIMBS * LOG_LIMB_SIZE) - 256u) + 16u) - LOG_LIMB_SIZE;
+
+    x_bigint.limbs[NUM_LIMBS - 1] = x_bytes[0] >> shift;
+    y_bigint.limbs[NUM_LIMBS - 1] = y_bytes[0] >> shift;
+
+    // Convert x,y to Montgomery form: X = x * R mod p, Y = y * R mod p.
+    BigInt r = get_r();
+    BigInt x_mont = field_mul(x_bigint, r);
+    BigInt y_mont = field_mul(y_bigint, r);
+
+    // Store them in point_x, point_y
+    point_x[id] = x_mont;
+    point_y[id] = y_mont;
+
+    // 2) Decompose scalars: read 8 32-bit values => 16 halfwords in `scalar_bytes`.
+    uint scalar_bytes[16];
+    for (uint i = 0; i < 8u; i++) {
+        uint s = scalars[id * 8u + i];
+        uint hi = s >> 16u;
+        uint lo = s & 0xFFFFu;
+        scalar_bytes[15u - (i * 2u)]     = lo;
+        scalar_bytes[15u - (i * 2u) - 1u] = hi;
+    }
+
+    // an array of `NUM_SUBTASKS` chunks, each chunk is CHUNK_SIZE bits from the scalar.
+
+    uint chunks_arr[NUM_SUBTASKS];
+    for (uint i = 0; i < NUM_SUBTASKS; i++) {
+        uint w = extract_word_from_bytes_le(scalar_bytes, i, CHUNK_SIZE);
+        chunks_arr[i] = w;
+    }
+
+    // The last chunk is special if (NUM_SUBTASKS * CHUNK_SIZE > 256)
+    chunks_arr[NUM_SUBTASKS - 1] =
+        scalar_bytes[0] >> ( ((NUM_SUBTASKS * CHUNK_SIZE - 256u) + 16u) - CHUNK_SIZE);
+
+    // 3) Signed wNAF
+    uint l = NUM_COLUMNS;
+    uint s = l / 2u;
+
+    int signed_slices[NUM_SUBTASKS];
+    int carry = 0;
+    for (uint i = 0; i < NUM_SUBTASKS; i++) {
+        int slice_val = int(chunks_arr[i]) + carry;
+        if (slice_val >= int(s)) {
+            slice_val -= int(l);
+            carry = 1;
+        } else if (slice_val < 0) {
+            slice_val += int(l);
+            carry = -1;
+        } else {
+            carry = 0;
+        }
+        signed_slices[i] = slice_val;
+    }
+
+    // Typically you want a separate location for each subtask. 
+    // The total size might be `NUM_SUBTASKS * input_size`.
+    // Make sure your `chunks` buffer is large enough.
+    for (uint i = 0; i < NUM_SUBTASKS; i++) {
+        uint offset = i * input_size;
+        // shift negative slices by +s to keep them in [0, l) range
+        chunks[id + offset] = uint(signed_slices[i]) + s;
+    }
+}

--- a/mopro-msm/src/msm/metal_msm/shader/cuzk/extract_word_from_bytes_le.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/cuzk/extract_word_from_bytes_le.metal
@@ -29,19 +29,3 @@ uint32_t extract_word_from_bytes_le(
     
     return word;
 }
-
-// // Similar to bigint_funcs from bigint.metal
-// BigInt extract_word_from_bytes_le(constant uint* bytes, uint word_idx, uint word_size) {
-//     uint mask = (1 << word_size) - 1;
-//     uint byte_idx = word_idx * word_size / 32;
-//     uint bit_offset = (word_idx * word_size) % 32;
-    
-//     uint word = bytes[byte_idx];
-//     if (bit_offset + word_size > 32) {
-//         uint next_word = bytes[byte_idx + 1];
-//         word = (next_word << (32 - bit_offset)) | (word >> bit_offset);
-//     } else {
-//         word = (word >> bit_offset) & mask;
-//     }
-//     return word;
-// }

--- a/mopro-msm/src/msm/metal_msm/shader/cuzk/extract_word_from_bytes_le.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/cuzk/extract_word_from_bytes_le.metal
@@ -1,0 +1,31 @@
+#pragma once
+
+using namespace metal;
+#include <metal_stdlib>
+#include <metal_math>
+
+uint32_t extract_word_from_bytes_le(
+    device const uint32_t* input,
+    uint32_t word_idx,
+    uint32_t chunk_size
+) {
+    uint32_t word = 0;
+    const uint32_t start_byte_idx = 15 - ((word_idx * chunk_size + chunk_size) / 16);
+    const uint32_t end_byte_idx = 15 - ((word_idx * chunk_size) / 16);
+    
+    const uint32_t start_byte_offset = (word_idx * chunk_size + chunk_size) % 16;
+    const uint32_t end_byte_offset = (word_idx * chunk_size) % 16;
+    
+    uint32_t mask = 0;
+    if (start_byte_offset > 0) {
+        mask = (2 << (start_byte_offset - 1)) - 1;
+    }
+    if (start_byte_idx == end_byte_idx) {
+        word = (input[start_byte_idx] & mask) >> end_byte_offset;
+    } else {
+        word = (input[start_byte_idx] & mask) << (16 - end_byte_offset);
+        word += input[end_byte_idx] >> end_byte_offset;
+    }
+    
+    return word;
+}

--- a/mopro-msm/src/msm/metal_msm/shader/cuzk/extract_word_from_bytes_le.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/cuzk/extract_word_from_bytes_le.metal
@@ -5,7 +5,7 @@ using namespace metal;
 #include <metal_math>
 
 uint32_t extract_word_from_bytes_le(
-    device const uint32_t* input,
+    const thread uint32_t* input,
     uint32_t word_idx,
     uint32_t chunk_size
 ) {
@@ -29,3 +29,19 @@ uint32_t extract_word_from_bytes_le(
     
     return word;
 }
+
+// // Similar to bigint_funcs from bigint.metal
+// BigInt extract_word_from_bytes_le(constant uint* bytes, uint word_idx, uint word_size) {
+//     uint mask = (1 << word_size) - 1;
+//     uint byte_idx = word_idx * word_size / 32;
+//     uint bit_offset = (word_idx * word_size) % 32;
+    
+//     uint word = bytes[byte_idx];
+//     if (bit_offset + word_size > 32) {
+//         uint next_word = bytes[byte_idx + 1];
+//         word = (next_word << (32 - bit_offset)) | (word >> bit_offset);
+//     } else {
+//         word = (word >> bit_offset) & mask;
+//     }
+//     return word;
+// }

--- a/mopro-msm/src/msm/metal_msm/tests/cuzk/convert_point_coords_and_decompose_scalars.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/cuzk/convert_point_coords_and_decompose_scalars.rs
@@ -14,74 +14,74 @@ use rand::thread_rng;
 #[test]
 #[serial_test::serial]
 fn test_point_coords_conversion() {
+    // BN254 parameters
     let log_limb_size = 16;
     let num_limbs = 16;
     let p: BigUint = BaseField::MODULUS.try_into().unwrap();
+
     let r = calc_mont_radix(num_limbs, log_limb_size);
     let (_, n0) = calc_rinv_and_n0(&p, &r, log_limb_size);
     let nsafe = calc_nsafe(log_limb_size);
 
-    // Generate valid test data (BN254 base field element)
-    let mut rng = thread_rng();
-    let scalar = rng.gen_biguint(256);
-    let scalar_in_scalarfield = ScalarField::from(scalar.clone());
-    let point = G::generator().into_affine();
+    // We only need one scalar for the kernel call, but we won't test it here
+    // So let's just supply zeros for the scalar array
+    let scalars = vec![0u32; num_limbs];
 
+    // Generate a point on BN254 for testing
+    let point = G::generator().into_affine();
     let x: BigUint = point.x.into_bigint().try_into().unwrap();
     let y: BigUint = point.y.into_bigint().try_into().unwrap();
 
+    // Host-side: compute x_mont, y_mont
     let x_mont = (&x * &r) % &p;
     let y_mont = (&y * &r) % &p;
 
+    // Convert them to ark_ff BigInt<4>, then to limbs
     let x_mont_in_ark: BigInt<4> = x_mont.clone().try_into().unwrap();
     let y_mont_in_ark: BigInt<4> = y_mont.clone().try_into().unwrap();
-
     let x_mont_in_ark_limbs = x_mont_in_ark.to_limbs(num_limbs, log_limb_size);
     let y_mont_in_ark_limbs = y_mont_in_ark.to_limbs(num_limbs, log_limb_size);
+
+    // Convert unreduced x,y into `num_limbs` “halfword” limbs
     let x_in_ark: BigInt<4> = x.clone().try_into().unwrap();
     let y_in_ark: BigInt<4> = y.clone().try_into().unwrap();
     let x_limb = x_in_ark.to_limbs(num_limbs, log_limb_size);
     let y_limb = y_in_ark.to_limbs(num_limbs, log_limb_size);
 
-    // Convert coordinates to packed 32-bit limbs (2x16-bit)
-    let pack_limbs = |limbs: Vec<u32>| -> Vec<u32> {
+    // Helper to pack every pair of 16-bit limbs into one 32-bit word
+    let pack_limbs = |limbs: &[u32]| -> Vec<u32> {
         limbs
             .chunks(2)
             .map(|chunk| (chunk[1] << 16) | chunk[0])
             .collect()
     };
 
-    let x_packed = pack_limbs(x_limb);
-    let y_packed = pack_limbs(y_limb);
+    let x_packed = pack_limbs(&x_limb);
+    let y_packed = pack_limbs(&y_limb);
 
-    // Create input buffers with valid data (8 packed u32s per coordinate)
+    // The coords buffer: x + y, each is 8 packed u32 => total 16
     let coords = [x_packed, y_packed].concat();
-    let mut scalars = scalar_in_scalarfield
-        .into_bigint()
-        .to_limbs(num_limbs, log_limb_size);
-    scalars.reverse();
 
+    // Setup Metal buffers
     let device = get_default_device();
     let coords_buf = create_buffer(&device, &coords);
-    let scalars_buf = create_buffer(&device, &scalars);
-    let input_size_buf = create_buffer(&device, &vec![1u32]); // only one point
+    let scalars_buf = create_buffer(&device, &scalars); // all zero
+    let input_size_buf = create_buffer(&device, &vec![1u32]); // only 1 point
 
-    // Create output buffers
+    // Prepare output buffers for the kernel
     let point_x_buf = create_empty_buffer(&device, num_limbs);
     let point_y_buf = create_empty_buffer(&device, num_limbs);
-    let chunk_size = if BaseField::MODULUS_BIT_SIZE / 32 >= 65536 {
-        16
-    } else {
-        4
-    };
-    let num_subtasks = (256f32 / chunk_size as f32).ceil() as usize;
-    let chunks_buf = create_empty_buffer(&device, num_subtasks); // Buffer for scalar chunks
+
+    // We also need a chunks buffer, but we won't actually check it in this test
+    let chunks_buf = create_empty_buffer(&device, num_limbs);
+
+    // Build the pipeline
     let command_queue = device.new_command_queue();
     let command_buffer = command_queue.new_command_buffer();
-
     let compute_pass_descriptor = ComputePassDescriptor::new();
     let encoder = command_buffer.compute_command_encoder_with_descriptor(compute_pass_descriptor);
 
+    // Compile your metal source
     write_constants(
         "../mopro-msm/src/msm/metal_msm/shader",
         num_limbs,
@@ -100,7 +100,6 @@ fn test_point_coords_conversion() {
 
     let pipeline_state_descriptor = ComputePipelineDescriptor::new();
     pipeline_state_descriptor.set_compute_function(Some(&kernel));
-
     let pipeline_state = device
         .new_compute_pipeline_state_with_function(
             pipeline_state_descriptor.compute_function().unwrap(),
@@ -108,6 +107,8 @@ fn test_point_coords_conversion() {
         .unwrap();
 
     encoder.set_compute_pipeline_state(&pipeline_state);
+
+    // Match buffer indices to kernel signature
     encoder.set_buffer(0, Some(&coords_buf), 0);
     encoder.set_buffer(1, Some(&scalars_buf), 0);
     encoder.set_buffer(2, Some(&input_size_buf), 0);
@@ -115,33 +116,203 @@ fn test_point_coords_conversion() {
     encoder.set_buffer(4, Some(&point_y_buf), 0);
     encoder.set_buffer(5, Some(&chunks_buf), 0);
 
-    let thread_group_count = MTLSize {
+    // Dispatch
+    let tg_count = MTLSize {
         width: 1,
         height: 1,
         depth: 1,
     };
-
-    let thread_group_size = MTLSize {
+    let tg_size = MTLSize {
         width: 1,
         height: 1,
         depth: 1,
     };
-
-    encoder.dispatch_thread_groups(thread_group_count, thread_group_size);
+    encoder.dispatch_thread_groups(tg_count, tg_size);
     encoder.end_encoding();
 
     command_buffer.commit();
     command_buffer.wait_until_completed();
 
+    // Read back X,Y results and compare
     let x_result = read_buffer(&point_x_buf, num_limbs);
     let y_result = read_buffer(&point_y_buf, num_limbs);
 
-    assert_eq!(
-        x_result, x_mont_in_ark_limbs,
-        "X coordinate conversion failed"
+    assert_eq!(x_result, x_mont_in_ark_limbs, "X conversion mismatch");
+    assert_eq!(y_result, y_mont_in_ark_limbs, "Y conversion mismatch");
+}
+
+#[test]
+#[serial_test::serial]
+fn test_scalar_decomposition() {
+    // BN254 parameters
+    let log_limb_size = 16;
+    let num_limbs = 16;
+    let chunk_size = if BaseField::MODULUS_BIT_SIZE / 32 >= 65536 {
+        16
+    } else {
+        4
+    };
+    let num_subtasks = (256f32 / chunk_size as f32).ceil() as usize;
+    let num_columns = 1 << chunk_size; // 2^chunk_size
+
+    let p: BigUint = BaseField::MODULUS.try_into().unwrap();
+    let r = calc_mont_radix(num_limbs, log_limb_size);
+    let (_, n0) = calc_rinv_and_n0(&p, &r, log_limb_size);
+    let nsafe = calc_nsafe(log_limb_size);
+
+    // For scalar test, we can provide dummy coords (X=0, Y=0)
+    let coords = vec![0u32; 16]; // 16 zeros
+
+    // Generate a random 254-bit scalar
+    let mut rng = thread_rng();
+    let scalar = rng.gen_biguint(254);
+    let scalar_in_scalarfield = ScalarField::from(scalar.clone());
+
+    // Convert scalar to the same limb format the kernel expects
+    let scalars = scalar_in_scalarfield
+        .into_bigint()
+        .to_limbs(num_limbs, log_limb_size);
+
+    // Setup Metal buffers
+    let device = get_default_device();
+    let coords_buf = create_buffer(&device, &coords); // dummy
+    let scalars_buf = create_buffer(&device, &scalars); // real scalar
+    let input_size_buf = create_buffer(&device, &vec![1u32]); // only 1 scalar
+
+    // We'll ignore X,Y outputs, but we must pass them
+    let point_x_buf = create_empty_buffer(&device, num_limbs);
+    let point_y_buf = create_empty_buffer(&device, num_limbs);
+
+    // The important output: chunk decomposition
+    let chunks_buf = create_empty_buffer(&device, num_subtasks);
+
+    // Build the pipeline
+    let command_queue = device.new_command_queue();
+    let command_buffer = command_queue.new_command_buffer();
+    let compute_pass_descriptor = ComputePassDescriptor::new();
+    let encoder = command_buffer.compute_command_encoder_with_descriptor(compute_pass_descriptor);
+
+    // Compile your metal source
+    write_constants(
+        "../mopro-msm/src/msm/metal_msm/shader",
+        num_limbs,
+        log_limb_size,
+        n0,
+        nsafe,
     );
+    let library_path = compile_metal(
+        "../mopro-msm/src/msm/metal_msm/shader/cuzk",
+        "convert_point_coords_and_decompose_scalars.metal",
+    );
+    let library = device.new_library_with_file(library_path).unwrap();
+    let kernel = library
+        .get_function("convert_point_coords_and_decompose_scalars", None)
+        .unwrap();
+
+    let pipeline_state_descriptor = ComputePipelineDescriptor::new();
+    pipeline_state_descriptor.set_compute_function(Some(&kernel));
+    let pipeline_state = device
+        .new_compute_pipeline_state_with_function(
+            pipeline_state_descriptor.compute_function().unwrap(),
+        )
+        .unwrap();
+
+    encoder.set_compute_pipeline_state(&pipeline_state);
+
+    // Buffer indices to match kernel
+    encoder.set_buffer(0, Some(&coords_buf), 0);
+    encoder.set_buffer(1, Some(&scalars_buf), 0);
+    encoder.set_buffer(2, Some(&input_size_buf), 0);
+    encoder.set_buffer(3, Some(&point_x_buf), 0);
+    encoder.set_buffer(4, Some(&point_y_buf), 0);
+    encoder.set_buffer(5, Some(&chunks_buf), 0);
+
+    let tg_count = MTLSize {
+        width: 1,
+        height: 1,
+        depth: 1,
+    };
+    let tg_size = MTLSize {
+        width: 1,
+        height: 1,
+        depth: 1,
+    };
+    encoder.dispatch_thread_groups(tg_count, tg_size);
+    encoder.end_encoding();
+
+    command_buffer.commit();
+    command_buffer.wait_until_completed();
+
+    // Read back the chunk data from GPU
+    let gpu_chunks = read_buffer(&chunks_buf, num_subtasks);
+
+    // Now replicate the GPU logic in Rust:
+    // (1) build scalar_bytes[16]
+    // (2) extract chunk_size bits
+    // (3) fix up the last chunk for BN254 (254 bits)
+    // (4) do sign logic => range [-s..s-1], then store +s
+    let mut scalar_bytes = vec![0u32; 16];
+    for (i, &val) in scalars.iter().enumerate().take(8) {
+        let lo = val & 0xFFFF;
+        let hi = val >> 16;
+        // mirrored indexing like the kernel
+        scalar_bytes[15 - (i * 2)] = lo;
+        scalar_bytes[15 - (i * 2) - 1] = hi;
+    }
+
+    fn extract_word_from_bytes_le_mock(bytes: &[u32], word_idx: u32, chunk_size: u32) -> u32 {
+        let start_byte_idx = 15 - ((word_idx * chunk_size + chunk_size) / 16);
+        let end_byte_idx = 15 - ((word_idx * chunk_size) / 16);
+        let start_byte_offset = (word_idx * chunk_size + chunk_size) % 16;
+        let end_byte_offset = (word_idx * chunk_size) % 16;
+
+        let mut mask = 0u32;
+        if start_byte_offset > 0 {
+            mask = (2 << (start_byte_offset - 1)) - 1;
+        }
+
+        if start_byte_idx == end_byte_idx {
+            (bytes[start_byte_idx as usize] & mask) >> end_byte_offset
+        } else {
+            let part1 = (bytes[start_byte_idx as usize] & mask) << (16 - end_byte_offset);
+            let part2 = bytes[end_byte_idx as usize] >> end_byte_offset;
+            part1 + part2
+        }
+    }
+
+    // (C) Extract chunk_size-bit words for all but the last chunk
+    let mut cpu_chunks = vec![0u32; num_subtasks];
+    for i in 0..(num_subtasks - 1) {
+        cpu_chunks[i] = extract_word_from_bytes_le_mock(&scalar_bytes, i as u32, chunk_size as u32);
+    }
+
+    // (D) Last chunk for 254 bits: top 2 bits are unused
+    let shift_254 = ((num_subtasks as u32 * chunk_size as u32 - 254) + 16) - chunk_size as u32;
+    cpu_chunks[num_subtasks - 1] = scalar_bytes[0] >> shift_254;
+
+    // (E) Sign logic
+    let l = num_columns;
+    let s = l / 2;
+    let mut carry = 0u32;
+    let mut cpu_signed_slices = vec![0i32; num_subtasks];
+
+    for i in 0..num_subtasks {
+        let raw_val = (cpu_chunks[i] as i32) + (carry as i32);
+        if raw_val >= s as i32 {
+            cpu_signed_slices[i] = (l as i32 - raw_val) * -1;
+            carry = 1;
+        } else {
+            cpu_signed_slices[i] = raw_val;
+            carry = 0;
+        }
+    }
+
+    for i in 0..num_subtasks {
+        cpu_chunks[i] = (cpu_signed_slices[i] + s as i32) as u32;
+    }
+
     assert_eq!(
-        y_result, y_mont_in_ark_limbs,
-        "Y coordinate conversion failed"
+        gpu_chunks, cpu_chunks,
+        "Scalar decomposition mismatch between GPU and CPU!"
     );
 }

--- a/mopro-msm/src/msm/metal_msm/tests/cuzk/convert_point_coords_and_decompose_scalars.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/cuzk/convert_point_coords_and_decompose_scalars.rs
@@ -1,0 +1,147 @@
+use crate::msm::metal_msm::host::gpu::{
+    create_buffer, create_empty_buffer, get_default_device, read_buffer,
+};
+use crate::msm::metal_msm::host::shader::{compile_metal, write_constants};
+use crate::msm::metal_msm::utils::limbs_conversion::GenericLimbConversion;
+use crate::msm::metal_msm::utils::mont_params::{calc_mont_radix, calc_nsafe, calc_rinv_and_n0};
+use ark_bn254::{Fq as BaseField, Fr as ScalarField, G1Projective as G};
+use ark_ec::{CurveGroup, Group};
+use ark_ff::{BigInt, PrimeField};
+use metal::*;
+use num_bigint::{BigUint, RandBigInt};
+use rand::thread_rng;
+
+#[test]
+#[serial_test::serial]
+fn test_point_coords_conversion() {
+    let log_limb_size = 16;
+    let num_limbs = 16;
+    let p: BigUint = BaseField::MODULUS.try_into().unwrap();
+    let r = calc_mont_radix(num_limbs, log_limb_size);
+    let (_, n0) = calc_rinv_and_n0(&p, &r, log_limb_size);
+    let nsafe = calc_nsafe(log_limb_size);
+
+    // Generate valid test data (BN254 base field element)
+    let mut rng = thread_rng();
+    let scalar = rng.gen_biguint(256);
+    let scalar_in_scalarfield = ScalarField::from(scalar.clone());
+    let point = G::generator().into_affine();
+
+    let x: BigUint = point.x.into_bigint().try_into().unwrap();
+    let y: BigUint = point.y.into_bigint().try_into().unwrap();
+
+    let x_mont = (&x * &r) % &p;
+    let y_mont = (&y * &r) % &p;
+
+    let x_mont_in_ark: BigInt<4> = x_mont.clone().try_into().unwrap();
+    let y_mont_in_ark: BigInt<4> = y_mont.clone().try_into().unwrap();
+
+    let x_mont_in_ark_limbs = x_mont_in_ark.to_limbs(num_limbs, log_limb_size);
+    let y_mont_in_ark_limbs = y_mont_in_ark.to_limbs(num_limbs, log_limb_size);
+    let x_in_ark: BigInt<4> = x.clone().try_into().unwrap();
+    let y_in_ark: BigInt<4> = y.clone().try_into().unwrap();
+    let x_limb = x_in_ark.to_limbs(num_limbs, log_limb_size);
+    let y_limb = y_in_ark.to_limbs(num_limbs, log_limb_size);
+
+    // Convert coordinates to packed 32-bit limbs (2x16-bit)
+    let pack_limbs = |limbs: Vec<u32>| -> Vec<u32> {
+        limbs
+            .chunks(2)
+            .map(|chunk| (chunk[1] << 16) | chunk[0])
+            .collect()
+    };
+
+    let x_packed = pack_limbs(x_limb);
+    let y_packed = pack_limbs(y_limb);
+
+    // Create input buffers with valid data (8 packed u32s per coordinate)
+    let coords = [x_packed, y_packed].concat();
+    let mut scalars = scalar_in_scalarfield
+        .into_bigint()
+        .to_limbs(num_limbs, log_limb_size);
+    scalars.reverse();
+
+    let device = get_default_device();
+    let coords_buf = create_buffer(&device, &coords);
+    let scalars_buf = create_buffer(&device, &scalars);
+    let input_size_buf = create_buffer(&device, &vec![1u32]); // only one point
+
+    // Create output buffers
+    let point_x_buf = create_empty_buffer(&device, num_limbs);
+    let point_y_buf = create_empty_buffer(&device, num_limbs);
+    let chunk_size = if BaseField::MODULUS_BIT_SIZE / 32 >= 65536 {
+        16
+    } else {
+        4
+    };
+    let num_subtasks = (256f32 / chunk_size as f32).ceil() as usize;
+    let chunks_buf = create_empty_buffer(&device, num_subtasks); // Buffer for scalar chunks
+    let command_queue = device.new_command_queue();
+    let command_buffer = command_queue.new_command_buffer();
+
+    let compute_pass_descriptor = ComputePassDescriptor::new();
+    let encoder = command_buffer.compute_command_encoder_with_descriptor(compute_pass_descriptor);
+
+    write_constants(
+        "../mopro-msm/src/msm/metal_msm/shader",
+        num_limbs,
+        log_limb_size,
+        n0,
+        nsafe,
+    );
+    let library_path = compile_metal(
+        "../mopro-msm/src/msm/metal_msm/shader/cuzk",
+        "convert_point_coords_and_decompose_scalars.metal",
+    );
+    let library = device.new_library_with_file(library_path).unwrap();
+    let kernel = library
+        .get_function("convert_point_coords_and_decompose_scalars", None)
+        .unwrap();
+
+    let pipeline_state_descriptor = ComputePipelineDescriptor::new();
+    pipeline_state_descriptor.set_compute_function(Some(&kernel));
+
+    let pipeline_state = device
+        .new_compute_pipeline_state_with_function(
+            pipeline_state_descriptor.compute_function().unwrap(),
+        )
+        .unwrap();
+
+    encoder.set_compute_pipeline_state(&pipeline_state);
+    encoder.set_buffer(0, Some(&coords_buf), 0);
+    encoder.set_buffer(1, Some(&scalars_buf), 0);
+    encoder.set_buffer(2, Some(&input_size_buf), 0);
+    encoder.set_buffer(3, Some(&point_x_buf), 0);
+    encoder.set_buffer(4, Some(&point_y_buf), 0);
+    encoder.set_buffer(5, Some(&chunks_buf), 0);
+
+    let thread_group_count = MTLSize {
+        width: 1,
+        height: 1,
+        depth: 1,
+    };
+
+    let thread_group_size = MTLSize {
+        width: 1,
+        height: 1,
+        depth: 1,
+    };
+
+    encoder.dispatch_thread_groups(thread_group_count, thread_group_size);
+    encoder.end_encoding();
+
+    command_buffer.commit();
+    command_buffer.wait_until_completed();
+
+    let x_result = read_buffer(&point_x_buf, num_limbs);
+    let y_result = read_buffer(&point_y_buf, num_limbs);
+
+    assert_eq!(
+        x_result, x_mont_in_ark_limbs,
+        "X coordinate conversion failed"
+    );
+    assert_eq!(
+        y_result, y_mont_in_ark_limbs,
+        "Y coordinate conversion failed"
+    );
+}

--- a/mopro-msm/src/msm/metal_msm/tests/cuzk/mod.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/cuzk/mod.rs
@@ -1,2 +1,4 @@
 #[cfg(test)]
 pub mod barrett_reduction;
+#[cfg(test)]
+pub mod convert_point_coords_and_decompose_scalars;


### PR DESCRIPTION
- close #33 

### Shader Enhancements
* Added the `convert_point_coords_and_decompose_scalars` kernel function to handle point coordinate conversion and scalar decomposition in Metal. This function includes logic for converting coordinates to Montgomery form and decomposing scalars using wNAF representation.
* Introduced the `extract_word_from_bytes_le` utility function to extract words from byte arrays in little-endian format, which is used in the new kernel function.

### Host Code Updates
* Modified the `write_constants` function in `shader.rs` to define new constants required by the Metal kernel, such as `CHUNK_SIZE`, `NUM_COLUMNS`, `NUM_ROWS`, and workgroup sizes. [[1]](diffhunk://#diff-7e8b6b5206ea3569cff11dd982bf176abd658108e493123eadab9041967ee833R103-R145) [[2]](diffhunk://#diff-7e8b6b5206ea3569cff11dd982bf176abd658108e493123eadab9041967ee833R170-R177)

### Testing
* Added comprehensive tests for the new kernel function in `convert_point_coords_and_decompose_scalars.rs`. These tests validate the conversion of point coordinates to Montgomery form and the decomposition of scalars.
* Updated the test module to include the new test file for `convert_point_coords_and_decompose_scalars`.