### PR TITLE
Feat/cuzk/new bucket point reduction

### DIFF
--- a/mopro-msm/src/msm/metal_msm/shader/curve/jacobian.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/curve/jacobian.metal
@@ -196,3 +196,9 @@ Jacobian jacobian_scalar_mul(
     
     return result;
 }
+
+// Override operators in Jacobian
+Jacobian operator+(Jacobian a, Jacobian b) {
+    BigInt p = get_p();
+    return jacobian_add_2007_bl(a, b, p);
+}

--- a/mopro-msm/src/msm/metal_msm/shader/curve/jacobian_dataflow_test.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/curve/jacobian_dataflow_test.metal
@@ -1,0 +1,13 @@
+
+using namespace metal;
+#include <metal_stdlib>
+#include <metal_math>
+#include "jacobian.metal"
+
+kernel void run(
+    constant Jacobian* points [[ buffer(0) ]],
+    device Jacobian* out [[ buffer(1) ]],
+    uint gid [[ thread_position_in_grid ]]
+) {
+    out[gid] = jacobian_scalar_mul(points[gid], 2);
+}

--- a/mopro-msm/src/msm/metal_msm/shader/cuzk/pbpr.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/cuzk/pbpr.metal
@@ -1,0 +1,32 @@
+using namespace metal;
+#include <metal_stdlib>
+#include "../curve/jacobian.metal"
+#include "../misc/get_constant.metal"
+
+kernel void parallel_bpr(
+    constant Jacobian* buckets [[ buffer(0) ]],
+    device Jacobian* m_shared [[ buffer(1) ]],
+    device Jacobian* s_shared [[ buffer(2) ]],
+    constant uint32_t& bucket_size [[ buffer(3) ]],
+    constant uint32_t& total_threads [[ buffer(4) ]],
+    constant uint32_t& r [[ buffer(5) ]],
+    uint gid [[ thread_position_in_grid ]]
+) {     
+    // first version: 
+    if (gid >= total_threads) {
+        return;
+    }
+
+    // Accumulating buckets to s_shared and m_shared using 0-based indexing
+    for (uint32_t l = 1; l <= r; l++) {
+        if (l != 1) {
+            m_shared[gid] = m_shared[gid] + buckets[(gid + 1) * r - l];
+            s_shared[gid] = s_shared[gid] + m_shared[gid];
+        } else {
+            m_shared[gid] = buckets[(gid + 1) * r - 1];
+            s_shared[gid] = m_shared[gid];
+        }
+    }
+    uint32_t scalar = gid * r;
+    s_shared[gid] = s_shared[gid] + jacobian_scalar_mul(m_shared[gid], scalar);
+}

