### PR TITLE
refactor(metal): remove `bn254 p` parameter from curve and field ops

### DIFF
--- a/mopro-msm/src/msm/metal_msm/shader/curve/jacobian.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/curve/jacobian.metal
@@ -8,35 +8,32 @@ using namespace metal;
 #include "../mont_backend/mont.metal"
 #include "./utils.metal"
 
-Jacobian jacobian_dbl_2009_l(
-    Jacobian pt,
-    BigInt p
-) {
+Jacobian jacobian_dbl_2009_l(Jacobian pt) {
     BigInt x = pt.x;
     BigInt y = pt.y;
     BigInt z = pt.z;
 
-    BigInt a = mont_mul_cios(x, x, p);
-    BigInt b = mont_mul_cios(y, y, p);
-    BigInt c = mont_mul_cios(b, b, p);
-    BigInt x1b = ff_add(x, b, p);
-    BigInt x1b2 = mont_mul_cios(x1b, x1b, p);
-    BigInt ac = ff_add(a, c, p);
-    BigInt x1b2ac = ff_sub(x1b2, ac, p);
-    BigInt d = ff_add(x1b2ac, x1b2ac, p);
-    BigInt a2 = ff_add(a, a, p);
-    BigInt e = ff_add(a2, a, p);
-    BigInt f = mont_mul_cios(e, e, p);
-    BigInt d2 = ff_add(d, d, p);
-    BigInt x3 = ff_sub(f, d2, p);
-    BigInt c2 = ff_add(c, c, p);
-    BigInt c4 = ff_add(c2, c2, p);
-    BigInt c8 = ff_add(c4, c4, p);
-    BigInt dx3 = ff_sub(d, x3, p);
-    BigInt edx3 = mont_mul_cios(e, dx3, p);
-    BigInt y3 = ff_sub(edx3, c8, p);
-    BigInt y1z1 = mont_mul_cios(y, z, p);
-    BigInt z3 = ff_add(y1z1, y1z1, p);
+    BigInt a = mont_mul_cios(x, x);
+    BigInt b = mont_mul_cios(y, y);
+    BigInt c = mont_mul_cios(b, b);
+    BigInt x1b = ff_add(x, b);
+    BigInt x1b2 = mont_mul_cios(x1b, x1b);
+    BigInt ac = ff_add(a, c);
+    BigInt x1b2ac = ff_sub(x1b2, ac);
+    BigInt d = ff_add(x1b2ac, x1b2ac);
+    BigInt a2 = ff_add(a, a);
+    BigInt e = ff_add(a2, a);
+    BigInt f = mont_mul_cios(e, e);
+    BigInt d2 = ff_add(d, d);
+    BigInt x3 = ff_sub(f, d2);
+    BigInt c2 = ff_add(c, c);
+    BigInt c4 = ff_add(c2, c2);
+    BigInt c8 = ff_add(c4, c4);
+    BigInt dx3 = ff_sub(d, x3);
+    BigInt edx3 = mont_mul_cios(e, dx3);
+    BigInt y3 = ff_sub(edx3, c8);
+    BigInt y1z1 = mont_mul_cios(y, z);
+    BigInt z3 = ff_add(y1z1, y1z1);
 
     Jacobian result;
     result.x = x3;
@@ -45,14 +42,10 @@ Jacobian jacobian_dbl_2009_l(
     return result;
 }
 
-Jacobian jacobian_add_2007_bl(
-    Jacobian a,
-    Jacobian b,
-    BigInt p
-) {
+Jacobian jacobian_add_2007_bl(Jacobian a, Jacobian b) {
     if (is_jacobian_zero(a)) return b;
     if (is_jacobian_zero(b)) return a;
-    if (a == b) return jacobian_dbl_2009_l(a, p);
+    if (a == b) return jacobian_dbl_2009_l(a);
 
     BigInt x1 = a.x;
     BigInt y1 = a.y;
@@ -62,37 +55,37 @@ Jacobian jacobian_add_2007_bl(
     BigInt z2 = b.z;
 
     // First compute z coordinates
-    BigInt z1z1 = mont_mul_cios(z1, z1, p);
-    BigInt z2z2 = mont_mul_cios(z2, z2, p);
-    BigInt u1 = mont_mul_cios(x1, z2z2, p);
-    BigInt u2 = mont_mul_cios(x2, z1z1, p);
-    BigInt y1z2 = mont_mul_cios(y1, z2, p);
-    BigInt s1 = mont_mul_cios(y1z2, z2z2, p);
+    BigInt z1z1 = mont_mul_cios(z1, z1);
+    BigInt z2z2 = mont_mul_cios(z2, z2);
+    BigInt u1 = mont_mul_cios(x1, z2z2);
+    BigInt u2 = mont_mul_cios(x2, z1z1);
+    BigInt y1z2 = mont_mul_cios(y1, z2);
+    BigInt s1 = mont_mul_cios(y1z2, z2z2);
 
-    BigInt y2z1 = mont_mul_cios(y2, z1, p);
-    BigInt s2 = mont_mul_cios(y2z1, z1z1, p);
-    BigInt h = ff_sub(u2, u1, p);
-    BigInt h2 = ff_add(h, h, p);
-    BigInt i = mont_mul_cios(h2, h2, p);
-    BigInt j = mont_mul_cios(h, i, p);
+    BigInt y2z1 = mont_mul_cios(y2, z1);
+    BigInt s2 = mont_mul_cios(y2z1, z1z1);
+    BigInt h = ff_sub(u2, u1);
+    BigInt h2 = ff_add(h, h);
+    BigInt i = mont_mul_cios(h2, h2);
+    BigInt j = mont_mul_cios(h, i);
 
-    BigInt s2s1 = ff_sub(s2, s1, p);
-    BigInt r = ff_add(s2s1, s2s1, p);
-    BigInt v = mont_mul_cios(u1, i, p);
-    BigInt v2 = ff_add(v, v, p);
-    BigInt r2 = mont_mul_cios(r, r, p);
-    BigInt jv2 = ff_add(j, v2, p);
-    BigInt x3 = ff_sub(r2, jv2, p);
+    BigInt s2s1 = ff_sub(s2, s1);
+    BigInt r = ff_add(s2s1, s2s1);
+    BigInt v = mont_mul_cios(u1, i);
+    BigInt v2 = ff_add(v, v);
+    BigInt r2 = mont_mul_cios(r, r);
+    BigInt jv2 = ff_add(j, v2);
+    BigInt x3 = ff_sub(r2, jv2);
 
-    BigInt vx3 = ff_sub(v, x3, p);
-    BigInt rvx3 = mont_mul_cios(r, vx3, p);
-    BigInt s12 = ff_add(s1, s1, p);
-    BigInt s12j = mont_mul_cios(s12, j, p);
-    BigInt y3 = ff_sub(rvx3, s12j, p);
+    BigInt vx3 = ff_sub(v, x3);
+    BigInt rvx3 = mont_mul_cios(r, vx3);
+    BigInt s12 = ff_add(s1, s1);
+    BigInt s12j = mont_mul_cios(s12, j);
+    BigInt y3 = ff_sub(rvx3, s12j);
 
-    BigInt z1z2 = mont_mul_cios(z1, z2, p);
-    BigInt z1z2h = mont_mul_cios(z1z2, h, p);
-    BigInt z3 = ff_add(z1z2h, z1z2h, p);
+    BigInt z1z2 = mont_mul_cios(z1, z2);
+    BigInt z1z2h = mont_mul_cios(z1z2, h);
+    BigInt z3 = ff_add(z1z2h, z1z2h);
 
     Jacobian result;
     result.x = x3;
@@ -101,12 +94,9 @@ Jacobian jacobian_add_2007_bl(
     return result;
 }
 
-//http://www.hyperelliptic.org/EFD/g1p/auto-shortw-jacobian-0.html#addition-madd-2007-bl
-Jacobian jacobian_madd_2007_bl(
-    Jacobian a,
-    Affine b,
-    BigInt p
-) {
+// Notice that this algo only takes standard form instead of Montgomery form
+// http://www.hyperelliptic.org/EFD/g1p/auto-shortw-jacobian-0.html#addition-madd-2007-bl
+Jacobian jacobian_madd_2007_bl(Jacobian a, Affine b) {
     BigInt x1 = a.x;
     BigInt y1 = a.y;
     BigInt z1 = a.z;
@@ -114,53 +104,53 @@ Jacobian jacobian_madd_2007_bl(
     BigInt y2 = b.y;
 
     // Z1Z1 = Z1^2
-    BigInt z1z1 = mont_mul_cios(z1, z1, p);
+    BigInt z1z1 = mont_mul_cios(z1, z1);
     
     // U2 = X2*Z1Z1
-    BigInt u2 = mont_mul_cios(x2, z1z1, p);
+    BigInt u2 = mont_mul_cios(x2, z1z1);
     
     // S2 = Y2*Z1*Z1Z1
-    BigInt temp_s2 = mont_mul_cios(y2, z1, p);
-    BigInt s2 = mont_mul_cios(temp_s2, z1z1, p);
+    BigInt temp_s2 = mont_mul_cios(y2, z1);
+    BigInt s2 = mont_mul_cios(temp_s2, z1z1);
     
     // H = U2-X1
-    BigInt h = ff_sub(u2, x1, p);
+    BigInt h = ff_sub(u2, x1);
     
     // HH = H^2
-    BigInt hh = mont_mul_cios(h, h, p);
+    BigInt hh = mont_mul_cios(h, h);
     
     // I = 4*HH
-    BigInt i = ff_add(hh, hh, p); // *2
-    i = ff_add(i, i, p);          // *4
+    BigInt i = ff_add(hh, hh); // *2
+    i = ff_add(i, i);          // *4
     
     // J = H*I
-    BigInt j = mont_mul_cios(h, i, p);
+    BigInt j = mont_mul_cios(h, i);
     
     // r = 2*(S2-Y1)
-    BigInt s2_minus_y1 = ff_sub(s2, y1, p);
-    BigInt r = ff_add(s2_minus_y1, s2_minus_y1, p);
+    BigInt s2_minus_y1 = ff_sub(s2, y1);
+    BigInt r = ff_add(s2_minus_y1, s2_minus_y1);
     
     // V = X1*I
-    BigInt v = mont_mul_cios(x1, i, p);
+    BigInt v = mont_mul_cios(x1, i);
     
     // X3 = r^2-J-2*V
-    BigInt r2 = mont_mul_cios(r, r, p);
-    BigInt v2 = ff_add(v, v, p);
-    BigInt jv2 = ff_add(j, v2, p);
-    BigInt x3 = ff_sub(r2, jv2, p);
+    BigInt r2 = mont_mul_cios(r, r);
+    BigInt v2 = ff_add(v, v);
+    BigInt jv2 = ff_add(j, v2);
+    BigInt x3 = ff_sub(r2, jv2);
     
     // Y3 = r*(V-X3)-2*Y1*J
-    BigInt v_minus_x3 = ff_sub(v, x3, p);
-    BigInt r_vmx3 = mont_mul_cios(r, v_minus_x3, p);
-    BigInt y1j = mont_mul_cios(y1, j, p);
-    BigInt y1j2 = ff_add(y1j, y1j, p);
-    BigInt y3 = ff_sub(r_vmx3, y1j2, p);
+    BigInt v_minus_x3 = ff_sub(v, x3);
+    BigInt r_vmx3 = mont_mul_cios(r, v_minus_x3);
+    BigInt y1j = mont_mul_cios(y1, j);
+    BigInt y1j2 = ff_add(y1j, y1j);
+    BigInt y3 = ff_sub(r_vmx3, y1j2);
     
     // Z3 = (Z1+H)^2-Z1Z1-HH
-    BigInt z1_plus_h = ff_add(z1, h, p);
-    BigInt z1_plus_h_squared = mont_mul_cios(z1_plus_h, z1_plus_h, p);
-    BigInt temp = ff_sub(z1_plus_h_squared, z1z1, p);
-    BigInt z3 = ff_sub(temp, hh, p);
+    BigInt z1_plus_h = ff_add(z1, h);
+    BigInt z1_plus_h_squared = mont_mul_cios(z1_plus_h, z1_plus_h);
+    BigInt temp = ff_sub(z1_plus_h_squared, z1z1);
+    BigInt z3 = ff_sub(temp, hh);
     
     Jacobian result;
     result.x = x3;
@@ -181,30 +171,27 @@ Jacobian jacobian_scalar_mul(
         return point;
     }
 
-    BigInt p = get_p();
     Jacobian result = get_bn254_zero_mont();
     Jacobian temp = point;
     uint s = scalar;
 
     while (s > 0) {
         if (s & 1) {
-            result = jacobian_add_2007_bl(result, temp, p);
+            result = jacobian_add_2007_bl(result, temp);
         }
-        temp = jacobian_dbl_2009_l(temp, p);
+        temp = jacobian_dbl_2009_l(temp);
         s = s >> 1;
     }
     
     return result;
 }
 
-Jacobian jacobian_neg(
-    Jacobian a,
-    BigInt p
-) {
+Jacobian jacobian_neg(Jacobian a) {
     if (is_jacobian_zero(a)) { return a; }
 
     // Negate Y (mod p): newY = p - Y
-    BigInt negY = ff_sub(p, a.y, p);
+    BigInt p = get_p();
+    BigInt negY = ff_sub(p, a.y);
 
     Jacobian result;
     result.x = a.x;
@@ -214,7 +201,6 @@ Jacobian jacobian_neg(
 }
 
 // Override operators in Jacobian
-Jacobian operator+(Jacobian a, Jacobian b) {
-    BigInt p = get_p();
-    return jacobian_add_2007_bl(a, b, p);
+constexpr Jacobian operator+(const Jacobian lhs, const Jacobian rhs) {
+    return jacobian_add_2007_bl(lhs, rhs);
 }

--- a/mopro-msm/src/msm/metal_msm/shader/curve/jacobian_add_2007_bl.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/curve/jacobian_add_2007_bl.metal
@@ -6,19 +6,17 @@ using namespace metal;
 #include "jacobian.metal"
 
 kernel void run(
-    device BigInt* prime [[ buffer(0) ]],
-    device BigInt* a_xr [[ buffer(1) ]],
-    device BigInt* a_yr [[ buffer(2) ]],
-    device BigInt* a_zr [[ buffer(3) ]],
-    device BigInt* b_xr [[ buffer(4) ]],
-    device BigInt* b_yr [[ buffer(5) ]],
-    device BigInt* b_zr [[ buffer(6) ]],
-    device BigInt* result_xr [[ buffer(7) ]],
-    device BigInt* result_yr [[ buffer(8) ]],
-    device BigInt* result_zr [[ buffer(9) ]],
+    device BigInt* a_xr [[ buffer(0) ]],
+    device BigInt* a_yr [[ buffer(1) ]],
+    device BigInt* a_zr [[ buffer(2) ]],
+    device BigInt* b_xr [[ buffer(3) ]],
+    device BigInt* b_yr [[ buffer(4) ]],
+    device BigInt* b_zr [[ buffer(5) ]],
+    device BigInt* result_xr [[ buffer(6) ]],
+    device BigInt* result_yr [[ buffer(7) ]],
+    device BigInt* result_zr [[ buffer(8) ]],
     uint gid [[ thread_position_in_grid ]]
 ) {
-    BigInt p = *prime;
     BigInt x1 = *a_xr;
     BigInt y1 = *a_yr;
     BigInt z1 = *a_zr;
@@ -29,7 +27,7 @@ kernel void run(
     Jacobian a; a.x = x1; a.y = y1; a.z = z1;
     Jacobian b; b.x = x2; b.y = y2; b.z = z2;
 
-    Jacobian res = jacobian_add_2007_bl(a, b, p);
+    Jacobian res = jacobian_add_2007_bl(a, b);
     *result_xr = res.x;
     *result_yr = res.y;
     *result_zr = res.z;

--- a/mopro-msm/src/msm/metal_msm/shader/curve/jacobian_dbl_2009_l.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/curve/jacobian_dbl_2009_l.metal
@@ -6,23 +6,21 @@ using namespace metal;
 #include "jacobian.metal"
 
 kernel void run(
-    device BigInt* prime [[ buffer(0) ]],
-    device BigInt* a_xr [[ buffer(1) ]],
-    device BigInt* a_yr [[ buffer(2) ]],
-    device BigInt* a_zr [[ buffer(3) ]],
-    device BigInt* result_xr [[ buffer(4) ]],
-    device BigInt* result_yr [[ buffer(5) ]],
-    device BigInt* result_zr [[ buffer(6) ]],
+    device BigInt* a_xr [[ buffer(0) ]],
+    device BigInt* a_yr [[ buffer(1) ]],
+    device BigInt* a_zr [[ buffer(2) ]],
+    device BigInt* result_xr [[ buffer(3) ]],
+    device BigInt* result_yr [[ buffer(4) ]],
+    device BigInt* result_zr [[ buffer(5) ]],
     uint gid [[ thread_position_in_grid ]]
 ) {
-    BigInt p = *prime;
     BigInt x1 = *a_xr;
     BigInt y1 = *a_yr;
     BigInt z1 = *a_zr;
 
     Jacobian a; a.x = x1; a.y = y1; a.z = z1;
 
-    Jacobian res = jacobian_dbl_2009_l(a, p);
+    Jacobian res = jacobian_dbl_2009_l(a);
     *result_xr = res.x;
     *result_yr = res.y;
     *result_zr = res.z;

--- a/mopro-msm/src/msm/metal_msm/shader/curve/jacobian_madd_2007_bl.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/curve/jacobian_madd_2007_bl.metal
@@ -6,18 +6,16 @@ using namespace metal;
 #include "jacobian.metal"
 
 kernel void run(
-    device BigInt* prime [[ buffer(0) ]],
-    device BigInt* a_xr [[ buffer(1) ]],
-    device BigInt* a_yr [[ buffer(2) ]],
-    device BigInt* a_zr [[ buffer(3) ]],
-    device BigInt* b_xr [[ buffer(4) ]],
-    device BigInt* b_yr [[ buffer(5) ]],
-    device BigInt* result_xr [[ buffer(6) ]],
-    device BigInt* result_yr [[ buffer(7) ]],
-    device BigInt* result_zr [[ buffer(8) ]],
+    device BigInt* a_xr [[ buffer(0) ]],
+    device BigInt* a_yr [[ buffer(1) ]],
+    device BigInt* a_zr [[ buffer(2) ]],
+    device BigInt* b_xr [[ buffer(3) ]],
+    device BigInt* b_yr [[ buffer(4) ]],
+    device BigInt* result_xr [[ buffer(5) ]],
+    device BigInt* result_yr [[ buffer(6) ]],
+    device BigInt* result_zr [[ buffer(7) ]],
     uint gid [[ thread_position_in_grid ]]
 ) {
-    BigInt p = *prime;
     BigInt x1 = *a_xr;
     BigInt y1 = *a_yr;
     BigInt z1 = *a_zr;
@@ -27,7 +25,7 @@ kernel void run(
     Jacobian a; a.x = x1; a.y = y1; a.z = z1;
     Affine b; b.x = x2; b.y = y2;
 
-    Jacobian res = jacobian_madd_2007_bl(a, b, p);
+    Jacobian res = jacobian_madd_2007_bl(a, b);
     *result_xr = res.x;
     *result_yr = res.y;
     *result_zr = res.z;

--- a/mopro-msm/src/msm/metal_msm/shader/curve/jacobian_neg.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/curve/jacobian_neg.metal
@@ -6,23 +6,21 @@ using namespace metal;
 #include "jacobian.metal"
 
 kernel void run(
-    device BigInt* prime [[ buffer(0) ]],
-    device BigInt* a_xr [[ buffer(1) ]],
-    device BigInt* a_yr [[ buffer(2) ]],
-    device BigInt* a_zr [[ buffer(3) ]],
-    device BigInt* result_xr [[ buffer(4) ]],
-    device BigInt* result_yr [[ buffer(5) ]],
-    device BigInt* result_zr [[ buffer(6) ]],
+    device BigInt* a_xr [[ buffer(0) ]],
+    device BigInt* a_yr [[ buffer(1) ]],
+    device BigInt* a_zr [[ buffer(2) ]],
+    device BigInt* result_xr [[ buffer(3) ]],
+    device BigInt* result_yr [[ buffer(4) ]],
+    device BigInt* result_zr [[ buffer(5) ]],
     uint gid [[ thread_position_in_grid ]]
 ) {
-    BigInt p = *prime;
     BigInt x1 = *a_xr;
     BigInt y1 = *a_yr;
     BigInt z1 = *a_zr;
 
     Jacobian a; a.x = x1; a.y = y1; a.z = z1;
 
-    Jacobian res = jacobian_neg(a, p);
+    Jacobian res = jacobian_neg(a);
     *result_xr = res.x;
     *result_yr = res.y;
     *result_zr = res.z;

--- a/mopro-msm/src/msm/metal_msm/shader/curve/utils.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/curve/utils.metal
@@ -20,8 +20,8 @@ bool jacobian_eq(
     return true;
 }
 
-bool is_jacobian_zero(Jacobian p) {
-    return is_bigint_zero(p.z);
+bool is_jacobian_zero(Jacobian a) {
+    return is_bigint_zero(a.z);
 }
 
 constexpr bool operator==(const Jacobian lhs, const Jacobian rhs) {

--- a/mopro-msm/src/msm/metal_msm/shader/cuzk/barrett_reduction.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/cuzk/barrett_reduction.metal
@@ -103,7 +103,7 @@ BigInt barrett_reduce(BigIntExtraWide a) {
         r.limbs[i] = r_wide.limbs[i];
     }
 
-    return ff_reduce(r, p);
+    return ff_reduce(r);
 }
 
 BigInt field_mul(BigIntWide a, BigIntWide b) {

--- a/mopro-msm/src/msm/metal_msm/shader/cuzk/smvp.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/cuzk/smvp.metal
@@ -42,7 +42,6 @@ kernel void smvp(
 
     const uint subtask_idx = id / half_columns;
 
-    const BigInt p = get_p();
     Jacobian inf = get_bn254_zero_mont();
 
     // an offset for each subtask's row_ptr
@@ -75,7 +74,7 @@ kernel void smvp(
             b.y = new_point_y[idx];
             b.z = get_bn254_one_mont().z;
 
-            sum = jacobian_add_2007_bl(sum, b, p);
+            sum = jacobian_add_2007_bl(sum, b);
 
             // Debug for correct input points
             LOG_DEBUG("new_point_x[%u].limbs[0]: %u", idx, new_point_x[idx].limbs[0]);
@@ -86,7 +85,7 @@ kernel void smvp(
         if (half_columns > row_idx) {
             // Negative bucket => flip sign of sum
             bucket_idx = half_columns - row_idx;
-            sum = jacobian_neg(sum, p);
+            sum = jacobian_neg(sum);
         } else {
             // Positive bucket
             bucket_idx = row_idx - half_columns;
@@ -105,7 +104,7 @@ kernel void smvp(
                 bucket_val.z = bucket_z[bi];
 
                 // sum = oldBucket + sum
-                sum = jacobian_add_2007_bl(bucket_val, sum, p);
+                sum = jacobian_add_2007_bl(bucket_val, sum);
             }
 
             // Store the result in bucket arrays
@@ -116,22 +115,9 @@ kernel void smvp(
 
         // Debug for correct sum
         if (id == 0) {
-            LOG_DEBUG("sum[%u].x: %u", id, sum.x.limbs[0]);
-            LOG_DEBUG("sum[%u].x: %u", id, sum.x.limbs[1]);
-            LOG_DEBUG("sum[%u].x: %u", id, sum.x.limbs[2]);
-            LOG_DEBUG("sum[%u].x: %u", id, sum.x.limbs[3]);
-            LOG_DEBUG("sum[%u].x: %u", id, sum.x.limbs[4]);
-            LOG_DEBUG("sum[%u].x: %u", id, sum.x.limbs[5]);
-            LOG_DEBUG("sum[%u].x: %u", id, sum.x.limbs[6]);
-            LOG_DEBUG("sum[%u].x: %u", id, sum.x.limbs[7]);
-            LOG_DEBUG("sum[%u].x: %u", id, sum.x.limbs[8]);
-            LOG_DEBUG("sum[%u].x: %u", id, sum.x.limbs[9]);
-            LOG_DEBUG("sum[%u].x: %u", id, sum.x.limbs[10]);
-            LOG_DEBUG("sum[%u].x: %u", id, sum.x.limbs[11]);
-            LOG_DEBUG("sum[%u].x: %u", id, sum.x.limbs[12]);
-            LOG_DEBUG("sum[%u].x: %u", id, sum.x.limbs[13]);
-            LOG_DEBUG("sum[%u].x: %u", id, sum.x.limbs[14]);
-            LOG_DEBUG("sum[%u].x: %u", id, sum.x.limbs[15]);
+            for (uint i = 0; i < NUM_LIMBS; i++) {
+                LOG_DEBUG("sum[%u].x: %u", id, sum.x.limbs[i]);
+            }
         }
     }
 }

--- a/mopro-msm/src/msm/metal_msm/shader/field/ff.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/field/ff.metal
@@ -6,29 +6,19 @@ using namespace metal;
 #include <metal_math>
 #include "../bigint/bigint.metal"
 
-BigInt ff_reduce(
-    BigInt a,
-    BigInt p
-) {
+BigInt ff_reduce(BigInt a) {
+    BigInt p = get_p();
     BigIntResult res = bigint_sub(a, p);
     if (res.carry == 1) return a;
     return res.value;
 }
 
-BigInt ff_add(
-    BigInt a,
-    BigInt b,
-    BigInt p
-) {
+BigInt ff_add(BigInt a, BigInt b) {
     BigIntResult res = bigint_add_unsafe(a, b);
-    return ff_reduce(res.value, p);
+    return ff_reduce(res.value);
 }
 
-BigInt ff_sub(
-    BigInt a,
-    BigInt b,
-    BigInt p
-) {
+BigInt ff_sub(BigInt a, BigInt b) {
     bool a_gte_b = bigint_gte(a, b);
 
     if (a_gte_b) {
@@ -37,6 +27,7 @@ BigInt ff_sub(
     }
     else {
         // p - (b - a)
+        BigInt p = get_p();
         BigIntResult diff = bigint_sub(b, a);
         BigIntResult res = bigint_sub(p, diff.value);
         return res.value;

--- a/mopro-msm/src/msm/metal_msm/shader/field/ff_add.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/field/ff_add.metal
@@ -8,9 +8,8 @@ using namespace metal;
 kernel void run(
     device BigInt* a [[ buffer(0) ]],
     device BigInt* b [[ buffer(1) ]],
-    device BigInt* prime [[ buffer(2) ]],
-    device BigInt* res [[ buffer(3) ]],
+    device BigInt* res [[ buffer(2) ]],
     uint gid [[ thread_position_in_grid ]]
 ) {
-    *res = ff_add(*a, *b, *prime);
+    *res = ff_add(*a, *b);
 }

--- a/mopro-msm/src/msm/metal_msm/shader/field/ff_reduce.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/field/ff_reduce.metal
@@ -7,9 +7,8 @@ using namespace metal;
 
 kernel void run(
     device BigInt* a [[ buffer(0) ]],
-    device BigInt* prime [[ buffer(1) ]],
-    device BigInt* res [[ buffer(2) ]],
+    device BigInt* res [[ buffer(1) ]],
     uint gid [[ thread_position_in_grid ]]
 ) {
-    *res = ff_reduce(*a, *prime);
+    *res = ff_reduce(*a);
 }

--- a/mopro-msm/src/msm/metal_msm/shader/field/ff_sub.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/field/ff_sub.metal
@@ -8,9 +8,8 @@ using namespace metal;
 kernel void run(
     device BigInt* a [[ buffer(0) ]],
     device BigInt* b [[ buffer(1) ]],
-    device BigInt* prime [[ buffer(2) ]],
-    device BigInt* res [[ buffer(3) ]],
+    device BigInt* res [[ buffer(2) ]],
     uint gid [[ thread_position_in_grid ]]
 ) {
-    *res = ff_sub(*a, *b, *prime);
+    *res = ff_sub(*a, *b);
 }

--- a/mopro-msm/src/msm/metal_msm/shader/mont_backend/mont.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/mont_backend/mont.metal
@@ -22,13 +22,9 @@ BigInt conditional_reduce(
 /// An optimised variant of the Montgomery product algorithm from
 /// https://github.com/mitschabaude/montgomery#13-x-30-bit-multiplication.
 /// Known to work with 12 and 13-bit limbs.
-BigInt mont_mul_optimised(
-    BigInt x,
-    BigInt y,
-    BigInt p
-) {
+BigInt mont_mul_optimised(BigInt x, BigInt y) {
+    BigInt p = get_p();
     BigInt s = bigint_zero();
-
     for (uint i = 0; i < NUM_LIMBS; i ++) {
         uint t = s.limbs[0] + x.limbs[i] * y.limbs[0];
         uint tprime = t & MASK;
@@ -55,11 +51,8 @@ BigInt mont_mul_optimised(
 /// An modified variant of the Montgomery product algorithm from
 /// https://github.com/mitschabaude/montgomery#13-x-30-bit-multiplication.
 /// Known to work with 14 and 15-bit limbs.
-BigInt mont_mul_modified(
-    BigInt x,
-    BigInt y,
-    BigInt p
-) {
+BigInt mont_mul_modified(BigInt x, BigInt y) {
+    BigInt p = get_p();
     BigInt s = bigint_zero();
 
     for (uint i = 0; i < NUM_LIMBS; i ++) {
@@ -99,13 +92,11 @@ BigInt mont_mul_modified(
 /// The CIOS method for Montgomery multiplication from Tolga Acar's thesis:
 /// High-Speed Algorithms & Architectures For Number-Theoretic Cryptosystems
 /// https://www.proquest.com/openview/1018972f191afe55443658b28041c118/1
-BigInt mont_mul_cios(
-    BigInt x,
-    BigInt y,
-    BigInt p
-) {
-    uint t[NUM_LIMBS + 2] = {0};  // Extra space for carries
+BigInt mont_mul_cios(BigInt x, BigInt y) {
+    BigInt p = get_p();
+
     BigInt result;
+    uint t[NUM_LIMBS + 2] = {0};  // Extra space for carries
     
     for (uint i = 0; i < NUM_LIMBS; i++) {
         // Step 1: Multiply and add

--- a/mopro-msm/src/msm/metal_msm/shader/mont_backend/mont_mul_cios.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/mont_backend/mont_mul_cios.metal
@@ -8,14 +8,8 @@ using namespace metal;
 kernel void run(
     device BigInt* lhs [[ buffer(0) ]],
     device BigInt* rhs [[ buffer(1) ]],
-    device BigInt* prime [[ buffer(2) ]],
-    device BigInt* result [[ buffer(3) ]],
+    device BigInt* result [[ buffer(2) ]],
     uint gid [[ thread_position_in_grid ]]
 ) {
-    BigInt a = *lhs;
-    BigInt b = *rhs;
-    BigInt p = *prime;
-
-    BigInt res = mont_mul_cios(a, b, p);
-    *result = res;
+    *result = mont_mul_cios(*lhs, *rhs);
 }

--- a/mopro-msm/src/msm/metal_msm/shader/mont_backend/mont_mul_cios_benchmarks.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/mont_backend/mont_mul_cios_benchmarks.metal
@@ -6,20 +6,17 @@ using namespace metal;
 kernel void run(
     device BigInt* lhs [[ buffer(0) ]],
     device BigInt* rhs [[ buffer(1) ]],
-    device BigInt* prime [[ buffer(2) ]],
-    device array<uint, 1>* cost [[ buffer(3) ]],
-    device BigInt* result [[ buffer(4) ]],
+    device array<uint, 1>* cost [[ buffer(2) ]],
+    device BigInt* result [[ buffer(3) ]],
     uint gid [[ thread_position_in_grid ]]
 ) {
     BigInt a = *lhs;
     BigInt b = *rhs;
-    BigInt p = *prime;
     array<uint, 1> cost_arr = *cost;
 
-    BigInt c = mont_mul_cios(a, a, p);
+    BigInt c = mont_mul_cios(a, a);
     for (uint i = 1; i < cost_arr[0]; i ++) {
-        c = mont_mul_cios(c, a, p);
+        c = mont_mul_cios(c, a);
     }
-    BigInt res = mont_mul_cios(c, b, p);
-    *result = res;
+    *result = mont_mul_cios(c, b);
 }

--- a/mopro-msm/src/msm/metal_msm/shader/mont_backend/mont_mul_modified.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/mont_backend/mont_mul_modified.metal
@@ -8,14 +8,8 @@ using namespace metal;
 kernel void run(
     device BigInt* lhs [[ buffer(0) ]],
     device BigInt* rhs [[ buffer(1) ]],
-    device BigInt* prime [[ buffer(2) ]],
-    device BigInt* result [[ buffer(3) ]],
+    device BigInt* result [[ buffer(2) ]],
     uint gid [[ thread_position_in_grid ]]
 ) {
-    BigInt a = *lhs;
-    BigInt b = *rhs;
-    BigInt p = *prime;
-
-    BigInt res = mont_mul_modified(a, b, p);
-    *result = res;
+    *result = mont_mul_modified(*lhs, *rhs);
 }

--- a/mopro-msm/src/msm/metal_msm/shader/mont_backend/mont_mul_modified_benchmarks.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/mont_backend/mont_mul_modified_benchmarks.metal
@@ -6,20 +6,17 @@ using namespace metal;
 kernel void run(
     device BigInt* lhs [[ buffer(0) ]],
     device BigInt* rhs [[ buffer(1) ]],
-    device BigInt* prime [[ buffer(2) ]],
-    device array<uint, 1>* cost [[ buffer(3) ]],
-    device BigInt* result [[ buffer(4) ]],
+    device array<uint, 1>* cost [[ buffer(2) ]],
+    device BigInt* result [[ buffer(3) ]],
     uint gid [[ thread_position_in_grid ]]
 ) {
     BigInt a = *lhs;
     BigInt b = *rhs;
-    BigInt p = *prime;
     array<uint, 1> cost_arr = *cost;
 
-    BigInt c = mont_mul_modified(a, a, p);
+    BigInt c = mont_mul_modified(a, a);
     for (uint i = 1; i < cost_arr[0]; i ++) {
-        c = mont_mul_modified(c, a, p);
+        c = mont_mul_modified(c, a);
     }
-    BigInt res = mont_mul_modified(c, b, p);
-    *result = res;
+    *result = mont_mul_modified(c, b);
 }

--- a/mopro-msm/src/msm/metal_msm/shader/mont_backend/mont_mul_optimised.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/mont_backend/mont_mul_optimised.metal
@@ -8,14 +8,8 @@ using namespace metal;
 kernel void run(
     device BigInt* lhs [[ buffer(0) ]],
     device BigInt* rhs [[ buffer(1) ]],
-    device BigInt* prime [[ buffer(2) ]],
-    device BigInt* result [[ buffer(3) ]],
+    device BigInt* result [[ buffer(2) ]],
     uint gid [[ thread_position_in_grid ]]
 ) {
-    BigInt a = *lhs;
-    BigInt b = *rhs;
-    BigInt p = *prime;
-
-    BigInt res = mont_mul_optimised(a, b, p);
-    *result = res;
+    *result = mont_mul_optimised(*lhs, *rhs);
 }

--- a/mopro-msm/src/msm/metal_msm/shader/mont_backend/mont_mul_optimised_benchmarks.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/mont_backend/mont_mul_optimised_benchmarks.metal
@@ -6,20 +6,17 @@ using namespace metal;
 kernel void run(
     device BigInt* lhs [[ buffer(0) ]],
     device BigInt* rhs [[ buffer(1) ]],
-    device BigInt* prime [[ buffer(2) ]],
-    device array<uint, 1>* cost [[ buffer(3) ]],
-    device BigInt* result [[ buffer(4) ]],
+    device array<uint, 1>* cost [[ buffer(2) ]],
+    device BigInt* result [[ buffer(3) ]],
     uint gid [[ thread_position_in_grid ]]
 ) {
     BigInt a = *lhs;
     BigInt b = *rhs;
-    BigInt p = *prime;
     array<uint, 1> cost_arr = *cost;
 
-    BigInt c = mont_mul_optimised(a, a, p);
+    BigInt c = mont_mul_optimised(a, a);
     for (uint i = 1; i < cost_arr[0]; i ++) {
-        c = mont_mul_optimised(c, a, p);
+        c = mont_mul_optimised(c, a);
     }
-    BigInt res = mont_mul_optimised(c, b, p);
-    *result = res;
+    *result = mont_mul_optimised(c, b);
 }

--- a/mopro-msm/src/msm/metal_msm/tests/curve/jacobian_add_2007_b1.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/curve/jacobian_add_2007_b1.rs
@@ -41,7 +41,6 @@ fn jacobian_add_2007_bl_kernel(a: G, b: G, name: &str) -> G {
     let byr = (&by * &r) % &p;
     let bzr = (&bz * &r) % &p;
 
-    let p_limbs = BaseField::MODULUS.to_limbs(num_limbs, log_limb_size);
     let axr_limbs = ark_ff::BigInt::<4>::try_from(axr.clone())
         .unwrap()
         .to_limbs(num_limbs, log_limb_size);
@@ -62,7 +61,6 @@ fn jacobian_add_2007_bl_kernel(a: G, b: G, name: &str) -> G {
         .to_limbs(num_limbs, log_limb_size);
 
     let device = get_default_device();
-    let prime_buf = create_buffer(&device, &p_limbs);
     let axr_buf = create_buffer(&device, &axr_limbs);
     let ayr_buf = create_buffer(&device, &ayr_limbs);
     let azr_buf = create_buffer(&device, &azr_limbs);
@@ -104,16 +102,15 @@ fn jacobian_add_2007_bl_kernel(a: G, b: G, name: &str) -> G {
         .unwrap();
 
     encoder.set_compute_pipeline_state(&pipeline_state);
-    encoder.set_buffer(0, Some(&prime_buf), 0);
-    encoder.set_buffer(1, Some(&axr_buf), 0);
-    encoder.set_buffer(2, Some(&ayr_buf), 0);
-    encoder.set_buffer(3, Some(&azr_buf), 0);
-    encoder.set_buffer(4, Some(&bxr_buf), 0);
-    encoder.set_buffer(5, Some(&byr_buf), 0);
-    encoder.set_buffer(6, Some(&bzr_buf), 0);
-    encoder.set_buffer(7, Some(&result_xr_buf), 0);
-    encoder.set_buffer(8, Some(&result_yr_buf), 0);
-    encoder.set_buffer(9, Some(&result_zr_buf), 0);
+    encoder.set_buffer(0, Some(&axr_buf), 0);
+    encoder.set_buffer(1, Some(&ayr_buf), 0);
+    encoder.set_buffer(2, Some(&azr_buf), 0);
+    encoder.set_buffer(3, Some(&bxr_buf), 0);
+    encoder.set_buffer(4, Some(&byr_buf), 0);
+    encoder.set_buffer(5, Some(&bzr_buf), 0);
+    encoder.set_buffer(6, Some(&result_xr_buf), 0);
+    encoder.set_buffer(7, Some(&result_yr_buf), 0);
+    encoder.set_buffer(8, Some(&result_zr_buf), 0);
 
     let thread_group_count = MTLSize {
         width: 1,

--- a/mopro-msm/src/msm/metal_msm/tests/curve/jacobian_dbl_2009_l.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/curve/jacobian_dbl_2009_l.rs
@@ -43,7 +43,6 @@ pub fn test_jacobian_dbl_2009_l() {
     let ayr = (&ay * &r) % &p;
     let azr = (&az * &r) % &p;
 
-    let p_limbs = BaseField::MODULUS.to_limbs(num_limbs, log_limb_size);
     let axr_limbs = ark_ff::BigInt::<4>::try_from(axr)
         .unwrap()
         .to_limbs(num_limbs, log_limb_size);
@@ -55,7 +54,6 @@ pub fn test_jacobian_dbl_2009_l() {
         .to_limbs(num_limbs, log_limb_size);
 
     let device = get_default_device();
-    let prime_buf = create_buffer(&device, &p_limbs);
     let axr_buf = create_buffer(&device, &axr_limbs);
     let ayr_buf = create_buffer(&device, &ayr_limbs);
     let azr_buf = create_buffer(&device, &azr_limbs);
@@ -93,13 +91,12 @@ pub fn test_jacobian_dbl_2009_l() {
         .unwrap();
 
     encoder.set_compute_pipeline_state(&pipeline_state);
-    encoder.set_buffer(0, Some(&prime_buf), 0);
-    encoder.set_buffer(1, Some(&axr_buf), 0);
-    encoder.set_buffer(2, Some(&ayr_buf), 0);
-    encoder.set_buffer(3, Some(&azr_buf), 0);
-    encoder.set_buffer(4, Some(&result_xr_buf), 0);
-    encoder.set_buffer(5, Some(&result_yr_buf), 0);
-    encoder.set_buffer(6, Some(&result_zr_buf), 0);
+    encoder.set_buffer(0, Some(&axr_buf), 0);
+    encoder.set_buffer(1, Some(&ayr_buf), 0);
+    encoder.set_buffer(2, Some(&azr_buf), 0);
+    encoder.set_buffer(3, Some(&result_xr_buf), 0);
+    encoder.set_buffer(4, Some(&result_yr_buf), 0);
+    encoder.set_buffer(5, Some(&result_zr_buf), 0);
 
     let thread_group_count = MTLSize {
         width: 1,

--- a/mopro-msm/src/msm/metal_msm/tests/curve/jacobian_madd_2007_bl.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/curve/jacobian_madd_2007_bl.rs
@@ -63,7 +63,6 @@ pub fn test_jacobian_add_2007_bl() {
     let bxr = (&bx * &r) % &p;
     let byr = (&by * &r) % &p;
 
-    let p_limbs = BaseField::MODULUS.to_limbs(num_limbs, log_limb_size);
     let axr_limbs = ark_ff::BigInt::<4>::try_from(axr.clone())
         .unwrap()
         .to_limbs(num_limbs, log_limb_size);
@@ -81,7 +80,6 @@ pub fn test_jacobian_add_2007_bl() {
         .to_limbs(num_limbs, log_limb_size);
 
     let device = get_default_device();
-    let prime_buf = create_buffer(&device, &p_limbs);
     let axr_buf = create_buffer(&device, &axr_limbs);
     let ayr_buf = create_buffer(&device, &ayr_limbs);
     let azr_buf = create_buffer(&device, &azr_limbs);
@@ -121,15 +119,14 @@ pub fn test_jacobian_add_2007_bl() {
         .unwrap();
 
     encoder.set_compute_pipeline_state(&pipeline_state);
-    encoder.set_buffer(0, Some(&prime_buf), 0);
-    encoder.set_buffer(1, Some(&axr_buf), 0);
-    encoder.set_buffer(2, Some(&ayr_buf), 0);
-    encoder.set_buffer(3, Some(&azr_buf), 0);
-    encoder.set_buffer(4, Some(&bxr_buf), 0);
-    encoder.set_buffer(5, Some(&byr_buf), 0);
-    encoder.set_buffer(6, Some(&result_xr_buf), 0);
-    encoder.set_buffer(7, Some(&result_yr_buf), 0);
-    encoder.set_buffer(8, Some(&result_zr_buf), 0);
+    encoder.set_buffer(0, Some(&axr_buf), 0);
+    encoder.set_buffer(1, Some(&ayr_buf), 0);
+    encoder.set_buffer(2, Some(&azr_buf), 0);
+    encoder.set_buffer(3, Some(&bxr_buf), 0);
+    encoder.set_buffer(4, Some(&byr_buf), 0);
+    encoder.set_buffer(5, Some(&result_xr_buf), 0);
+    encoder.set_buffer(6, Some(&result_yr_buf), 0);
+    encoder.set_buffer(7, Some(&result_zr_buf), 0);
 
     let thread_group_count = MTLSize {
         width: 1,

--- a/mopro-msm/src/msm/metal_msm/tests/curve/jacobian_neg.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/curve/jacobian_neg.rs
@@ -41,7 +41,6 @@ pub fn test_jacobian_neg() {
     let ayr = (&ay * &r) % &p;
     let azr = (&az * &r) % &p;
 
-    let p_limbs = BaseField::MODULUS.to_limbs(num_limbs, log_limb_size);
     let axr_limbs = ark_ff::BigInt::<4>::try_from(axr)
         .unwrap()
         .to_limbs(num_limbs, log_limb_size);
@@ -53,7 +52,6 @@ pub fn test_jacobian_neg() {
         .to_limbs(num_limbs, log_limb_size);
 
     let device = get_default_device();
-    let prime_buf = create_buffer(&device, &p_limbs);
     let axr_buf = create_buffer(&device, &axr_limbs);
     let ayr_buf = create_buffer(&device, &ayr_limbs);
     let azr_buf = create_buffer(&device, &azr_limbs);
@@ -91,13 +89,12 @@ pub fn test_jacobian_neg() {
         .unwrap();
 
     encoder.set_compute_pipeline_state(&pipeline_state);
-    encoder.set_buffer(0, Some(&prime_buf), 0);
-    encoder.set_buffer(1, Some(&axr_buf), 0);
-    encoder.set_buffer(2, Some(&ayr_buf), 0);
-    encoder.set_buffer(3, Some(&azr_buf), 0);
-    encoder.set_buffer(4, Some(&result_xr_buf), 0);
-    encoder.set_buffer(5, Some(&result_yr_buf), 0);
-    encoder.set_buffer(6, Some(&result_zr_buf), 0);
+    encoder.set_buffer(0, Some(&axr_buf), 0);
+    encoder.set_buffer(1, Some(&ayr_buf), 0);
+    encoder.set_buffer(2, Some(&azr_buf), 0);
+    encoder.set_buffer(3, Some(&result_xr_buf), 0);
+    encoder.set_buffer(4, Some(&result_yr_buf), 0);
+    encoder.set_buffer(5, Some(&result_zr_buf), 0);
 
     let thread_group_count = MTLSize {
         width: 1,

--- a/mopro-msm/src/msm/metal_msm/tests/field/ff_add.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/field/ff_add.rs
@@ -41,7 +41,6 @@ pub fn test_ff_add() {
     let device = get_default_device();
     let a_buf = create_buffer(&device, &a.to_limbs(num_limbs, log_limb_size));
     let b_buf = create_buffer(&device, &b.to_limbs(num_limbs, log_limb_size));
-    let p_buf = create_buffer(&device, &p.to_limbs(num_limbs, log_limb_size));
     let result_buf = create_empty_buffer(&device, num_limbs);
 
     // Perform (a + b) % p
@@ -99,8 +98,7 @@ pub fn test_ff_add() {
     encoder.set_compute_pipeline_state(&pipeline_state);
     encoder.set_buffer(0, Some(&a_buf), 0);
     encoder.set_buffer(1, Some(&b_buf), 0);
-    encoder.set_buffer(2, Some(&p_buf), 0);
-    encoder.set_buffer(3, Some(&result_buf), 0);
+    encoder.set_buffer(2, Some(&result_buf), 0);
 
     let thread_group_count = MTLSize {
         width: 1,

--- a/mopro-msm/src/msm/metal_msm/tests/field/ff_reduce.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/field/ff_reduce.rs
@@ -37,7 +37,6 @@ pub fn test_ff_reduce_a_less_than_p() {
     let a_limbs = a.to_limbs(num_limbs, log_limb_size);
     let device = get_default_device();
     let a_buf = create_buffer(&device, &a_limbs);
-    let p_buf = create_buffer(&device, &p.to_limbs(num_limbs, log_limb_size));
     let result_buf = create_empty_buffer(&device, num_limbs);
 
     let command_queue = device.new_command_queue();
@@ -71,8 +70,7 @@ pub fn test_ff_reduce_a_less_than_p() {
 
     encoder.set_compute_pipeline_state(&pipeline_state);
     encoder.set_buffer(0, Some(&a_buf), 0);
-    encoder.set_buffer(1, Some(&p_buf), 0);
-    encoder.set_buffer(2, Some(&result_buf), 0);
+    encoder.set_buffer(1, Some(&result_buf), 0);
 
     let thread_group_count = MTLSize {
         width: 1,
@@ -137,7 +135,6 @@ pub fn test_ff_reduce_a_greater_than_p_less_than_2p() {
     let a_limbs = a.to_limbs(num_limbs, log_limb_size);
     let device = get_default_device();
     let a_buf = create_buffer(&device, &a_limbs);
-    let p_buf = create_buffer(&device, &p.to_limbs(num_limbs, log_limb_size));
     let result_buf = create_empty_buffer(&device, num_limbs);
 
     let command_queue = device.new_command_queue();
@@ -171,8 +168,7 @@ pub fn test_ff_reduce_a_greater_than_p_less_than_2p() {
 
     encoder.set_compute_pipeline_state(&pipeline_state);
     encoder.set_buffer(0, Some(&a_buf), 0);
-    encoder.set_buffer(1, Some(&p_buf), 0);
-    encoder.set_buffer(2, Some(&result_buf), 0);
+    encoder.set_buffer(1, Some(&result_buf), 0);
 
     let thread_group_count = MTLSize {
         width: 1,

--- a/mopro-msm/src/msm/metal_msm/tests/field/ff_sub.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/field/ff_sub.rs
@@ -41,7 +41,6 @@ pub fn test_ff_sub() {
     let device = get_default_device();
     let a_buf = create_buffer(&device, &a.to_limbs(num_limbs, log_limb_size));
     let b_buf = create_buffer(&device, &b.to_limbs(num_limbs, log_limb_size));
-    let p_buf = create_buffer(&device, &p.to_limbs(num_limbs, log_limb_size));
     let result_buf = create_empty_buffer(&device, num_limbs);
 
     // (a - b) % p
@@ -103,8 +102,7 @@ pub fn test_ff_sub() {
     encoder.set_compute_pipeline_state(&pipeline_state);
     encoder.set_buffer(0, Some(&a_buf), 0);
     encoder.set_buffer(1, Some(&b_buf), 0);
-    encoder.set_buffer(2, Some(&p_buf), 0);
-    encoder.set_buffer(3, Some(&result_buf), 0);
+    encoder.set_buffer(2, Some(&result_buf), 0);
 
     let thread_group_count = MTLSize {
         width: 1,

--- a/mopro-msm/src/msm/metal_msm/tests/mont_backend/mont_benchmarks.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/mont_backend/mont_benchmarks.rs
@@ -84,13 +84,11 @@ pub fn benchmark(log_limb_size: u32, shader_file: &str) -> Result<i64, String> {
         .unwrap()
         .into_bigint()
         .to_limbs(num_limbs, log_limb_size);
-    let p_limbs = &BaseField::MODULUS.to_limbs(num_limbs, log_limb_size);
 
     let device = get_default_device();
 
     let a_buf = create_buffer(&device, &ar_limbs);
     let b_buf = create_buffer(&device, &br_limbs);
-    let p_buf = create_buffer(&device, &p_limbs);
     let cost_buf = create_buffer(&device, &vec![cost as u32]);
     let result_buf = create_empty_buffer(&device, num_limbs);
 
@@ -126,9 +124,8 @@ pub fn benchmark(log_limb_size: u32, shader_file: &str) -> Result<i64, String> {
     encoder.set_compute_pipeline_state(&pipeline_state);
     encoder.set_buffer(0, Some(&a_buf), 0);
     encoder.set_buffer(1, Some(&b_buf), 0);
-    encoder.set_buffer(2, Some(&p_buf), 0);
-    encoder.set_buffer(3, Some(&cost_buf), 0);
-    encoder.set_buffer(4, Some(&result_buf), 0);
+    encoder.set_buffer(2, Some(&cost_buf), 0);
+    encoder.set_buffer(3, Some(&result_buf), 0);
 
     let thread_group_count = MTLSize {
         width: 1,
@@ -162,10 +159,6 @@ pub fn benchmark(log_limb_size: u32, shader_file: &str) -> Result<i64, String> {
     }
 
     let result = BigInt::<4>::from_limbs(&result_limbs, log_limb_size);
-
-    // assert!(result == expected.try_into().unwrap());
-    // assert!(result_limbs == expected_limbs);
-
     if result == expected.try_into().unwrap() && result_limbs == expected_limbs {
         Ok(elapsed)
     } else {

--- a/mopro-msm/src/msm/metal_msm/tests/mont_backend/mont_mul_cios.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/mont_backend/mont_mul_cios.rs
@@ -59,10 +59,6 @@ pub fn do_test(log_limb_size: u32) {
         &device,
         &b_r_in_ark.into_bigint().to_limbs(num_limbs, log_limb_size),
     );
-    let p_buf = create_buffer(
-        &device,
-        &BaseField::MODULUS.to_limbs(num_limbs, log_limb_size),
-    );
     let result_buf = create_empty_buffer(&device, num_limbs);
 
     let command_queue = device.new_command_queue();
@@ -97,8 +93,7 @@ pub fn do_test(log_limb_size: u32) {
     encoder.set_compute_pipeline_state(&pipeline_state);
     encoder.set_buffer(0, Some(&a_buf), 0);
     encoder.set_buffer(1, Some(&b_buf), 0);
-    encoder.set_buffer(2, Some(&p_buf), 0);
-    encoder.set_buffer(3, Some(&result_buf), 0);
+    encoder.set_buffer(2, Some(&result_buf), 0);
 
     let thread_group_count = MTLSize {
         width: 1,

--- a/mopro-msm/src/msm/metal_msm/tests/mont_backend/mont_mul_modified.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/mont_backend/mont_mul_modified.rs
@@ -59,10 +59,6 @@ pub fn do_test(log_limb_size: u32) {
         &device,
         &b_r_in_ark.into_bigint().to_limbs(num_limbs, log_limb_size),
     );
-    let p_buf = create_buffer(
-        &device,
-        &BaseField::MODULUS.to_limbs(num_limbs, log_limb_size),
-    );
     let result_buf = create_empty_buffer(&device, num_limbs);
 
     let command_queue = device.new_command_queue();
@@ -97,8 +93,7 @@ pub fn do_test(log_limb_size: u32) {
     encoder.set_compute_pipeline_state(&pipeline_state);
     encoder.set_buffer(0, Some(&a_buf), 0);
     encoder.set_buffer(1, Some(&b_buf), 0);
-    encoder.set_buffer(2, Some(&p_buf), 0);
-    encoder.set_buffer(3, Some(&result_buf), 0);
+    encoder.set_buffer(2, Some(&result_buf), 0);
 
     let thread_group_count = MTLSize {
         width: 1,

--- a/mopro-msm/src/msm/metal_msm/tests/mont_backend/mont_mul_optimised.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/mont_backend/mont_mul_optimised.rs
@@ -62,10 +62,6 @@ pub fn do_test(log_limb_size: u32) {
         &device,
         &b_r_in_ark.into_bigint().to_limbs(num_limbs, log_limb_size),
     );
-    let p_buf = create_buffer(
-        &device,
-        &BaseField::MODULUS.to_limbs(num_limbs, log_limb_size),
-    );
     let result_buf = create_empty_buffer(&device, num_limbs);
 
     let command_queue = device.new_command_queue();
@@ -100,8 +96,7 @@ pub fn do_test(log_limb_size: u32) {
     encoder.set_compute_pipeline_state(&pipeline_state);
     encoder.set_buffer(0, Some(&a_buf), 0);
     encoder.set_buffer(1, Some(&b_buf), 0);
-    encoder.set_buffer(2, Some(&p_buf), 0);
-    encoder.set_buffer(3, Some(&result_buf), 0);
+    encoder.set_buffer(2, Some(&result_buf), 0);
 
     let thread_group_count = MTLSize {
         width: 1,


### PR DESCRIPTION
- related issue: #32

To avoid redundant `p` (BN254 Basefield modulus) parameter in each low-level shaders, this PR simplifies code by removing the `BigInt p` parameter and make it retrievable from shaders through `get_p()` in `get_constant.metal`.

Also, related Rust host code are adjusted accordingly.