### PR TITLE
Bpr enhancements

### DIFF
--- a/mopro-msm/src/msm/metal_msm/shader/cuzk/pbpr.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/cuzk/pbpr.metal
@@ -4,20 +4,21 @@ using namespace metal;
 #include "../misc/get_constant.metal"
 
 kernel void parallel_bpr(
-    constant Jacobian* buckets [[ buffer(0) ]],
-    device Jacobian* m_shared [[ buffer(1) ]],
-    device Jacobian* s_shared [[ buffer(2) ]],
-    constant uint32_t& bucket_size [[ buffer(3) ]],
-    constant uint32_t& total_threads [[ buffer(4) ]],
-    constant uint32_t& r [[ buffer(5) ]],
-    uint gid [[ thread_position_in_grid ]]
-) {     
-    // first version: 
+    constant Jacobian* buckets         [[ buffer(0) ]],
+    device Jacobian* m_shared          [[ buffer(1) ]],
+    device Jacobian* s_shared          [[ buffer(2) ]],
+    constant uint32_t& grid_width      [[ buffer(3) ]],
+    constant uint32_t& total_threads   [[ buffer(4) ]],
+    constant uint32_t& r               [[ buffer(5) ]],
+    uint2 tid                          [[ thread_position_in_grid ]]
+) {
+    // Convert the 2D thread coordinate into a flat index.
+    uint gid = tid.y * grid_width + tid.x;
     if (gid >= total_threads) {
         return;
     }
 
-    // Accumulating buckets to s_shared and m_shared using 0-based indexing
+    // Accumulating buckets into s_shared and m_shared using 0-based indexing.
     for (uint32_t l = 1; l <= r; l++) {
         if (l != 1) {
             m_shared[gid] = m_shared[gid] + buckets[(gid + 1) * r - l];


### PR DESCRIPTION
This is the enhancement on @FoodChain1028's work on bucket point reduction shader implementation. It takes the original implementation and makes it a little bit more flexible in the following ways:

1. Algo in it's both CPU and GPU parts now utilise dynamic number of both threads and thread_groups.
2. Shader as well as CPU part now internally works with 2D arrays rather than 1D, which should decrease overhead on data reading from GPU side according to Apple's docs.
3. Odd bucket size issue has been fixed (not sure it was presented to the date though).

Other:
`encoder.dispatch_threads` used instead of old fashioned `encoder.dispatch_thread_groups` function. Due to [Apple's recommendation](https://developer.apple.com/documentation/metal/mtlcomputecommandencoder/1443138-dispatchthreadgroups)

Known issues:

1. Too small `optimal_threads` value used. It should be that, since it means that we're performing all the work serially in a single `threadgroup`. Yet I consider this improvement as a next milestone task.

> As the idea out of top my head of further improvements is to implement tree like shader logic with kernel side synchronisation to benefit from further parallelisation.