--- a/mopro-msm/src/msm/metal_msm/tests/curve/jacobian_data_conversion.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/curve/jacobian_data_conversion.rs
@@ -1,0 +1,80 @@
+use crate::msm::metal_msm::host::gpu::get_default_device;
+use crate::msm::metal_msm::host::shader::{compile_metal, write_constants};
+use crate::msm::metal_msm::utils::data_conversion::{points_from_gpu_buffer, points_to_gpu_buffer};
+use crate::msm::metal_msm::utils::mont_params::{calc_mont_radix, calc_nsafe, calc_rinv_and_n0};
+use ark_bn254::{Fq as BaseField, Fr as ScalarField, G1Projective as G};
+use ark_ec::Group;
+use ark_ff::PrimeField;
+use ark_std::{rand::thread_rng, UniformRand, Zero};
+use metal::*;
+use num_bigint::BigUint;
+
+#[test]
+#[serial_test::serial]
+fn test_jacobian_dataflow() {
+    let log_limb_size = 16;
+    let p: BigUint = BaseField::MODULUS.try_into().unwrap();
+
+    let modulus_bits = BaseField::MODULUS_BIT_SIZE as u32;
+    let num_limbs = ((modulus_bits + log_limb_size - 1) / log_limb_size) as usize;
+
+    let r = calc_mont_radix(num_limbs, log_limb_size);
+    let res = calc_rinv_and_n0(&p, &r, log_limb_size);
+    let rinv = res.0;
+    let n0 = res.1;
+    let nsafe = calc_nsafe(log_limb_size);
+
+    let mut rng = thread_rng();
+    let base_point = G::generator();
+    let points: Vec<G> = (0..10)
+        .map(|_| base_point * ScalarField::rand(&mut rng))
+        .collect();
+    let output_points: Vec<G> = (0..10).map(|_| G::zero()).collect();
+    let device = get_default_device();
+    let input_buffer = points_to_gpu_buffer(&points, num_limbs, &device);
+    let output_buffer = points_to_gpu_buffer(&output_points, num_limbs, &device);
+
+    let command_queue = device.new_command_queue();
+
+    write_constants(
+        "../mopro-msm/src/msm/metal_msm/shader",
+        num_limbs,
+        log_limb_size,
+        n0,
+        nsafe,
+    );
+
+    let library_path = compile_metal(
+        "../mopro-msm/src/msm/metal_msm/shader/curve",
+        &format!("{}.metal", "jacobian_dataflow_test"),
+    );
+    let library = device.new_library_with_file(library_path).unwrap();
+    let kernel = library.get_function("run", None).unwrap();
+    let pipeline_state_descriptor = ComputePipelineDescriptor::new();
+    pipeline_state_descriptor.set_compute_function(Some(&kernel));
+    let pipeline_state = device
+        .new_compute_pipeline_state_with_function(
+            pipeline_state_descriptor.compute_function().unwrap(),
+        )
+        .unwrap();
+
+    let command_buffer = command_queue.new_command_buffer();
+    let compute_pass_descriptor = ComputePassDescriptor::new();
+    let encoder = command_buffer.compute_command_encoder_with_descriptor(compute_pass_descriptor);
+    encoder.set_compute_pipeline_state(&pipeline_state);
+
+    encoder.set_buffer(0, Some(&input_buffer), 0);
+    encoder.set_buffer(1, Some(&output_buffer), 0);
+
+    let threads_per_threadgroup = MTLSize::new(10, 1, 1);
+    let threadgroup_size = MTLSize::new(1, 1, 1);
+    encoder.dispatch_threads(threads_per_threadgroup, threadgroup_size);
+    encoder.end_encoding();
+    command_buffer.commit();
+    command_buffer.wait_until_completed();
+
+    let result_points: Vec<G> = points_from_gpu_buffer(&output_buffer, num_limbs, p, rinv);
+    for i in 0..points.len() {
+        assert_eq!(points[i] * ScalarField::from(2 as u64), result_points[i]);
+    }
+}

--- a/mopro-msm/src/msm/metal_msm/tests/curve/mod.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/curve/mod.rs
@@ -1,6 +1,8 @@
 #[cfg(test)]
 pub mod jacobian_add_2007_b1;
 #[cfg(test)]
+pub mod jacobian_data_conversion;
+#[cfg(test)]
 pub mod jacobian_dbl_2009_l;
 #[cfg(test)]
 pub mod jacobian_madd_2007_bl;

--- a/mopro-msm/src/msm/metal_msm/tests/cuzk/mod.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/cuzk/mod.rs
@@ -3,4 +3,6 @@ pub mod barrett_reduction;
 #[cfg(test)]
 pub mod convert_point_coords_and_decompose_scalars;
 #[cfg(test)]
+pub mod pbpr;
+#[cfg(test)]
 pub mod transpose;

