### PR TITLE
feat: add big int as input for pbpr

### DIFF
--- a/mopro-msm/src/msm/metal_msm/shader/cuzk/pbpr.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/cuzk/pbpr.metal
@@ -4,35 +4,6 @@ using namespace metal;
 #include "../misc/get_constant.metal"
 
 kernel void parallel_bpr(
-    constant Jacobian* buckets         [[ buffer(0) ]],
-    device Jacobian* m_shared          [[ buffer(1) ]],
-    device Jacobian* s_shared          [[ buffer(2) ]],
-    constant uint32_t& grid_width      [[ buffer(3) ]],
-    constant uint32_t& total_threads   [[ buffer(4) ]],
-    constant uint32_t& r               [[ buffer(5) ]],
-    uint2 tid                          [[ thread_position_in_grid ]]
-) {
-    // Convert the 2D thread coordinate into a flat index.
-    uint gid = tid.y * grid_width + tid.x;
-    if (gid >= total_threads) {
-        return;
-    }
-
-    // Accumulating buckets into s_shared and m_shared using 0-based indexing.
-    for (uint32_t l = 1; l <= r; l++) {
-        if (l != 1) {
-            m_shared[gid] = m_shared[gid] + buckets[(gid + 1) * r - l];
-            s_shared[gid] = s_shared[gid] + m_shared[gid];
-        } else {
-            m_shared[gid] = buckets[(gid + 1) * r - 1];
-            s_shared[gid] = m_shared[gid];
-        }
-    }
-    uint32_t scalar = gid * r;
-    s_shared[gid] = s_shared[gid] + jacobian_scalar_mul(m_shared[gid], scalar);
-}
-
-kernel void parallel_bpr_big_int(
     constant BigInt* buckets_x         [[ buffer(0) ]],
     constant BigInt* buckets_y         [[ buffer(1) ]],
     constant BigInt* buckets_z         [[ buffer(2) ]],

--- a/mopro-msm/src/msm/metal_msm/shader/cuzk/pbpr.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/cuzk/pbpr.metal
@@ -31,3 +31,86 @@ kernel void parallel_bpr(
     uint32_t scalar = gid * r;
     s_shared[gid] = s_shared[gid] + jacobian_scalar_mul(m_shared[gid], scalar);
 }
+
+kernel void parallel_bpr_big_int(
+    constant BigInt* buckets_x         [[ buffer(0) ]],
+    constant BigInt* buckets_y         [[ buffer(1) ]],
+    constant BigInt* buckets_z         [[ buffer(2) ]],
+    device BigInt* m_x                 [[ buffer(3) ]],
+    device BigInt* m_y                 [[ buffer(4) ]],
+    device BigInt* m_z                 [[ buffer(5) ]],
+    device BigInt* s_x                 [[ buffer(6) ]],
+    device BigInt* s_y                 [[ buffer(7) ]],
+    device BigInt* s_z                 [[ buffer(8) ]],
+    constant uint32_t& grid_width      [[ buffer(9) ]],
+    constant uint32_t& total_threads   [[ buffer(10) ]],
+    constant uint32_t& r               [[ buffer(11) ]],
+    uint2 tid                          [[ thread_position_in_grid ]]
+) {
+    // Convert the 2D thread coordinate into a flat index.
+    uint gid = tid.y * grid_width + tid.x;
+    if (gid >= total_threads) {
+        return;
+    }
+   
+    // Accumulating buckets into s_shared and m_shared using 0-based indexing.
+    for (uint32_t l = 1; l <= r; l++) {
+        
+        Jacobian m_shared = {
+            m_x[gid],
+            m_y[gid],
+            m_z[gid]
+        };
+
+        Jacobian s_shared = {
+            s_x[gid],
+            s_y[gid],
+            s_z[gid]
+        };
+
+        Jacobian bucket_val;
+
+        if (l != 1) {
+            bucket_val.x = buckets_x[(gid + 1) * r - l];
+            bucket_val.y = buckets_y[(gid + 1) * r - l];
+            bucket_val.z = buckets_z[(gid + 1) * r - l];
+            
+            m_shared = m_shared + bucket_val;
+            s_shared = s_shared + m_shared;
+        } else {
+            bucket_val.x = buckets_x[(gid + 1) * r - 1];
+            bucket_val.y = buckets_y[(gid + 1) * r - 1];
+            bucket_val.z = buckets_z[(gid + 1) * r - 1];
+            
+            m_shared = bucket_val;
+            s_shared = m_shared;
+        }
+        
+        m_x[gid] = m_shared.x;
+        m_y[gid] = m_shared.y;
+        m_z[gid] = m_shared.z;
+        
+        s_x[gid] = s_shared.x;
+        s_y[gid] = s_shared.y;
+        s_z[gid] = s_shared.z;
+    }
+
+    Jacobian final_s = {
+        s_x[gid],
+        s_y[gid],
+        s_z[gid]
+    };
+
+    Jacobian m = {
+        m_x[gid],
+        m_y[gid],
+        m_z[gid]
+    };
+
+    uint32_t scalar = gid * r;
+    final_s = final_s + jacobian_scalar_mul(m, scalar);
+    
+    s_x[gid] = final_s.x;
+    s_y[gid] = final_s.y;
+    s_z[gid] = final_s.z;
+}

--- a/mopro-msm/src/msm/metal_msm/tests/curve/jacobian_data_conversion.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/curve/jacobian_data_conversion.rs
@@ -20,7 +20,6 @@ fn test_jacobian_dataflow() {
 
     let r = calc_mont_radix(num_limbs, log_limb_size);
     let res = calc_rinv_and_n0(&p, &r, log_limb_size);
-    let rinv = res.0;
     let n0 = res.1;
     let nsafe = calc_nsafe(log_limb_size);
 
@@ -73,7 +72,7 @@ fn test_jacobian_dataflow() {
     command_buffer.commit();
     command_buffer.wait_until_completed();
 
-    let result_points: Vec<G> = points_from_gpu_buffer(&output_buffer, num_limbs, p, rinv);
+    let result_points: Vec<G> = points_from_gpu_buffer(&output_buffer, num_limbs);
     for i in 0..points.len() {
         assert_eq!(points[i] * ScalarField::from(2 as u64), result_points[i]);
     }

--- a/mopro-msm/src/msm/metal_msm/tests/cuzk/pbpr.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/cuzk/pbpr.rs
@@ -1,4 +1,4 @@
-use crate::msm::metal_msm::host::gpu::{create_buffer, create_empty_buffer, get_default_device};
+use crate::msm::metal_msm::host::gpu::{create_buffer, get_default_device};
 use crate::msm::metal_msm::host::shader::{compile_metal, write_constants};
 use crate::msm::metal_msm::utils::data_conversion::{
     points_from_gpu_buffer, points_to_gpu_buffer, raw_reduction,
@@ -37,9 +37,7 @@ fn closest_power_of_two(n: usize) -> usize {
 fn gpu_parallel_bpr(buckets: &Vec<G>) -> G {
     let mont_params = MontgomeryParams::default();
     let log_limb_size: u32 = 16;
-    let p: BigUint = mont_params.p;
     let num_limbs = mont_params.num_limbs;
-    let rinv = mont_params.rinv;
     let n0 = mont_params.n0;
     let nsafe = mont_params.nsafe;
 
@@ -133,7 +131,7 @@ fn gpu_parallel_bpr(buckets: &Vec<G>) -> G {
     command_buffer.commit();
     command_buffer.wait_until_completed();
 
-    let s_shared = points_from_gpu_buffer(&s_shared_buffer, num_limbs, p, rinv);
+    let s_shared = points_from_gpu_buffer(&s_shared_buffer, num_limbs);
 
     s_shared.iter().sum::<G>()
 }

--- a/mopro-msm/src/msm/metal_msm/tests/cuzk/pbpr.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/cuzk/pbpr.rs
@@ -1,8 +1,6 @@
 use crate::msm::metal_msm::host::gpu::{create_buffer, get_default_device};
 use crate::msm::metal_msm::host::shader::{compile_metal, write_constants};
-use crate::msm::metal_msm::utils::data_conversion::{
-    points_from_gpu_buffer, points_to_gpu_buffer, raw_reduction,
-};
+use crate::msm::metal_msm::utils::data_conversion::raw_reduction;
 use crate::msm::metal_msm::utils::limbs_conversion::GenericLimbConversion;
 use crate::msm::metal_msm::utils::mont_params::{calc_mont_radix, MontgomeryParams};
 use ark_bn254::{Fq as BaseField, Fr as ScalarField, G1Projective as G};
@@ -33,111 +31,8 @@ fn closest_power_of_two(n: usize) -> usize {
     }
 }
 
-// Implements parallel bucket reduction in GPU
-fn gpu_parallel_bpr(buckets: &Vec<G>) -> G {
-    let mont_params = MontgomeryParams::default();
-    let log_limb_size: u32 = 16;
-    let num_limbs = mont_params.num_limbs;
-    let n0 = mont_params.n0;
-    let nsafe = mont_params.nsafe;
-
-    let device = get_default_device();
-    let bucket_size = buckets.len();
-    let bucket_buffer = points_to_gpu_buffer(buckets, num_limbs, &device);
-
-    let library_path = compile_metal("../mopro-msm/src/msm/metal_msm/shader/cuzk", "pbpr.metal");
-    let library = device.new_library_with_file(library_path).unwrap();
-    let kernel = library.get_function("parallel_bpr", None).unwrap();
-
-    let pipeline_state_descriptor = ComputePipelineDescriptor::new();
-    pipeline_state_descriptor.set_compute_function(Some(&kernel));
-
-    let pipeline_state = device
-        .new_compute_pipeline_state_with_function(
-            pipeline_state_descriptor.compute_function().unwrap(),
-        )
-        .unwrap();
-
-    let thread_group_width = pipeline_state.thread_execution_width();
-    let thread_group_height =
-        pipeline_state.max_total_threads_per_threadgroup() / thread_group_width;
-
-    let max_group_threads = pipeline_state.max_total_threads_per_threadgroup();
-
-    let optimal_threads = max_group_threads;
-
-    let candidate = if bucket_size < optimal_threads as usize {
-        bucket_size
-    } else {
-        optimal_threads as usize // This is wrong, since we're workloading just a single TG,
-                                 // The thing is that this gives the best performance so far
-                                 // But we need to introduce cross kernel synchronisation to improve this.
-    };
-
-    let total_threads = closest_power_of_two(candidate) as usize;
-
-    let grid_width = (total_threads as f64).sqrt().ceil() as u64;
-    let grid_height = (total_threads as u64 + grid_width - 1) / grid_width;
-
-    let threads_per_thread_group = MTLSize {
-        width: thread_group_width,
-        height: thread_group_height,
-        depth: 1,
-    };
-
-    let threads_total = MTLSize {
-        width: grid_width,
-        height: grid_height,
-        depth: 1,
-    };
-
-    let total_threads_buffer = create_buffer(&device, &vec![total_threads as u32]);
-    let grid_width_buffer = create_buffer(&device, &vec![grid_width as u32]);
-
-    let m_shared = vec![G::zero(); total_threads];
-    let s_shared = vec![G::zero(); total_threads];
-
-    let m_shared_buffer = points_to_gpu_buffer(&m_shared, num_limbs, &device);
-    let s_shared_buffer = points_to_gpu_buffer(&s_shared, num_limbs, &device);
-
-    let num_subtask = (bucket_size + total_threads - 1) / total_threads;
-    let num_subtask_buffer = create_buffer(&device, &vec![num_subtask as u32]);
-
-    // set up command queue and encoder
-    let command_queue = device.new_command_queue();
-    let command_buffer = command_queue.new_command_buffer();
-    let encoder =
-        command_buffer.compute_command_encoder_with_descriptor(ComputePassDescriptor::new());
-
-    write_constants(
-        "../mopro-msm/src/msm/metal_msm/shader",
-        num_limbs,
-        log_limb_size,
-        n0,
-        nsafe,
-    );
-
-    encoder.set_compute_pipeline_state(&pipeline_state);
-
-    encoder.set_buffer(0, Some(&bucket_buffer), 0);
-    encoder.set_buffer(1, Some(&m_shared_buffer), 0);
-    encoder.set_buffer(2, Some(&s_shared_buffer), 0);
-    encoder.set_buffer(3, Some(&grid_width_buffer), 0);
-    encoder.set_buffer(4, Some(&total_threads_buffer), 0);
-    encoder.set_buffer(5, Some(&num_subtask_buffer), 0);
-
-    encoder.dispatch_threads(threads_total, threads_per_thread_group);
-    encoder.end_encoding();
-    command_buffer.commit();
-    command_buffer.wait_until_completed();
-
-    let s_shared = points_from_gpu_buffer(&s_shared_buffer, num_limbs);
-
-    s_shared.iter().sum::<G>()
-}
-
 /// Implement parallel bucket reduction in GPU using separated buffers internally
-fn gpu_parallel_bpr_big_int(buckets: &Vec<G>) -> G {
+fn gpu_parallel_bpr(buckets: &Vec<G>) -> G {
     /// Converts a bucket vector into three separated vectors for the x, y, and z coordinates
     /// Each coordinate is represented as a vector of u32 values in Montgomery form
     fn buckets_to_separated_coords(
@@ -223,6 +118,7 @@ fn gpu_parallel_bpr_big_int(buckets: &Vec<G>) -> G {
 
         points
     }
+
     let mont_params = MontgomeryParams::default();
     let log_limb_size: u32 = 16;
     let num_limbs = mont_params.num_limbs;
@@ -243,7 +139,7 @@ fn gpu_parallel_bpr_big_int(buckets: &Vec<G>) -> G {
     // Compile shader and create pipeline
     let library_path = compile_metal("../mopro-msm/src/msm/metal_msm/shader/cuzk", "pbpr.metal");
     let library = device.new_library_with_file(library_path).unwrap();
-    let kernel = library.get_function("parallel_bpr_big_int", None).unwrap();
+    let kernel = library.get_function("parallel_bpr", None).unwrap();
 
     let pipeline_state_descriptor = ComputePipelineDescriptor::new();
     pipeline_state_descriptor.set_compute_function(Some(&kernel));
@@ -265,7 +161,9 @@ fn gpu_parallel_bpr_big_int(buckets: &Vec<G>) -> G {
     let candidate = if bucket_size < optimal_threads as usize {
         bucket_size
     } else {
-        optimal_threads as usize
+        optimal_threads as usize // This is wrong, since we're workloading just a single TG,
+                                 // The thing is that this gives the best performance so far
+                                 // But we need to introduce cross kernel synchronisation to improve this.
     };
 
     let total_threads = closest_power_of_two(candidate);
@@ -517,22 +415,4 @@ fn test_pbpr_random_inputs() {
         );
         assert_eq!(gpu_pbpr_result, naive_result);
     }
-}
-
-#[test]
-#[serial_test::serial]
-fn test_pbpr_big_int() {
-    let generator = G::generator();
-    let c: u32 = 9;
-    let bucket_size = 1 << c;
-    let buckets = (1..=bucket_size).map(|_| generator).collect::<Vec<G>>();
-
-    // let cpu_naive_result = cpu_naive_bpr(&buckets);
-    let cpu_pbpr_result = cpu_parallel_bpr(&buckets);
-
-    let start = Instant::now();
-    let gpu_pbpr_big_int_result = gpu_parallel_bpr_big_int(&buckets);
-    let duration = start.elapsed();
-    println!("gpu_parallel_bpr_big_int execution time: {:?}", duration);
-    assert_eq!(gpu_pbpr_big_int_result, cpu_pbpr_result);
 }

--- a/mopro-msm/src/msm/metal_msm/tests/cuzk/pbpr.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/cuzk/pbpr.rs
@@ -1,9 +1,13 @@
-use crate::msm::metal_msm::host::gpu::{create_buffer, get_default_device};
+use crate::msm::metal_msm::host::gpu::{create_buffer, create_empty_buffer, get_default_device};
 use crate::msm::metal_msm::host::shader::{compile_metal, write_constants};
-use crate::msm::metal_msm::utils::data_conversion::{points_from_gpu_buffer, points_to_gpu_buffer};
-use crate::msm::metal_msm::utils::mont_params::MontgomeryParams;
-use ark_bn254::{Fr as ScalarField, G1Projective as G};
+use crate::msm::metal_msm::utils::data_conversion::{
+    points_from_gpu_buffer, points_to_gpu_buffer, raw_reduction,
+};
+use crate::msm::metal_msm::utils::limbs_conversion::GenericLimbConversion;
+use crate::msm::metal_msm::utils::mont_params::{calc_mont_radix, MontgomeryParams};
+use ark_bn254::{Fq as BaseField, Fr as ScalarField, G1Projective as G};
 use ark_ec::Group;
+use ark_ff::{BigInt, PrimeField};
 use ark_std::{rand::thread_rng, UniformRand, Zero};
 use metal::*;
 use num_bigint::BigUint;
@@ -134,6 +138,302 @@ fn gpu_parallel_bpr(buckets: &Vec<G>) -> G {
     s_shared.iter().sum::<G>()
 }
 
+/// Implement parallel bucket reduction in GPU using separated buffers internally
+fn gpu_parallel_bpr_big_int(buckets: &Vec<G>) -> G {
+    /// Converts a bucket vector into three separated vectors for the x, y, and z coordinates
+    /// Each coordinate is represented as a vector of u32 values in Montgomery form
+    fn buckets_to_separated_coords(
+        buckets: &Vec<G>,
+        num_limbs: usize,
+    ) -> (Vec<u32>, Vec<u32>, Vec<u32>) {
+        let log_limb_size: u32 = 16;
+        let p: BigUint = BaseField::MODULUS.try_into().unwrap();
+        let r = calc_mont_radix(num_limbs, log_limb_size);
+
+        // Pre-allocate vectors for the limbs
+        let total_limbs = buckets.len() * num_limbs;
+        let mut buckets_x = Vec::with_capacity(total_limbs);
+        let mut buckets_y = Vec::with_capacity(total_limbs);
+        let mut buckets_z = Vec::with_capacity(total_limbs);
+
+        for point in buckets {
+            // Convert to Montgomery form
+            let px: BigUint = point.x.into();
+            let py: BigUint = point.y.into();
+            let pz: BigUint = point.z.into();
+
+            let pxr = (&px * &r) % &p;
+            let pyr = (&py * &r) % &p;
+            let pzr = (&pz * &r) % &p;
+
+            // Convert to limbs
+            let pxr_limbs = BigInt::<4>::try_from(pxr)
+                .unwrap()
+                .to_limbs(num_limbs, log_limb_size);
+            let pyr_limbs = BigInt::<4>::try_from(pyr)
+                .unwrap()
+                .to_limbs(num_limbs, log_limb_size);
+            let pzr_limbs = BigInt::<4>::try_from(pzr)
+                .unwrap()
+                .to_limbs(num_limbs, log_limb_size);
+
+            // Add limbs to the coordinate vectors
+            buckets_x.extend_from_slice(&pxr_limbs);
+            buckets_y.extend_from_slice(&pyr_limbs);
+            buckets_z.extend_from_slice(&pzr_limbs);
+        }
+
+        (buckets_x, buckets_y, buckets_z)
+    }
+
+    /// Convert separated coordinate buffers from GPU back to a vector of points
+    fn points_from_separated_buffers(
+        x_buffer: &[u32],
+        y_buffer: &[u32],
+        z_buffer: &[u32],
+        num_limbs: usize,
+    ) -> Vec<G> {
+        let log_limb_size = 16;
+        let coord_size = num_limbs;
+        let total_u32s = x_buffer.len() as usize;
+        let num_points = total_u32s / coord_size;
+
+        let mut points = Vec::with_capacity(num_points);
+
+        for i in 0..num_points {
+            let start_idx = i * coord_size;
+            let end_idx = start_idx + coord_size;
+
+            // Extract limbs for each coordinate
+            let x_limbs = &x_buffer[start_idx..end_idx];
+            let y_limbs = &y_buffer[start_idx..end_idx];
+            let z_limbs = &z_buffer[start_idx..end_idx];
+
+            // Convert limbs back to BigInt
+            let x_bigint = raw_reduction(BigInt::<4>::from_limbs(x_limbs, log_limb_size));
+            let y_bigint = raw_reduction(BigInt::<4>::from_limbs(y_limbs, log_limb_size));
+            let z_bigint = raw_reduction(BigInt::<4>::from_limbs(z_limbs, log_limb_size));
+
+            // Convert to field elements
+            let x = BaseField::from_bigint(x_bigint).unwrap();
+            let y = BaseField::from_bigint(y_bigint).unwrap();
+            let z = BaseField::from_bigint(z_bigint).unwrap();
+
+            // Create and add the point
+            points.push(G::new_unchecked(x, y, z));
+        }
+
+        points
+    }
+    let mont_params = MontgomeryParams::default();
+    let log_limb_size: u32 = 16;
+    let num_limbs = mont_params.num_limbs;
+    let n0 = mont_params.n0;
+    let nsafe = mont_params.nsafe;
+
+    let device = get_default_device();
+    let bucket_size = buckets.len();
+
+    // Convert buckets to separated coordinate arrays
+    let (buckets_x, buckets_y, buckets_z) = buckets_to_separated_coords(buckets, num_limbs);
+
+    // Create buffers for coordinates
+    let buckets_x_buffer = create_buffer(&device, &buckets_x);
+    let buckets_y_buffer = create_buffer(&device, &buckets_y);
+    let buckets_z_buffer = create_buffer(&device, &buckets_z);
+
+    // Compile shader and create pipeline
+    let library_path = compile_metal("../mopro-msm/src/msm/metal_msm/shader/cuzk", "pbpr.metal");
+    let library = device.new_library_with_file(library_path).unwrap();
+    let kernel = library.get_function("parallel_bpr_big_int", None).unwrap();
+
+    let pipeline_state_descriptor = ComputePipelineDescriptor::new();
+    pipeline_state_descriptor.set_compute_function(Some(&kernel));
+
+    let pipeline_state = device
+        .new_compute_pipeline_state_with_function(
+            pipeline_state_descriptor.compute_function().unwrap(),
+        )
+        .unwrap();
+
+    // Get thread dimensions
+    let thread_group_width = pipeline_state.thread_execution_width();
+    let thread_group_height =
+        pipeline_state.max_total_threads_per_threadgroup() / thread_group_width;
+    let max_group_threads = pipeline_state.max_total_threads_per_threadgroup();
+    let optimal_threads = max_group_threads;
+
+    // Calculate total threads needed
+    let candidate = if bucket_size < optimal_threads as usize {
+        bucket_size
+    } else {
+        optimal_threads as usize
+    };
+
+    let total_threads = closest_power_of_two(candidate);
+
+    // Calculate grid dimensions
+    let grid_width = (total_threads as f64).sqrt().ceil() as u64;
+    let grid_height = (total_threads as u64 + grid_width - 1) / grid_width;
+
+    let threads_per_thread_group = MTLSize {
+        width: thread_group_width,
+        height: thread_group_height,
+        depth: 1,
+    };
+
+    let threads_total = MTLSize {
+        width: grid_width,
+        height: grid_height,
+        depth: 1,
+    };
+
+    // Create output buffers
+    let zero_point = G::zero();
+    let (zero_x, zero_y, zero_z) = buckets_to_separated_coords(&vec![zero_point], num_limbs);
+
+    // Fill the buffers with zero points
+    let mut m_shared_x = vec![0u32; total_threads * num_limbs];
+    let mut m_shared_y = vec![0u32; total_threads * num_limbs];
+    let mut m_shared_z = vec![0u32; total_threads * num_limbs];
+
+    let mut s_shared_x = vec![0u32; total_threads * num_limbs];
+    let mut s_shared_y = vec![0u32; total_threads * num_limbs];
+    let mut s_shared_z = vec![0u32; total_threads * num_limbs];
+
+    // Fill each position with the zero point
+    for i in 0..total_threads {
+        for j in 0..num_limbs {
+            m_shared_x[i * num_limbs + j] = zero_x[j];
+            m_shared_y[i * num_limbs + j] = zero_y[j];
+            m_shared_z[i * num_limbs + j] = zero_z[j];
+
+            s_shared_x[i * num_limbs + j] = zero_x[j];
+            s_shared_y[i * num_limbs + j] = zero_y[j];
+            s_shared_z[i * num_limbs + j] = zero_z[j];
+        }
+    }
+
+    let m_shared_x_buffer = create_buffer(&device, &m_shared_x);
+    let m_shared_y_buffer = create_buffer(&device, &m_shared_y);
+    let m_shared_z_buffer = create_buffer(&device, &m_shared_z);
+
+    let s_shared_x_buffer = create_buffer(&device, &s_shared_x);
+    let s_shared_y_buffer = create_buffer(&device, &s_shared_y);
+    let s_shared_z_buffer = create_buffer(&device, &s_shared_z);
+
+    // Create parameter buffers
+    let grid_width_buffer = create_buffer(&device, &vec![grid_width as u32]);
+    let total_threads_buffer = create_buffer(&device, &vec![total_threads as u32]);
+    let num_subtask = (bucket_size + total_threads - 1) / total_threads;
+    let num_subtask_buffer = create_buffer(&device, &vec![num_subtask as u32]);
+
+    // Set up command queue and encoder
+    let command_queue = device.new_command_queue();
+    let command_buffer = command_queue.new_command_buffer();
+    let encoder =
+        command_buffer.compute_command_encoder_with_descriptor(ComputePassDescriptor::new());
+
+    // Write constants
+    write_constants(
+        "../mopro-msm/src/msm/metal_msm/shader",
+        num_limbs,
+        log_limb_size,
+        n0,
+        nsafe,
+    );
+
+    encoder.set_compute_pipeline_state(&pipeline_state);
+
+    // Set kernel arguments
+    encoder.set_buffer(0, Some(&buckets_x_buffer), 0);
+    encoder.set_buffer(1, Some(&buckets_y_buffer), 0);
+    encoder.set_buffer(2, Some(&buckets_z_buffer), 0);
+    encoder.set_buffer(3, Some(&m_shared_x_buffer), 0);
+    encoder.set_buffer(4, Some(&m_shared_y_buffer), 0);
+    encoder.set_buffer(5, Some(&m_shared_z_buffer), 0);
+    encoder.set_buffer(6, Some(&s_shared_x_buffer), 0);
+    encoder.set_buffer(7, Some(&s_shared_y_buffer), 0);
+    encoder.set_buffer(8, Some(&s_shared_z_buffer), 0);
+    encoder.set_buffer(9, Some(&grid_width_buffer), 0);
+    encoder.set_buffer(10, Some(&total_threads_buffer), 0);
+    encoder.set_buffer(11, Some(&num_subtask_buffer), 0);
+
+    // Dispatch threads
+    encoder.dispatch_threads(threads_total, threads_per_thread_group);
+    encoder.end_encoding();
+    command_buffer.commit();
+    command_buffer.wait_until_completed();
+
+    // Read results back
+    let s_shared_x_ptr = s_shared_x_buffer.contents() as *const u32;
+    let s_shared_y_ptr = s_shared_y_buffer.contents() as *const u32;
+    let s_shared_z_ptr = s_shared_z_buffer.contents() as *const u32;
+
+    let mut s_shared_x_result = vec![0u32; total_threads * num_limbs];
+    let mut s_shared_y_result = vec![0u32; total_threads * num_limbs];
+    let mut s_shared_z_result = vec![0u32; total_threads * num_limbs];
+
+    unsafe {
+        std::ptr::copy_nonoverlapping(
+            s_shared_x_ptr,
+            s_shared_x_result.as_mut_ptr(),
+            total_threads * num_limbs,
+        );
+        std::ptr::copy_nonoverlapping(
+            s_shared_y_ptr,
+            s_shared_y_result.as_mut_ptr(),
+            total_threads * num_limbs,
+        );
+        std::ptr::copy_nonoverlapping(
+            s_shared_z_ptr,
+            s_shared_z_result.as_mut_ptr(),
+            total_threads * num_limbs,
+        );
+    }
+
+    // Read results back
+    let m_shared_x_ptr = m_shared_x_buffer.contents() as *const u32;
+    let m_shared_y_ptr = m_shared_y_buffer.contents() as *const u32;
+    let m_shared_z_ptr = m_shared_z_buffer.contents() as *const u32;
+
+    let mut m_shared_x_result = vec![0u32; total_threads * num_limbs];
+    let mut m_shared_y_result = vec![0u32; total_threads * num_limbs];
+    let mut m_shared_z_result = vec![0u32; total_threads * num_limbs];
+
+    unsafe {
+        std::ptr::copy_nonoverlapping(
+            m_shared_x_ptr,
+            m_shared_x_result.as_mut_ptr(),
+            total_threads * num_limbs,
+        );
+        std::ptr::copy_nonoverlapping(
+            m_shared_y_ptr,
+            m_shared_y_result.as_mut_ptr(),
+            total_threads * num_limbs,
+        );
+        std::ptr::copy_nonoverlapping(
+            m_shared_z_ptr,
+            m_shared_z_result.as_mut_ptr(),
+            total_threads * num_limbs,
+        );
+    }
+
+    // for debug
+    // let m_shared_points = points_from_separated_buffers(&m_shared_x_result, &m_shared_y_result, &m_shared_z_result, num_limbs);
+
+    // Convert results back to points
+    let s_shared_points = points_from_separated_buffers(
+        &s_shared_x_result,
+        &s_shared_y_result,
+        &s_shared_z_result,
+        num_limbs,
+    );
+
+    // Sum the points
+    s_shared_points.iter().sum::<G>()
+}
+
 // This is a very naive way to implement the bucket reduction
 // computing sum_{i=1}^{len} i * buckets[i]
 fn cpu_naive_bpr(buckets: &Vec<G>) -> G {
@@ -150,7 +450,7 @@ fn cpu_naive_bpr(buckets: &Vec<G>) -> G {
 // This immitates the parallel bucket point reduction algortihm in GPU.
 // TODO: 1. make total thread dynamic
 fn cpu_parallel_bpr(buckets: &Vec<G>) -> G {
-    let total_threads = 4 as usize; // TODO: To make this dynamic
+    let total_threads = 8 as usize; // TODO: To make this dynamic
     let bucket_size = buckets.len() as usize;
     let r = (bucket_size + total_threads - 1) / total_threads;
     let mut s = vec![G::zero(); total_threads];
@@ -219,4 +519,22 @@ fn test_pbpr_random_inputs() {
         );
         assert_eq!(gpu_pbpr_result, naive_result);
     }
+}
+
+#[test]
+#[serial_test::serial]
+fn test_pbpr_big_int() {
+    let generator = G::generator();
+    let c: u32 = 9;
+    let bucket_size = 1 << c;
+    let buckets = (1..=bucket_size).map(|_| generator).collect::<Vec<G>>();
+
+    // let cpu_naive_result = cpu_naive_bpr(&buckets);
+    let cpu_pbpr_result = cpu_parallel_bpr(&buckets);
+
+    let start = Instant::now();
+    let gpu_pbpr_big_int_result = gpu_parallel_bpr_big_int(&buckets);
+    let duration = start.elapsed();
+    println!("gpu_parallel_bpr_big_int execution time: {:?}", duration);
+    assert_eq!(gpu_pbpr_big_int_result, cpu_pbpr_result);
 }

--- a/mopro-msm/src/msm/metal_msm/tests/cuzk/pbpr.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/cuzk/pbpr.rs
@@ -384,11 +384,7 @@ pub fn test_pbpr_simple_input() {
 
     let cpu_naive_result = cpu_naive_bpr(&buckets);
     let cpu_pbpr_result = cpu_parallel_bpr(&buckets);
-
-    let start = Instant::now();
     let gpu_pbpr_result = gpu_parallel_bpr(&buckets);
-    let duration = start.elapsed();
-    println!("gpu_parallel_bpr execution time: {:?}", duration);
 
     assert_eq!(gpu_pbpr_result, cpu_naive_result);
     assert_eq!(gpu_pbpr_result, cpu_pbpr_result);
@@ -406,13 +402,7 @@ fn test_pbpr_random_inputs() {
             .map(|_| generator * ScalarField::rand(&mut rng))
             .collect::<Vec<G>>();
         let naive_result = cpu_naive_bpr(&buckets);
-        let start = Instant::now();
         let gpu_pbpr_result = gpu_parallel_bpr(&buckets);
-        let duration = start.elapsed();
-        println!(
-            "Size: {}, gpu_parallel_bpr execution time: {:?}",
-            size, duration
-        );
         assert_eq!(gpu_pbpr_result, naive_result);
     }
 }

--- a/mopro-msm/src/msm/metal_msm/utils/data_conversion.rs
+++ b/mopro-msm/src/msm/metal_msm/utils/data_conversion.rs
@@ -2,7 +2,7 @@ use crate::msm::metal_msm::host::gpu::create_buffer;
 use crate::msm::metal_msm::utils::limbs_conversion::GenericLimbConversion;
 use crate::msm::metal_msm::utils::mont_params::calc_mont_radix;
 use ark_bn254::{Fq as BaseField, FqConfig, G1Projective as G};
-use ark_ff::{biginteger::arithmetic as fa, BigInt, MontBackend, MontConfig, PrimeField};
+use ark_ff::{biginteger::arithmetic as fa, BigInt, MontConfig, PrimeField};
 use metal::*;
 use num_bigint::BigUint;
 
@@ -78,12 +78,7 @@ pub fn points_to_gpu_buffer(points: &[G], num_limbs: usize, device: &Device) -> 
     create_buffer(&device, &all_point_data)
 }
 
-pub fn points_from_gpu_buffer(
-    buffer: &Buffer,
-    num_limbs: usize,
-    p: BigUint,
-    rinv: BigUint,
-) -> Vec<G> {
+pub fn points_from_gpu_buffer(buffer: &Buffer, num_limbs: usize) -> Vec<G> {
     let log_limb_size = 16;
     let point_size = num_limbs * 3;
     let total_u32s = buffer.length() as usize / std::mem::size_of::<u32>();


### PR DESCRIPTION
This pull request introduces a new kernel function and corresponding test cases to handle parallel bucket point reduction using big integers in the GPU. The most important changes include the addition of the `parallel_bpr_big_int` kernel function, updates to the test suite to include this new functionality, and some refactoring to support the new kernel.

New kernel function:

* [`mopro-msm/src/msm/metal_msm/shader/cuzk/pbpr.metal`](diffhunk://#diff-1368aa7d89a12aa80882de87cc10c44955b6911bc2db1d111417003f7de7fbf7R34-R116): Added the `parallel_bpr_big_int` kernel function to handle parallel bucket point reduction using big integers.

Test suite updates:

* [`mopro-msm/src/msm/metal_msm/tests/cuzk/pbpr.rs`](diffhunk://#diff-6aacf406153e86596ec9bbc655497fad67bd600a7d3b63537176468701415ccbR141-R436): Added the `gpu_parallel_bpr_big_int` function to implement parallel bucket reduction in the GPU using separated buffers internally. This includes helper functions for converting bucket vectors to separated coordinate vectors and back.
* [`mopro-msm/src/msm/metal_msm/tests/cuzk/pbpr.rs`](diffhunk://#diff-6aacf406153e86596ec9bbc655497fad67bd600a7d3b63537176468701415ccbR523-R540): Added the `test_pbpr_big_int` test case to validate the new `parallel_bpr_big_int` kernel function against the CPU implementation.

Refactoring and additional imports:

* [`mopro-msm/src/msm/metal_msm/tests/cuzk/pbpr.rs`](diffhunk://#diff-6aacf406153e86596ec9bbc655497fad67bd600a7d3b63537176468701415ccbL1-R10): Updated imports to include necessary functions and types for handling big integers and Montgomery form conversions.
* [`mopro-msm/src/msm/metal_msm/tests/cuzk/pbpr.rs`](diffhunk://#diff-6aacf406153e86596ec9bbc655497fad67bd600a7d3b63537176468701415ccbL153-R453): Increased the number of total threads in the `cpu_parallel_bpr` function from 4 to 8.