--- a/mopro-msm/src/msm/metal_msm/tests/cuzk/pbpr.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/cuzk/pbpr.rs
@@ -1,0 +1,176 @@
+use crate::msm::metal_msm::host::gpu::{create_buffer, get_default_device};
+use crate::msm::metal_msm::host::shader::{compile_metal, write_constants};
+use crate::msm::metal_msm::utils::data_conversion::{points_from_gpu_buffer, points_to_gpu_buffer};
+use crate::msm::metal_msm::utils::mont_params::MontgomeryParams;
+use ark_bn254::{Fr as ScalarField, G1Projective as G};
+use ark_ec::Group;
+use ark_std::{rand::thread_rng, UniformRand, Zero};
+use metal::*;
+use num_bigint::BigUint;
+use rayon::prelude::*;
+use std::cmp::min;
+
+// Implements parallel bucket reduction in GPU
+// TODO: 1. current algorithm does not support odd bucket size (should be 2N)
+// TODO: 2. current total threads is fixed, we should change it into dynamic
+// TODO: 3. we should also dynamically dispatch the threadgroup_size and threads_per_threadgroup
+fn gpu_parallel_bpr(buckets: &Vec<G>) -> G {
+    let mont_params = MontgomeryParams::default();
+    let log_limb_size: u32 = 16;
+    let p: BigUint = mont_params.p;
+    let num_limbs = mont_params.num_limbs;
+    let rinv = mont_params.rinv;
+    let n0 = mont_params.n0;
+    let nsafe = mont_params.nsafe;
+
+    let device = get_default_device();
+    let bucket_size = buckets.len();
+    let bucket_buffer = points_to_gpu_buffer(buckets, num_limbs, &device);
+
+    let total_threads = min(4096, bucket_size.next_power_of_two()); // TODO: To make this dynamic
+
+    let total_threads_buffer = create_buffer(&device, &vec![total_threads as u32]);
+    let bucket_size_buffer = create_buffer(&device, &vec![bucket_size as u32]);
+
+    let m_shared = vec![G::zero(); total_threads];
+    let s_shared = vec![G::zero(); total_threads];
+
+    let m_shared_buffer = points_to_gpu_buffer(&m_shared, num_limbs, &device);
+    let s_shared_buffer = points_to_gpu_buffer(&s_shared, num_limbs, &device);
+
+    let num_subtask = (bucket_size + total_threads - 1) / total_threads;
+    let num_subtask_buffer = create_buffer(&device, &vec![num_subtask as u32]);
+    // set up command queue and encoder
+    let command_queue = device.new_command_queue();
+    let command_buffer = command_queue.new_command_buffer();
+    let encoder =
+        command_buffer.compute_command_encoder_with_descriptor(ComputePassDescriptor::new());
+
+    write_constants(
+        "../mopro-msm/src/msm/metal_msm/shader",
+        num_limbs,
+        log_limb_size,
+        n0,
+        nsafe,
+    );
+    let library_path = compile_metal("../mopro-msm/src/msm/metal_msm/shader/cuzk", "pbpr.metal");
+    let library = device.new_library_with_file(library_path).unwrap();
+    let kernel = library.get_function("parallel_bpr", None).unwrap();
+
+    // set up pipeline
+    let pipeline_state_descriptor = ComputePipelineDescriptor::new();
+    pipeline_state_descriptor.set_compute_function(Some(&kernel));
+
+    let pipeline_state = device
+        .new_compute_pipeline_state_with_function(
+            pipeline_state_descriptor.compute_function().unwrap(),
+        )
+        .unwrap();
+
+    encoder.set_compute_pipeline_state(&pipeline_state);
+
+    encoder.set_buffer(0, Some(&bucket_buffer), 0);
+    encoder.set_buffer(1, Some(&m_shared_buffer), 0);
+    encoder.set_buffer(2, Some(&s_shared_buffer), 0);
+    encoder.set_buffer(3, Some(&bucket_size_buffer), 0);
+    encoder.set_buffer(4, Some(&total_threads_buffer), 0);
+    encoder.set_buffer(5, Some(&num_subtask_buffer), 0);
+
+    // TODO: make this dynamic
+    let threads_per_thread_group = MTLSize {
+        width: 256,
+        height: 1,
+        depth: 1,
+    };
+
+    let thread_group_count = MTLSize {
+        width: ((total_threads + 256 - 1) / 256) as u64,
+        height: 1,
+        depth: 1,
+    };
+
+    encoder.dispatch_thread_groups(thread_group_count, threads_per_thread_group);
+    encoder.end_encoding();
+    command_buffer.commit();
+    command_buffer.wait_until_completed();
+
+    let s_shared = points_from_gpu_buffer(&s_shared_buffer, num_limbs, p, rinv);
+
+    s_shared.iter().sum::<G>()
+}
+
+// This is a very naive way to implement the bucket reduction
+// computing $\sum_{i=1}^{len} i * buckets[i]$
+fn cpu_naive_bpr(buckets: &Vec<G>) -> G {
+    buckets
+        .par_iter()
+        .enumerate()
+        .fold(
+            || G::zero(),
+            |acc, (i, p)| acc + *p * ScalarField::from((i + 1) as u64),
+        )
+        .sum()
+}
+
+// This immitates the parallel bucket point reduction algortihm in GPU.
+// TODO: 1. This algorithm only supports even bucket size (2N), we have to find a way to deal with odd input size.
+// TODO: 2. make total thread dynamic
+fn cpu_parallel_bpr(buckets: &Vec<G>) -> G {
+    let total_threads = 4 as usize; // TODO: To make this dynamic
+    let bucket_size = buckets.len() as usize;
+    let r = (bucket_size + total_threads - 1) / total_threads;
+    let mut s = vec![G::zero(); total_threads];
+    let mut m = vec![G::zero(); total_threads];
+
+    for gid in 0..total_threads {
+        for l in 1..=r {
+            if l != 1 {
+                m[gid] = m[gid] + buckets[(gid + 1) * r - l];
+                s[gid] = s[gid] + m[gid];
+            } else {
+                m[gid] = buckets[(gid + 1) * r - 1];
+                s[gid] = m[gid];
+            }
+        }
+    }
+
+    let mut result_arr: Vec<G> = vec![];
+    for i in 0..total_threads {
+        result_arr.push(s[i] + (m[i] * ScalarField::from((r * i) as u64)));
+    }
+
+    result_arr.iter().sum::<G>()
+}
+
+#[test]
+pub fn test_pbpr_simple_input() {
+    let generator = G::generator();
+    let c: u32 = 16;
+    let bucket_size = 1 << c;
+    let buckets = (1..=bucket_size)
+        .map(|i| generator * ScalarField::from(i as u64))
+        .collect::<Vec<G>>();
+
+    let cpu_naive_result = cpu_naive_bpr(&buckets);
+    let cpu_pbpr_result = cpu_parallel_bpr(&buckets);
+    let gpu_pbpr_result = gpu_parallel_bpr(&buckets);
+
+    assert_eq!(gpu_pbpr_result, cpu_naive_result);
+    assert_eq!(gpu_pbpr_result, cpu_pbpr_result);
+}
+
+#[test]
+fn test_pbpr_random_inputs() {
+    let generator = G::generator();
+    let mut rng = thread_rng();
+    let bucket_size = vec![10, 11, 12, 13, 14, 15];
+
+    for size in bucket_size {
+        let buckets = (0..(1 << size))
+            .map(|_| generator * ScalarField::rand(&mut rng))
+            .collect::<Vec<G>>();
+        let naive_result = cpu_naive_bpr(&buckets);
+        let gpu_pbpr_result = gpu_parallel_bpr(&buckets);
+        assert_eq!(gpu_pbpr_result, naive_result);
+    }
+}

--- a/mopro-msm/src/msm/metal_msm/utils/data_conversion.rs
+++ b/mopro-msm/src/msm/metal_msm/utils/data_conversion.rs
@@ -1,0 +1,126 @@
+use crate::msm::metal_msm::host::gpu::create_buffer;
+use crate::msm::metal_msm::utils::limbs_conversion::GenericLimbConversion;
+use crate::msm::metal_msm::utils::mont_params::calc_mont_radix;
+use ark_bn254::{Fq as BaseField, FqConfig, G1Projective as G};
+use ark_ff::{biginteger::arithmetic as fa, BigInt, MontBackend, MontConfig, PrimeField};
+use metal::*;
+use num_bigint::BigUint;
+
+pub fn raw_reduction<const N: usize>(a: BigInt<N>) -> BigInt<N>
+where
+    FqConfig: MontConfig<N>,
+{
+    let mut r = a.0; // parse into [u64; N]
+
+    // Montgomery Reduction
+    for i in 0..N {
+        let k = r[i].wrapping_mul(<FqConfig as MontConfig<N>>::INV);
+        let mut carry = 0;
+
+        fa::mac_with_carry(
+            r[i],
+            k,
+            <FqConfig as MontConfig<N>>::MODULUS.0[0],
+            &mut carry,
+        );
+        for j in 1..N {
+            r[(j + i) % N] = fa::mac_with_carry(
+                r[(j + i) % N],
+                k,
+                <FqConfig as MontConfig<N>>::MODULUS.0[j],
+                &mut carry,
+            );
+        }
+        r[i % N] = carry;
+    }
+    BigInt::new(r)
+}
+
+fn point_to_gpu_form(point: &G, num_limbs: usize) -> Vec<u32> {
+    let log_limb_size: u32 = 16;
+    let p: BigUint = BaseField::MODULUS.try_into().unwrap();
+    let r = calc_mont_radix(num_limbs, log_limb_size);
+
+    let px: BigUint = point.x.into();
+    let py: BigUint = point.y.into();
+    let pz: BigUint = point.z.into();
+
+    let pxr = (&px * &r) % &p;
+    let pyr = (&py * &r) % &p;
+    let pzr = (&pz * &r) % &p;
+
+    let pxr_limbs = ark_ff::BigInt::<4>::try_from(pxr)
+        .unwrap()
+        .to_limbs(num_limbs, log_limb_size);
+    let pyr_limbs = ark_ff::BigInt::<4>::try_from(pyr)
+        .unwrap()
+        .to_limbs(num_limbs, log_limb_size);
+    let pzr_limbs = ark_ff::BigInt::<4>::try_from(pzr)
+        .unwrap()
+        .to_limbs(num_limbs, log_limb_size);
+
+    let mut point_data = vec![0u32; num_limbs * 3];
+    point_data[..num_limbs].copy_from_slice(&pxr_limbs);
+    point_data[num_limbs..2 * num_limbs].copy_from_slice(&pyr_limbs);
+    point_data[2 * num_limbs..].copy_from_slice(&pzr_limbs);
+
+    point_data
+}
+
+pub fn points_to_gpu_buffer(points: &[G], num_limbs: usize, device: &Device) -> metal::Buffer {
+    let total_size = points.len() * num_limbs * 3;
+    let mut all_point_data = Vec::with_capacity(total_size);
+
+    for point in points {
+        let point_data = point_to_gpu_form(point, num_limbs);
+        all_point_data.extend_from_slice(&point_data);
+    }
+    create_buffer(&device, &all_point_data)
+}
+
+pub fn points_from_gpu_buffer(
+    buffer: &Buffer,
+    num_limbs: usize,
+    p: BigUint,
+    rinv: BigUint,
+) -> Vec<G> {
+    let log_limb_size = 16;
+    let point_size = num_limbs * 3;
+    let total_u32s = buffer.length() as usize / std::mem::size_of::<u32>();
+    let num_points = total_u32s / point_size;
+
+    let mut points: Vec<G> = Vec::with_capacity(num_points);
+
+    let ptr = buffer.contents() as *const u32;
+    let result_limbs: Vec<u32>;
+
+    if !ptr.is_null() {
+        result_limbs = unsafe { std::slice::from_raw_parts(ptr, total_u32s) }.to_vec();
+    } else {
+        panic!("Pointer is null");
+    }
+
+    for i in 0..num_points {
+        let start = i * point_size;
+
+        let x_reduced = raw_reduction(BigInt::<4>::from_limbs(
+            &result_limbs[start..start + num_limbs],
+            log_limb_size,
+        ));
+        let y_reduced = raw_reduction(BigInt::<4>::from_limbs(
+            &result_limbs[start + num_limbs..start + 2 * num_limbs],
+            log_limb_size,
+        ));
+        let z_reduced = raw_reduction(BigInt::<4>::from_limbs(
+            &result_limbs[start + 2 * num_limbs..start + 3 * num_limbs],
+            log_limb_size,
+        ));
+
+        let x = BaseField::from_bigint(x_reduced).unwrap();
+        let y = BaseField::from_bigint(y_reduced).unwrap();
+        let z = BaseField::from_bigint(z_reduced).unwrap();
+
+        points.push(G::new_unchecked(x, y, z));
+    }
+    points
+}

--- a/mopro-msm/src/msm/metal_msm/utils/mod.rs
+++ b/mopro-msm/src/msm/metal_msm/utils/mod.rs
@@ -1,4 +1,5 @@
 pub mod barrett_params;
+pub mod data_conversion;
 pub mod limbs_conversion;
 pub mod mont_params;
 pub mod mont_reduction;

--- a/mopro-msm/src/msm/metal_msm/utils/mont_params.rs
+++ b/mopro-msm/src/msm/metal_msm/utils/mont_params.rs
@@ -14,6 +14,8 @@
  * [2] https://github.com/scipr-lab/libff/blob/develop/libff/algebra/curves/alt_bn128/alt_bn128.sage
  */
 
+use ark_bn254::Fq as BaseField;
+use ark_ff::PrimeField;
 use num_bigint::{BigInt, BigUint, Sign};
 
 pub fn calc_nsafe(log_limb_size: u32) -> usize {
@@ -137,4 +139,39 @@ pub fn calc_bitwidth(p: &BigUint) -> usize {
     }
 
     p.to_radix_le(2).len()
+}
+
+pub struct MontgomeryParams {
+    pub log_limb_size: u32,
+    pub p: BigUint,
+    pub modulus_bits: u32,
+    pub num_limbs: usize,
+    pub r: BigUint,
+    pub rinv: BigUint,
+    pub n0: u32,
+    pub nsafe: usize,
+}
+
+impl Default for MontgomeryParams {
+    fn default() -> Self {
+        let log_limb_size: u32 = 16;
+        let p: BigUint = BaseField::MODULUS.try_into().unwrap();
+        let modulus_bits = BaseField::MODULUS_BIT_SIZE as u32;
+        let num_limbs = ((modulus_bits + log_limb_size - 1) / log_limb_size) as usize;
+
+        let r = calc_mont_radix(num_limbs, log_limb_size);
+        let (rinv, n0) = calc_rinv_and_n0(&p, &r, log_limb_size);
+        let nsafe = calc_nsafe(log_limb_size);
+
+        Self {
+            log_limb_size,
+            p,
+            modulus_bits,
+            num_limbs,
+            r,
+            rinv,
+            n0,
+            nsafe,
+        }
+    }
 }


### PR DESCRIPTION
This pull request includes: 
1. Jacobian points conversion
2. make Montgomery parameter as constant (should be modified in the future)
3. parallel bucket point reduction, includes
    * `gpu_parallel_bpr`: the algorithm calling metal shader kernel.
    * `cpu_parallel_bpr`: the algorithm implemented in rust. imitating the behavior in gpu.
    * `cpu_naive_bpr`: the naive method to do bucket reduction.

> Notice that currently the pbpr operation has some limitation: 
> 1. only support even bucket size
> 2. we have to input the parameters (`total_threads` & `r` (also `num_subtask`).
> 3. the `threads_per_thread_group` and `threadgroup_size` are fixed

### Testing improvements:
* [`mopro-msm/src/msm/metal_msm/tests/curve/jacobian_data_conversion.rs`](diffhunk://#diff-587ba45b5de151dcbc7084e449cea39b70dd92fdc6025d1dbd19bd9979514332R1-R80): Added a new test for Jacobian data conversion, ensuring the correctness of GPU buffer operations and scalar multiplication.
* [`mopro-msm/src/msm/metal_msm/tests/curve/mod.rs`](diffhunk://#diff-d78a6f316aa2cfb01f649ed5544c04c701dd5aad2ad31bb82bab1eb77a1268c0R4-R5): Included the new `jacobian_data_conversion` test module.

### New Utility Functions:
* Added `bpr.metal`, with kernel: `parallel_bpr`.

### Refactoring and Enhancements:
* Refactored Jacobian addition (`jacobian_add_2007_bl`) to handle special cases where one of the points is zero or both points are equal (`mopro-msm/src/msm/metal_msm/shader/curve/jacobian.metal`). [[1]](diffhunk://#diff-45d8ea7ac1690c5215194e37d137295e1c80377cdc82b50aca2b538c39f66d25R9-R68) [[2]](diffhunk://#diff-45d8ea7ac1690c5215194e37d137295e1c80377cdc82b50aca2b538c39f66d25L62-L98)
* Moved the `jacobian_dbl_2009_l` function to the top of the file and added it to the `jacobian_add_2007_bl` function to handle doubling when points are equal (`mopro-msm/src/msm/metal_msm/shader/curve/jacobian.metal`). [[1]](diffhunk://#diff-45d8ea7ac1690c5215194e37d137295e1c80377cdc82b50aca2b538c39f66d25R9-R68) [[2]](diffhunk://#diff-45d8ea7ac1690c5215194e37d137295e1c80377cdc82b50aca2b538c39f66d25L62-L98)

### New Functions:
* Added `jacobian_scalar_mul` function to perform scalar multiplication on Jacobian points (`mopro-msm/src/msm/metal_msm/shader/curve/jacobian.metal`).
* Added a new Metal kernel `run` for scalar multiplication in `jacobian_scalar_mul.metal` (`mopro-msm/src/msm/metal_msm/shader/curve/jacobian_scalar_mul.metal`).

### Tests:
* Added `gpu_parallel_bpr` test in rust side (`mopro-msm/src/msm/metal_msm/shader/cuzk/bpr.rs`)

### Data Conversion and Testing:
* Implemented data conversion functions and a new test for Jacobian data flow to ensure the correctness of GPU computations. [[1]](diffhunk://#diff-587ba45b5de151dcbc7084e449cea39b70dd92fdc6025d1dbd19bd9979514332R1-R80) [[2]](diffhunk://#diff-d78a6f316aa2cfb01f649ed5544c04c701dd5aad2ad31bb82bab1eb77a1268c0R4-R5)

These changes collectively improve the mathematical operations and data handling capabilities of the `mopro-msm` project, particularly in the context of GPU-accelerated computations.