### PR TITLE
Refactor/test/resource cleanup

### DIFF
--- a/mopro-msm/src/msm/metal_msm/shader/cuzk/transpose.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/cuzk/transpose.metal
@@ -3,10 +3,10 @@ using namespace metal;
 
 kernel void transpose(
     device const uint* all_csr_col_idx       [[buffer(0)]],
-    device atomic_uint* all_csc_col_ptr      [[buffer(1)]],
-    device uint* all_csc_val_idxs            [[buffer(2)]],
-    device atomic_uint* all_curr             [[buffer(3)]],
-    constant uint2& params                   [[buffer(4)]],
+    constant uint2& params                   [[buffer(1)]],
+    device atomic_uint* all_csc_col_ptr      [[buffer(2)]],
+    device uint* all_csc_val_idxs            [[buffer(3)]],
+    device atomic_uint* all_curr             [[buffer(4)]],
     uint gid [[thread_position_in_grid]]
 ) {
     // Subtask index (equivalent to thread ID)

--- a/mopro-msm/src/msm/metal_msm/tests/bigint/bigint_add_unsafe.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/bigint/bigint_add_unsafe.rs
@@ -1,22 +1,20 @@
-// adapted from: https://github.com/geometryxyz/msl-secp256k1
-
-use crate::msm::metal_msm::host::gpu::{
-    create_buffer, create_empty_buffer, get_default_device, read_buffer,
-};
-use crate::msm::metal_msm::host::shader::{compile_metal, write_constants};
+use crate::msm::metal_msm::tests::common::*;
 use crate::msm::metal_msm::utils::limbs_conversion::GenericLimbConversion;
+
 use ark_ff::{BigInt, BigInteger, UniformRand};
-use ark_std::rand;
-use metal::*;
 
 #[test]
 #[serial_test::serial]
 pub fn test_bigint_add_unsafe() {
-    // adjusted by bn254 scalar bits and mont_mul cios optimal limb size
-    let log_limb_size = 16;
-    let num_limbs = 16;
+    let config = MetalTestConfig {
+        log_limb_size: 16,
+        num_limbs: 16,
+        shader_file: "bigint/bigint_add_unsafe.metal".to_string(),
+        kernel_name: "run".to_string(),
+    };
 
-    // Create two test numbers that do not cause overflow
+    let mut helper = MetalTestHelper::new();
+
     let mut rng = rand::thread_rng();
     let (a, b, expected) = loop {
         let a = BigInt::<4>::rand(&mut rng);
@@ -31,73 +29,27 @@ pub fn test_bigint_add_unsafe() {
         }
     };
 
-    let device = get_default_device();
-    let a_buf = create_buffer(&device, &a.to_limbs(num_limbs, log_limb_size));
-    let b_buf = create_buffer(&device, &b.to_limbs(num_limbs, log_limb_size));
-    let result_buf = create_empty_buffer(&device, num_limbs);
+    let a_buf = helper.create_input_buffer(&a.to_limbs(config.num_limbs, config.log_limb_size));
+    let b_buf = helper.create_input_buffer(&b.to_limbs(config.num_limbs, config.log_limb_size));
+    let result_buf = helper.create_output_buffer(config.num_limbs);
 
-    let command_queue = device.new_command_queue();
-    let command_buffer = command_queue.new_command_buffer();
+    let thread_group_size = helper.create_thread_group_size(1, 1, 1);
+    let thread_group_count = helper.create_thread_group_size(1, 1, 1);
 
-    let compute_pass_descriptor = ComputePassDescriptor::new();
-    let encoder = command_buffer.compute_command_encoder_with_descriptor(compute_pass_descriptor);
-
-    write_constants(
-        "../mopro-msm/src/msm/metal_msm/shader",
-        num_limbs,
-        log_limb_size,
-        0,
-        0,
+    helper.execute_shader(
+        &config,
+        &[&a_buf, &b_buf],
+        &[&result_buf],
+        &thread_group_count,
+        &thread_group_size,
     );
-    let library_path = compile_metal(
-        "../mopro-msm/src/msm/metal_msm/shader/bigint",
-        "bigint_add_unsafe.metal",
-    );
-    let library = device.new_library_with_file(library_path).unwrap();
-    let kernel = library.get_function("run", None).unwrap();
 
-    let pipeline_state_descriptor = ComputePipelineDescriptor::new();
-    pipeline_state_descriptor.set_compute_function(Some(&kernel));
+    let result_limbs = helper.read_results(&result_buf, config.num_limbs);
+    let expected_limbs = expected.to_limbs(config.num_limbs, config.log_limb_size);
+    assert_eq!(result_limbs, expected_limbs, "Limb representation mismatch");
 
-    let pipeline_state = device
-        .new_compute_pipeline_state_with_function(
-            pipeline_state_descriptor.compute_function().unwrap(),
-        )
-        .unwrap();
+    let result: BigInt<4> = BigInt::from_limbs(&result_limbs, config.log_limb_size);
+    assert_eq!(result, expected, "BigInt result mismatch");
 
-    encoder.set_compute_pipeline_state(&pipeline_state);
-    encoder.set_buffer(0, Some(&a_buf), 0);
-    encoder.set_buffer(1, Some(&b_buf), 0);
-    encoder.set_buffer(2, Some(&result_buf), 0);
-
-    let thread_group_count = MTLSize {
-        width: 1,
-        height: 1,
-        depth: 1,
-    };
-
-    let thread_group_size = MTLSize {
-        width: 1,
-        height: 1,
-        depth: 1,
-    };
-
-    encoder.dispatch_thread_groups(thread_group_count, thread_group_size);
-    encoder.end_encoding();
-
-    command_buffer.commit();
-    command_buffer.wait_until_completed();
-
-    let result_limbs: Vec<u32> = read_buffer(&result_buf, num_limbs);
-    let expected_limbs = expected.to_limbs(num_limbs, log_limb_size);
-    assert_eq!(result_limbs, expected_limbs);
-
-    let result = BigInt::from_limbs(&result_limbs, log_limb_size);
-    assert_eq!(result, expected);
-
-    // Drop the buffers after reading the results
-    drop(a_buf);
-    drop(b_buf);
-    drop(result_buf);
-    drop(command_queue);
+    helper.drop_all_buffers();
 }

--- a/mopro-msm/src/msm/metal_msm/tests/bigint/bigint_add_unsafe.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/bigint/bigint_add_unsafe.rs
@@ -94,4 +94,10 @@ pub fn test_bigint_add_unsafe() {
 
     let result = BigInt::from_limbs(&result_limbs, log_limb_size);
     assert_eq!(result, expected);
+
+    // Drop the buffers after reading the results
+    drop(a_buf);
+    drop(b_buf);
+    drop(result_buf);
+    drop(command_queue);
 }

--- a/mopro-msm/src/msm/metal_msm/tests/bigint/bigint_add_wide.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/bigint/bigint_add_wide.rs
@@ -95,6 +95,12 @@ pub fn test_bigint_add_no_overflow() {
 
     let result = BigInt::from_limbs(&result_limbs, log_limb_size);
     assert_eq!(result, expected);
+
+    // Drop the buffers after reading the results
+    drop(a_buf);
+    drop(b_buf);
+    drop(result_buf);
+    drop(command_queue);
 }
 
 #[test]
@@ -183,4 +189,10 @@ pub fn test_bigint_add_overflow() {
 
     let result = BigInt::from_limbs(&result_limbs, log_limb_size);
     assert_eq!(result, expected);
+
+    // Drop the buffers after reading the results
+    drop(a_buf);
+    drop(b_buf);
+    drop(result_buf);
+    drop(command_queue);
 }

--- a/mopro-msm/src/msm/metal_msm/tests/bigint/bigint_add_wide.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/bigint/bigint_add_wide.rs
@@ -1,198 +1,69 @@
-// adapted from: https://github.com/geometryxyz/msl-secp256k1
-
-use crate::msm::metal_msm::host::gpu::{
-    create_buffer, create_empty_buffer, get_default_device, read_buffer,
-};
-use crate::msm::metal_msm::host::shader::{compile_metal, write_constants};
+use crate::msm::metal_msm::tests::common::*;
 use crate::msm::metal_msm::utils::limbs_conversion::GenericLimbConversion;
+
 use ark_ff::{BigInt, BigInteger, UniformRand};
 use ark_std::rand;
-use metal::*;
 
 #[test]
 #[serial_test::serial]
 pub fn test_bigint_add_no_overflow() {
-    // adjusted by bn254 scalar bits and mont_mul cios optimal limb size
-    let log_limb_size = 16;
-    let num_limbs = 16;
-
-    // Create two test numbers that do not cause overflow
-    let mut rng = rand::thread_rng();
-    let (a, b, expected) = loop {
-        let a = BigInt::<4>::rand(&mut rng);
-        let b = BigInt::<4>::rand(&mut rng);
-
-        let mut expected = a.clone();
-        let overflow = expected.add_with_carry(&b);
-
-        // Break the loop if addition does not overflow
-        if !overflow {
-            break (a, b, expected);
-        }
-    };
-
-    let device = get_default_device();
-    let a_buf = create_buffer(&device, &a.to_limbs(num_limbs, log_limb_size));
-    let b_buf = create_buffer(&device, &b.to_limbs(num_limbs, log_limb_size));
-    let result_buf = create_empty_buffer(&device, num_limbs + 1);
-
-    let command_queue = device.new_command_queue();
-    let command_buffer = command_queue.new_command_buffer();
-
-    let compute_pass_descriptor = ComputePassDescriptor::new();
-    let encoder = command_buffer.compute_command_encoder_with_descriptor(compute_pass_descriptor);
-
-    write_constants(
-        "../mopro-msm/src/msm/metal_msm/shader",
-        num_limbs,
-        log_limb_size,
-        0,
-        0,
-    );
-
-    let library_path = compile_metal(
-        "../mopro-msm/src/msm/metal_msm/shader/bigint",
-        "bigint_add_wide.metal",
-    );
-    let library = device.new_library_with_file(library_path).unwrap();
-    let kernel = library.get_function("run", None).unwrap();
-
-    let pipeline_state_descriptor = ComputePipelineDescriptor::new();
-    pipeline_state_descriptor.set_compute_function(Some(&kernel));
-
-    let pipeline_state = device
-        .new_compute_pipeline_state_with_function(
-            pipeline_state_descriptor.compute_function().unwrap(),
-        )
-        .unwrap();
-
-    encoder.set_compute_pipeline_state(&pipeline_state);
-    encoder.set_buffer(0, Some(&a_buf), 0);
-    encoder.set_buffer(1, Some(&b_buf), 0);
-    encoder.set_buffer(2, Some(&result_buf), 0);
-
-    let thread_group_count = MTLSize {
-        width: 1,
-        height: 1,
-        depth: 1,
-    };
-
-    let thread_group_size = MTLSize {
-        width: 1,
-        height: 1,
-        depth: 1,
-    };
-
-    encoder.dispatch_thread_groups(thread_group_count, thread_group_size);
-    encoder.end_encoding();
-
-    command_buffer.commit();
-    command_buffer.wait_until_completed();
-
-    let result_limbs: Vec<u32> = read_buffer(&result_buf, num_limbs);
-    let expected_limbs = expected.to_limbs(num_limbs, log_limb_size);
-    assert_eq!(result_limbs, expected_limbs);
-
-    let result = BigInt::from_limbs(&result_limbs, log_limb_size);
-    assert_eq!(result, expected);
-
-    // Drop the buffers after reading the results
-    drop(a_buf);
-    drop(b_buf);
-    drop(result_buf);
-    drop(command_queue);
+    let (a, b, expected) = generate_test_values(false);
+    run_bigint_add_test(&a, &b, &expected);
 }
 
 #[test]
 #[serial_test::serial]
 pub fn test_bigint_add_overflow() {
-    // adjusted by bn254 scalar bits and mont_mul cios optimal limb size
-    let log_limb_size = 16;
-    let num_limbs = 16;
+    let (a, b, expected) = generate_test_values(true);
+    run_bigint_add_test(&a, &b, &expected);
+}
 
-    // Create two test numbers that cause overflow
+fn generate_test_values(require_overflow: bool) -> (BigInt<4>, BigInt<4>, BigInt<4>) {
     let mut rng = rand::thread_rng();
-    let (a, b, expected) = loop {
+    loop {
         let a = BigInt::<4>::rand(&mut rng);
         let b = BigInt::<4>::rand(&mut rng);
 
         let mut expected = a.clone();
         let overflow = expected.add_with_carry(&b);
 
-        // Break the loop if addition overflow
-        if overflow {
-            break (a, b, expected);
+        if overflow == require_overflow {
+            return (a, b, expected);
         }
+    }
+}
+
+fn run_bigint_add_test(a: &BigInt<4>, b: &BigInt<4>, expected: &BigInt<4>) {
+    let config = MetalTestConfig {
+        log_limb_size: 16,
+        num_limbs: 16,
+        shader_file: "bigint/bigint_add_wide.metal".to_string(),
+        kernel_name: "run".to_string(),
     };
 
-    let device = get_default_device();
-    let a_buf = create_buffer(&device, &a.to_limbs(num_limbs, log_limb_size));
-    let b_buf = create_buffer(&device, &b.to_limbs(num_limbs, log_limb_size));
-    let result_buf = create_empty_buffer(&device, num_limbs + 1);
+    let mut helper = MetalTestHelper::new();
 
-    let command_queue = device.new_command_queue();
-    let command_buffer = command_queue.new_command_buffer();
+    let a_buf = helper.create_input_buffer(&a.to_limbs(config.num_limbs, config.log_limb_size));
+    let b_buf = helper.create_input_buffer(&b.to_limbs(config.num_limbs, config.log_limb_size));
+    let result_buf = helper.create_output_buffer(config.num_limbs + 1);
 
-    let compute_pass_descriptor = ComputePassDescriptor::new();
-    let encoder = command_buffer.compute_command_encoder_with_descriptor(compute_pass_descriptor);
+    let thread_group_count = helper.create_thread_group_size(1, 1, 1);
+    let thread_group_size = helper.create_thread_group_size(1, 1, 1);
 
-    write_constants(
-        "../mopro-msm/src/msm/metal_msm/shader",
-        num_limbs,
-        log_limb_size,
-        0,
-        0,
+    helper.execute_shader(
+        &config,
+        &[&a_buf, &b_buf],
+        &[&result_buf],
+        &thread_group_count,
+        &thread_group_size,
     );
 
-    let library_path = compile_metal(
-        "../mopro-msm/src/msm/metal_msm/shader/bigint",
-        "bigint_add_wide.metal",
-    );
-    let library = device.new_library_with_file(library_path).unwrap();
-    let kernel = library.get_function("run", None).unwrap();
-
-    let pipeline_state_descriptor = ComputePipelineDescriptor::new();
-    pipeline_state_descriptor.set_compute_function(Some(&kernel));
-
-    let pipeline_state = device
-        .new_compute_pipeline_state_with_function(
-            pipeline_state_descriptor.compute_function().unwrap(),
-        )
-        .unwrap();
-
-    encoder.set_compute_pipeline_state(&pipeline_state);
-    encoder.set_buffer(0, Some(&a_buf), 0);
-    encoder.set_buffer(1, Some(&b_buf), 0);
-    encoder.set_buffer(2, Some(&result_buf), 0);
-
-    let thread_group_count = MTLSize {
-        width: 1,
-        height: 1,
-        depth: 1,
-    };
-
-    let thread_group_size = MTLSize {
-        width: 1,
-        height: 1,
-        depth: 1,
-    };
-
-    encoder.dispatch_thread_groups(thread_group_count, thread_group_size);
-    encoder.end_encoding();
-
-    command_buffer.commit();
-    command_buffer.wait_until_completed();
-
-    let result_limbs: Vec<u32> = read_buffer(&result_buf, num_limbs);
-    let expected_limbs = expected.to_limbs(num_limbs, log_limb_size);
+    let result_limbs = helper.read_results(&result_buf, config.num_limbs);
+    let expected_limbs = expected.to_limbs(config.num_limbs, config.log_limb_size);
     assert_eq!(result_limbs, expected_limbs);
 
-    let result = BigInt::from_limbs(&result_limbs, log_limb_size);
-    assert_eq!(result, expected);
+    let result: BigInt<4> = BigInt::from_limbs(&result_limbs, config.log_limb_size);
+    assert_eq!(result, *expected);
 
-    // Drop the buffers after reading the results
-    drop(a_buf);
-    drop(b_buf);
-    drop(result_buf);
-    drop(command_queue);
+    helper.drop_all_buffers();
 }

--- a/mopro-msm/src/msm/metal_msm/tests/bigint/bigint_sub.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/bigint/bigint_sub.rs
@@ -1,195 +1,70 @@
-// adapted from: https://github.com/geometryxyz/msl-secp256k1
-
-use crate::msm::metal_msm::host::gpu::{
-    create_buffer, create_empty_buffer, get_default_device, read_buffer,
-};
-use crate::msm::metal_msm::host::shader::{compile_metal, write_constants};
+use crate::msm::metal_msm::tests::common::*;
 use crate::msm::metal_msm::utils::limbs_conversion::GenericLimbConversion;
+
 use ark_ff::{BigInt, BigInteger, UniformRand};
 use ark_std::rand;
-use metal::*;
 
 #[test]
 #[serial_test::serial]
 pub fn test_bigint_sub_no_underflow() {
-    // adjusted by bn254 scalar bits and mont_mul cios optimal limb size
-    let log_limb_size = 16;
-    let num_limbs = 16;
-
-    // Create two test numbers that do not cause underflow
-    let mut rng = rand::thread_rng();
-    let (a, b, expected) = loop {
-        let a = BigInt::<4>::rand(&mut rng);
-        let b = BigInt::<4>::rand(&mut rng);
-
-        let mut expected = a.clone();
-        let underflow = expected.sub_with_borrow(&b);
-
-        // Break the loop if subtraction does not underflow
-        if !underflow {
-            break (a, b, expected);
-        }
-    };
-
-    let device = get_default_device();
-    let a_buf = create_buffer(&device, &a.to_limbs(num_limbs, log_limb_size));
-    let b_buf = create_buffer(&device, &b.to_limbs(num_limbs, log_limb_size));
-    let result_buf = create_empty_buffer(&device, num_limbs);
-
-    let command_queue = device.new_command_queue();
-    let command_buffer = command_queue.new_command_buffer();
-
-    let compute_pass_descriptor = ComputePassDescriptor::new();
-    let encoder = command_buffer.compute_command_encoder_with_descriptor(compute_pass_descriptor);
-
-    write_constants(
-        "../mopro-msm/src/msm/metal_msm/shader",
-        num_limbs,
-        log_limb_size,
-        0,
-        0,
-    );
-    let library_path = compile_metal(
-        "../mopro-msm/src/msm/metal_msm/shader/bigint",
-        "bigint_sub.metal",
-    );
-    let library = device.new_library_with_file(library_path).unwrap();
-    let kernel = library.get_function("run", None).unwrap();
-
-    let pipeline_state_descriptor = ComputePipelineDescriptor::new();
-    pipeline_state_descriptor.set_compute_function(Some(&kernel));
-
-    let pipeline_state = device
-        .new_compute_pipeline_state_with_function(
-            pipeline_state_descriptor.compute_function().unwrap(),
-        )
-        .unwrap();
-
-    encoder.set_compute_pipeline_state(&pipeline_state);
-    encoder.set_buffer(0, Some(&a_buf), 0);
-    encoder.set_buffer(1, Some(&b_buf), 0);
-    encoder.set_buffer(2, Some(&result_buf), 0);
-
-    let thread_group_count = MTLSize {
-        width: 1,
-        height: 1,
-        depth: 1,
-    };
-
-    let thread_group_size = MTLSize {
-        width: 1,
-        height: 1,
-        depth: 1,
-    };
-
-    encoder.dispatch_thread_groups(thread_group_count, thread_group_size);
-    encoder.end_encoding();
-
-    command_buffer.commit();
-    command_buffer.wait_until_completed();
-
-    let result_limbs: Vec<u32> = read_buffer(&result_buf, num_limbs);
-    let expected_limbs = expected.to_limbs(num_limbs, log_limb_size);
-    assert_eq!(result_limbs, expected_limbs);
-
-    let result = BigInt::from_limbs(&result_limbs, log_limb_size);
-    assert_eq!(result, expected);
-
-    // Drop the buffers after reading the results
-    drop(a_buf);
-    drop(b_buf);
-    drop(result_buf);
-    drop(command_queue);
+    let (a, b, expected) = generate_test_values(false);
+    run_bigint_sub_test(a, b, expected);
 }
 
 #[test]
 #[serial_test::serial]
 fn test_bigint_sub_underflow() {
-    let num_limbs = 16;
-    let log_limb_size = 16;
+    let (a, b, expected) = generate_test_values(true);
+    run_bigint_sub_test(a, b, expected);
+}
 
-    // Create two test numbers that cause underflow
+fn run_bigint_sub_test(a: BigInt<4>, b: BigInt<4>, expected: BigInt<4>) {
+    let config = MetalTestConfig {
+        log_limb_size: 16,
+        num_limbs: 16,
+        shader_file: "bigint/bigint_sub.metal".to_string(),
+        kernel_name: "run".to_string(),
+    };
+
+    let mut helper = MetalTestHelper::new();
+
+    let a_buf = helper.create_input_buffer(&a.to_limbs(config.num_limbs, config.log_limb_size));
+    let b_buf = helper.create_input_buffer(&b.to_limbs(config.num_limbs, config.log_limb_size));
+    let result_buf = helper.create_output_buffer(config.num_limbs);
+
+    let thread_group_count = helper.create_thread_group_size(1, 1, 1);
+    let thread_group_size = helper.create_thread_group_size(1, 1, 1);
+
+    helper.execute_shader(
+        &config,
+        &[&a_buf, &b_buf],
+        &[&result_buf],
+        &thread_group_count,
+        &thread_group_size,
+    );
+
+    let result_limbs = helper.read_results(&result_buf, config.num_limbs);
+    let expected_limbs = expected.to_limbs(config.num_limbs, config.log_limb_size);
+    assert_eq!(result_limbs, expected_limbs, "Limb representation mismatch");
+
+    let result = BigInt::from_limbs(&result_limbs, config.log_limb_size);
+    assert_eq!(result, expected, "BigInt result mismatch");
+
+    helper.drop_all_buffers();
+}
+
+fn generate_test_values(require_underflow: bool) -> (BigInt<4>, BigInt<4>, BigInt<4>) {
     let mut rng = rand::thread_rng();
-    let (a, b, expected) = loop {
+
+    loop {
         let a = BigInt::<4>::rand(&mut rng);
         let b = BigInt::<4>::rand(&mut rng);
 
         let mut expected = a.clone();
         let underflow = expected.sub_with_borrow(&b);
 
-        // Break the loop if subtraction does not underflow
-        if underflow {
-            break (a, b, expected);
+        if underflow == require_underflow {
+            return (a, b, expected);
         }
-    };
-
-    let device = get_default_device();
-    let a_buf = create_buffer(&device, &a.to_limbs(num_limbs, log_limb_size));
-    let b_buf = create_buffer(&device, &b.to_limbs(num_limbs, log_limb_size));
-    let result_buf = create_empty_buffer(&device, num_limbs);
-
-    let command_queue = device.new_command_queue();
-    let command_buffer = command_queue.new_command_buffer();
-
-    let compute_pass_descriptor = ComputePassDescriptor::new();
-    let encoder = command_buffer.compute_command_encoder_with_descriptor(compute_pass_descriptor);
-
-    write_constants(
-        "../mopro-msm/src/msm/metal_msm/shader",
-        num_limbs,
-        log_limb_size,
-        0,
-        0,
-    );
-    let library_path = compile_metal(
-        "../mopro-msm/src/msm/metal_msm/shader/bigint",
-        "bigint_sub.metal",
-    );
-    let library = device.new_library_with_file(library_path).unwrap();
-    let kernel = library.get_function("run", None).unwrap();
-
-    let pipeline_state_descriptor = ComputePipelineDescriptor::new();
-    pipeline_state_descriptor.set_compute_function(Some(&kernel));
-
-    let pipeline_state = device
-        .new_compute_pipeline_state_with_function(
-            pipeline_state_descriptor.compute_function().unwrap(),
-        )
-        .unwrap();
-
-    encoder.set_compute_pipeline_state(&pipeline_state);
-    encoder.set_buffer(0, Some(&a_buf), 0);
-    encoder.set_buffer(1, Some(&b_buf), 0);
-    encoder.set_buffer(2, Some(&result_buf), 0);
-
-    let thread_group_count = MTLSize {
-        width: 1,
-        height: 1,
-        depth: 1,
-    };
-
-    let thread_group_size = MTLSize {
-        width: 1,
-        height: 1,
-        depth: 1,
-    };
-
-    encoder.dispatch_thread_groups(thread_group_count, thread_group_size);
-    encoder.end_encoding();
-
-    command_buffer.commit();
-    command_buffer.wait_until_completed();
-
-    let result_limbs: Vec<u32> = read_buffer(&result_buf, num_limbs);
-    let expected_limbs = expected.to_limbs(num_limbs, log_limb_size);
-    assert_eq!(result_limbs, expected_limbs);
-
-    let result = BigInt::from_limbs(&result_limbs, log_limb_size);
-    assert_eq!(result, expected);
-
-    // Drop the buffers after reading the results
-    drop(a_buf);
-    drop(b_buf);
-    drop(result_buf);
-    drop(command_queue);
+    }
 }

--- a/mopro-msm/src/msm/metal_msm/tests/bigint/bigint_sub.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/bigint/bigint_sub.rs
@@ -94,6 +94,12 @@ pub fn test_bigint_sub_no_underflow() {
 
     let result = BigInt::from_limbs(&result_limbs, log_limb_size);
     assert_eq!(result, expected);
+
+    // Drop the buffers after reading the results
+    drop(a_buf);
+    drop(b_buf);
+    drop(result_buf);
+    drop(command_queue);
 }
 
 #[test]
@@ -180,4 +186,10 @@ fn test_bigint_sub_underflow() {
 
     let result = BigInt::from_limbs(&result_limbs, log_limb_size);
     assert_eq!(result, expected);
+
+    // Drop the buffers after reading the results
+    drop(a_buf);
+    drop(b_buf);
+    drop(result_buf);
+    drop(command_queue);
 }

--- a/mopro-msm/src/msm/metal_msm/tests/common.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/common.rs
@@ -1,0 +1,203 @@
+use crate::msm::metal_msm::host::gpu::{
+    create_buffer, create_empty_buffer, get_default_device, read_buffer,
+};
+use crate::msm::metal_msm::host::shader::{compile_metal, write_constants};
+use crate::msm::metal_msm::utils::barrett_params::calc_barrett_mu;
+use crate::msm::metal_msm::utils::mont_params::{calc_mont_radix, calc_nsafe, calc_rinv_and_n0};
+
+use ark_bn254::Fq as BaseField;
+use ark_ff::PrimeField;
+use metal::*;
+use num_bigint::BigUint;
+
+use once_cell::sync::Lazy;
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+/// Directory containing the Metal shader files
+const SHADER_DIR: &str = "../mopro-msm/src/msm/metal_msm/shader";
+
+/// Cache of precomputed constants
+static CONSTANTS_CACHE: Lazy<Mutex<HashMap<(usize, u32), MSMConstants>>> =
+    Lazy::new(|| Mutex::new(HashMap::new()));
+
+/// Struct for Metal config
+pub struct MetalTestConfig {
+    pub log_limb_size: u32,
+    pub num_limbs: usize,
+    pub shader_file: String,
+    pub kernel_name: String,
+}
+
+/// Struct for MSM constants
+#[derive(Clone)]
+pub struct MSMConstants {
+    pub p: BigUint,
+    pub r: BigUint,
+    pub rinv: BigUint,
+    pub n0: u32,
+    pub nsafe: usize,
+    pub mu: BigUint,
+}
+
+impl Default for MetalTestConfig {
+    fn default() -> Self {
+        Self {
+            log_limb_size: 16,
+            num_limbs: 16,
+            shader_file: "".to_string(),
+            kernel_name: "".to_string(),
+        }
+    }
+}
+
+/// Helper to setup Metal device, buffers, and execute shader
+pub struct MetalTestHelper {
+    pub device: Device,
+    pub command_queue: CommandQueue,
+    pub buffers: Vec<Buffer>,
+}
+
+impl MetalTestHelper {
+    /// Create a new Metal test helper
+    pub fn new() -> Self {
+        let device = get_default_device();
+        let command_queue = device.new_command_queue();
+
+        Self {
+            device,
+            command_queue,
+            buffers: Vec::new(),
+        }
+    }
+
+    /// Create an input buffer in Vec<u32> and track it
+    pub fn create_input_buffer(&mut self, data: &Vec<u32>) -> Buffer {
+        let buffer = create_buffer(&self.device, data);
+        self.buffers.push(buffer.clone());
+        buffer
+    }
+
+    /// Create an output buffer and track it
+    pub fn create_output_buffer(&mut self, size: usize) -> Buffer {
+        let buffer = create_empty_buffer(&self.device, size);
+        self.buffers.push(buffer.clone());
+        buffer
+    }
+
+    /// Create thread group size
+    pub fn create_thread_group_size(&self, width: u64, height: u64, depth: u64) -> MTLSize {
+        MTLSize {
+            width,
+            height,
+            depth,
+        }
+    }
+
+    /// Execute a Metal compute shader
+    pub fn execute_shader(
+        &self,
+        config: &MetalTestConfig,
+        input_buffers: &[&Buffer],
+        output_buffers: &[&Buffer],
+        thread_group_count: &MTLSize,
+        thread_group_size: &MTLSize,
+    ) {
+        let command_buffer = self.command_queue.new_command_buffer();
+        let compute_pass_descriptor = ComputePassDescriptor::new();
+        let encoder =
+            command_buffer.compute_command_encoder_with_descriptor(compute_pass_descriptor);
+
+        // Setup shader constants
+        let constants = get_or_calc_constants(config.num_limbs, config.log_limb_size);
+        write_constants(
+            SHADER_DIR,
+            config.num_limbs,
+            config.log_limb_size,
+            constants.n0,
+            constants.nsafe,
+        );
+
+        // Prepare full shader path
+        let shader_path = format!("{}/{}", SHADER_DIR, config.shader_file);
+        let parts: Vec<&str> = shader_path.rsplitn(2, '/').collect();
+        let shader_dir = if parts.len() > 1 { parts[1] } else { "" };
+        let shader_file = parts[0];
+
+        // Compile shader
+        let library_path = compile_metal(shader_dir, shader_file);
+        let library = self.device.new_library_with_file(library_path).unwrap();
+        let kernel = library
+            .get_function(config.kernel_name.as_str(), None)
+            .unwrap();
+
+        // Create pipeline
+        let pipeline_state_descriptor = ComputePipelineDescriptor::new();
+        pipeline_state_descriptor.set_compute_function(Some(&kernel));
+
+        let pipeline_state = self
+            .device
+            .new_compute_pipeline_state_with_function(
+                pipeline_state_descriptor.compute_function().unwrap(),
+            )
+            .unwrap();
+
+        encoder.set_compute_pipeline_state(&pipeline_state);
+
+        // Set input buffers
+        for (i, buffer) in input_buffers.iter().enumerate() {
+            encoder.set_buffer(i as u64, Some(buffer), 0);
+        }
+
+        // Set output buffer
+        for (i, buffer) in output_buffers.iter().enumerate() {
+            encoder.set_buffer(input_buffers.len() as u64 + i as u64, Some(buffer), 0);
+        }
+        encoder.dispatch_thread_groups(*thread_group_count, *thread_group_size);
+        encoder.end_encoding();
+
+        command_buffer.commit();
+        command_buffer.wait_until_completed();
+    }
+
+    /// Read results in Vec<u32> from a buffer
+    pub fn read_results(&self, buffer: &Buffer, size: usize) -> Vec<u32> {
+        read_buffer(buffer, size)
+    }
+
+    /// Drop all tracked buffers
+    pub fn drop_all_buffers(&mut self) {
+        self.buffers.clear();
+    }
+}
+
+// Calculate or retrieve cached constants
+pub fn get_or_calc_constants(num_limbs: usize, log_limb_size: u32) -> MSMConstants {
+    let mut cache = CONSTANTS_CACHE.lock().unwrap();
+    let key = (num_limbs, log_limb_size);
+
+    if !cache.contains_key(&key) {
+        let constants = calc_constants(num_limbs, log_limb_size);
+        cache.insert(key, constants.clone());
+        constants
+    } else {
+        cache.get(&key).unwrap().clone()
+    }
+}
+
+// Helper to calculate constants
+fn calc_constants(num_limbs: usize, log_limb_size: u32) -> MSMConstants {
+    let p: BigUint = BaseField::MODULUS.try_into().unwrap();
+    let r = calc_mont_radix(num_limbs, log_limb_size);
+    let (rinv, n0) = calc_rinv_and_n0(&p, &r, log_limb_size);
+    let nsafe = calc_nsafe(log_limb_size);
+    let mu = calc_barrett_mu(&p);
+    MSMConstants {
+        p,
+        r,
+        rinv,
+        n0,
+        nsafe,
+        mu,
+    }
+}

--- a/mopro-msm/src/msm/metal_msm/tests/curve/jacobian_add_2007_b1.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/curve/jacobian_add_2007_b1.rs
@@ -134,6 +134,18 @@ fn jacobian_add_2007_bl_kernel(a: G, b: G, name: &str) -> G {
     let result_yr_limbs: Vec<u32> = read_buffer(&result_yr_buf, num_limbs);
     let result_zr_limbs: Vec<u32> = read_buffer(&result_zr_buf, num_limbs);
 
+    // Drop the buffers after reading the results
+    drop(axr_buf);
+    drop(ayr_buf);
+    drop(azr_buf);
+    drop(bxr_buf);
+    drop(byr_buf);
+    drop(bzr_buf);
+    drop(result_xr_buf);
+    drop(result_yr_buf);
+    drop(result_zr_buf);
+    drop(command_queue);
+
     let result_xr: BigUint = BigInt::<4>::from_limbs(&result_xr_limbs, log_limb_size)
         .try_into()
         .unwrap();

--- a/mopro-msm/src/msm/metal_msm/tests/curve/jacobian_add_2007_b1.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/curve/jacobian_add_2007_b1.rs
@@ -1,32 +1,31 @@
-// adapted from https://github.com/geometryxyz/msl-secp256k1
-
 use ark_bn254::{Fq as BaseField, Fr as ScalarField, G1Affine as GAffine, G1Projective as G};
 use ark_ec::{AffineRepr, Group};
-use metal::*;
-
-use crate::msm::metal_msm::host::gpu::{
-    create_buffer, create_empty_buffer, get_default_device, read_buffer,
-};
-use crate::msm::metal_msm::host::shader::{compile_metal, write_constants};
-use crate::msm::metal_msm::utils::limbs_conversion::GenericLimbConversion;
-use crate::msm::metal_msm::utils::mont_params::{calc_mont_radix, calc_nsafe, calc_rinv_and_n0};
 use ark_ff::{BigInt, PrimeField};
 use ark_std::{rand::thread_rng, UniformRand, Zero};
 use num_bigint::BigUint;
 
-fn jacobian_add_2007_bl_kernel(a: G, b: G, name: &str) -> G {
-    let log_limb_size = 16;
-    let p: BigUint = BaseField::MODULUS.try_into().unwrap();
+use crate::msm::metal_msm::tests::common::*;
+use crate::msm::metal_msm::utils::limbs_conversion::GenericLimbConversion;
 
+fn jacobian_add_2007_bl_kernel(a: G, b: G, shader_name: &str) -> G {
+    let log_limb_size = 16;
     let modulus_bits = BaseField::MODULUS_BIT_SIZE as u32;
     let num_limbs = ((modulus_bits + log_limb_size - 1) / log_limb_size) as usize;
 
-    let r = calc_mont_radix(num_limbs, log_limb_size);
-    let res = calc_rinv_and_n0(&p, &r, log_limb_size);
-    let rinv = res.0;
-    let n0 = res.1;
-    let nsafe = calc_nsafe(log_limb_size);
+    let config = MetalTestConfig {
+        log_limb_size,
+        num_limbs,
+        shader_file: format!("curve/{}.metal", shader_name),
+        kernel_name: "run".to_string(),
+    };
 
+    let mut helper = MetalTestHelper::new();
+    let constants = get_or_calc_constants(num_limbs, log_limb_size);
+    let p = &constants.p;
+    let r = &constants.r;
+    let rinv = &constants.rinv;
+
+    // Convert inputs to Montgomery domain
     let ax: BigUint = a.x.into();
     let ay: BigUint = a.y.into();
     let az: BigUint = a.z.into();
@@ -34,13 +33,14 @@ fn jacobian_add_2007_bl_kernel(a: G, b: G, name: &str) -> G {
     let by: BigUint = b.y.into();
     let bz: BigUint = b.z.into();
 
-    let axr = (&ax * &r) % &p;
-    let ayr = (&ay * &r) % &p;
-    let azr = (&az * &r) % &p;
-    let bxr = (&bx * &r) % &p;
-    let byr = (&by * &r) % &p;
-    let bzr = (&bz * &r) % &p;
+    let axr = (&ax * r) % p;
+    let ayr = (&ay * r) % p;
+    let azr = (&az * r) % p;
+    let bxr = (&bx * r) % p;
+    let byr = (&by * r) % p;
+    let bzr = (&bz * r) % p;
 
+    // Convert to limbs
     let axr_limbs = ark_ff::BigInt::<4>::try_from(axr.clone())
         .unwrap()
         .to_limbs(num_limbs, log_limb_size);
@@ -60,92 +60,35 @@ fn jacobian_add_2007_bl_kernel(a: G, b: G, name: &str) -> G {
         .unwrap()
         .to_limbs(num_limbs, log_limb_size);
 
-    let device = get_default_device();
-    let axr_buf = create_buffer(&device, &axr_limbs);
-    let ayr_buf = create_buffer(&device, &ayr_limbs);
-    let azr_buf = create_buffer(&device, &azr_limbs);
-    let bxr_buf = create_buffer(&device, &bxr_limbs);
-    let byr_buf = create_buffer(&device, &byr_limbs);
-    let bzr_buf = create_buffer(&device, &bzr_limbs);
-    let result_xr_buf = create_empty_buffer(&device, num_limbs);
-    let result_yr_buf = create_empty_buffer(&device, num_limbs);
-    let result_zr_buf = create_empty_buffer(&device, num_limbs);
+    // Create buffers
+    let axr_buf = helper.create_input_buffer(&axr_limbs);
+    let ayr_buf = helper.create_input_buffer(&ayr_limbs);
+    let azr_buf = helper.create_input_buffer(&azr_limbs);
+    let bxr_buf = helper.create_input_buffer(&bxr_limbs);
+    let byr_buf = helper.create_input_buffer(&byr_limbs);
+    let bzr_buf = helper.create_input_buffer(&bzr_limbs);
+    let result_xr_buf = helper.create_output_buffer(num_limbs);
+    let result_yr_buf = helper.create_output_buffer(num_limbs);
+    let result_zr_buf = helper.create_output_buffer(num_limbs);
 
-    let command_queue = device.new_command_queue();
-    let command_buffer = command_queue.new_command_buffer();
+    // Setup thread group sizes
+    let thread_group_count = helper.create_thread_group_size(1, 1, 1);
+    let thread_group_size = helper.create_thread_group_size(1, 1, 1);
 
-    let compute_pass_descriptor = ComputePassDescriptor::new();
-    let encoder = command_buffer.compute_command_encoder_with_descriptor(compute_pass_descriptor);
-
-    write_constants(
-        "../mopro-msm/src/msm/metal_msm/shader",
-        num_limbs,
-        log_limb_size,
-        n0,
-        nsafe,
+    helper.execute_shader(
+        &config,
+        &[&axr_buf, &ayr_buf, &azr_buf, &bxr_buf, &byr_buf, &bzr_buf],
+        &[&result_xr_buf, &result_yr_buf, &result_zr_buf],
+        &thread_group_count,
+        &thread_group_size,
     );
 
-    let library_path = compile_metal(
-        "../mopro-msm/src/msm/metal_msm/shader/curve",
-        &format!("{}.metal", name),
-    );
-    let library = device.new_library_with_file(library_path).unwrap();
-    let kernel = library.get_function("run", None).unwrap();
+    // Read results
+    let result_xr_limbs = helper.read_results(&result_xr_buf, num_limbs);
+    let result_yr_limbs = helper.read_results(&result_yr_buf, num_limbs);
+    let result_zr_limbs = helper.read_results(&result_zr_buf, num_limbs);
 
-    let pipeline_state_descriptor = ComputePipelineDescriptor::new();
-    pipeline_state_descriptor.set_compute_function(Some(&kernel));
-
-    let pipeline_state = device
-        .new_compute_pipeline_state_with_function(
-            pipeline_state_descriptor.compute_function().unwrap(),
-        )
-        .unwrap();
-
-    encoder.set_compute_pipeline_state(&pipeline_state);
-    encoder.set_buffer(0, Some(&axr_buf), 0);
-    encoder.set_buffer(1, Some(&ayr_buf), 0);
-    encoder.set_buffer(2, Some(&azr_buf), 0);
-    encoder.set_buffer(3, Some(&bxr_buf), 0);
-    encoder.set_buffer(4, Some(&byr_buf), 0);
-    encoder.set_buffer(5, Some(&bzr_buf), 0);
-    encoder.set_buffer(6, Some(&result_xr_buf), 0);
-    encoder.set_buffer(7, Some(&result_yr_buf), 0);
-    encoder.set_buffer(8, Some(&result_zr_buf), 0);
-
-    let thread_group_count = MTLSize {
-        width: 1,
-        height: 1,
-        depth: 1,
-    };
-
-    let thread_group_size = MTLSize {
-        width: 1,
-        height: 1,
-        depth: 1,
-    };
-
-    encoder.dispatch_thread_groups(thread_group_count, thread_group_size);
-    encoder.end_encoding();
-
-    command_buffer.commit();
-    command_buffer.wait_until_completed();
-
-    let result_xr_limbs: Vec<u32> = read_buffer(&result_xr_buf, num_limbs);
-    let result_yr_limbs: Vec<u32> = read_buffer(&result_yr_buf, num_limbs);
-    let result_zr_limbs: Vec<u32> = read_buffer(&result_zr_buf, num_limbs);
-
-    // Drop the buffers after reading the results
-    drop(axr_buf);
-    drop(ayr_buf);
-    drop(azr_buf);
-    drop(bxr_buf);
-    drop(byr_buf);
-    drop(bzr_buf);
-    drop(result_xr_buf);
-    drop(result_yr_buf);
-    drop(result_zr_buf);
-    drop(command_queue);
-
+    // Convert results from Montgomery domain
     let result_xr: BigUint = BigInt::<4>::from_limbs(&result_xr_limbs, log_limb_size)
         .try_into()
         .unwrap();
@@ -156,12 +99,14 @@ fn jacobian_add_2007_bl_kernel(a: G, b: G, name: &str) -> G {
         .try_into()
         .unwrap();
 
-    let result_x = (result_xr * &rinv) % &p;
-    let result_y = (result_yr * &rinv) % &p;
-    let result_z = (result_zr * &rinv) % &p;
+    let result_x = (result_xr * rinv) % p;
+    let result_y = (result_yr * rinv) % p;
+    let result_z = (result_zr * rinv) % p;
 
-    let result = G::new(result_x.into(), result_y.into(), result_z.into());
-    result
+    // Clean up buffers
+    helper.drop_all_buffers();
+
+    G::new(result_x.into(), result_y.into(), result_z.into())
 }
 
 #[test]

--- a/mopro-msm/src/msm/metal_msm/tests/curve/jacobian_data_conversion.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/curve/jacobian_data_conversion.rs
@@ -1,27 +1,26 @@
-use crate::msm::metal_msm::host::gpu::get_default_device;
-use crate::msm::metal_msm::host::shader::{compile_metal, write_constants};
-use crate::msm::metal_msm::utils::data_conversion::{points_from_gpu_buffer, points_to_gpu_buffer};
-use crate::msm::metal_msm::utils::mont_params::{calc_mont_radix, calc_nsafe, calc_rinv_and_n0};
 use ark_bn254::{Fq as BaseField, Fr as ScalarField, G1Projective as G};
 use ark_ec::Group;
 use ark_ff::PrimeField;
 use ark_std::{rand::thread_rng, UniformRand, Zero};
-use metal::*;
-use num_bigint::BigUint;
+
+use crate::msm::metal_msm::tests::common::*;
+use crate::msm::metal_msm::utils::data_conversion::{points_from_gpu_buffer, points_to_gpu_buffer};
 
 #[test]
 #[serial_test::serial]
 fn test_jacobian_dataflow() {
     let log_limb_size = 16;
-    let p: BigUint = BaseField::MODULUS.try_into().unwrap();
-
     let modulus_bits = BaseField::MODULUS_BIT_SIZE as u32;
     let num_limbs = ((modulus_bits + log_limb_size - 1) / log_limb_size) as usize;
 
-    let r = calc_mont_radix(num_limbs, log_limb_size);
-    let res = calc_rinv_and_n0(&p, &r, log_limb_size);
-    let n0 = res.1;
-    let nsafe = calc_nsafe(log_limb_size);
+    let config = MetalTestConfig {
+        log_limb_size,
+        num_limbs,
+        shader_file: "curve/jacobian_dataflow_test.metal".to_string(),
+        kernel_name: "run".to_string(),
+    };
+
+    let mut helper = MetalTestHelper::new();
 
     let mut rng = thread_rng();
     let base_point = G::generator();
@@ -29,56 +28,27 @@ fn test_jacobian_dataflow() {
         .map(|_| base_point * ScalarField::rand(&mut rng))
         .collect();
     let output_points: Vec<G> = (0..10).map(|_| G::zero()).collect();
-    let device = get_default_device();
-    let input_buffer = points_to_gpu_buffer(&points, num_limbs, &device);
-    let output_buffer = points_to_gpu_buffer(&output_points, num_limbs, &device);
 
-    let command_queue = device.new_command_queue();
+    let input_buffer = points_to_gpu_buffer(&points, num_limbs, &helper.device);
+    let output_buffer = points_to_gpu_buffer(&output_points, num_limbs, &helper.device);
+    helper.buffers.push(input_buffer.clone());
+    helper.buffers.push(output_buffer.clone());
 
-    write_constants(
-        "../mopro-msm/src/msm/metal_msm/shader",
-        num_limbs,
-        log_limb_size,
-        n0,
-        nsafe,
+    let threads_per_threadgroup = helper.create_thread_group_size(10, 1, 1);
+    let threadgroup_size = helper.create_thread_group_size(1, 1, 1);
+
+    helper.execute_shader(
+        &config,
+        &[&input_buffer],
+        &[&output_buffer],
+        &threads_per_threadgroup,
+        &threadgroup_size,
     );
-
-    let library_path = compile_metal(
-        "../mopro-msm/src/msm/metal_msm/shader/curve",
-        &format!("{}.metal", "jacobian_dataflow_test"),
-    );
-    let library = device.new_library_with_file(library_path).unwrap();
-    let kernel = library.get_function("run", None).unwrap();
-    let pipeline_state_descriptor = ComputePipelineDescriptor::new();
-    pipeline_state_descriptor.set_compute_function(Some(&kernel));
-    let pipeline_state = device
-        .new_compute_pipeline_state_with_function(
-            pipeline_state_descriptor.compute_function().unwrap(),
-        )
-        .unwrap();
-
-    let command_buffer = command_queue.new_command_buffer();
-    let compute_pass_descriptor = ComputePassDescriptor::new();
-    let encoder = command_buffer.compute_command_encoder_with_descriptor(compute_pass_descriptor);
-    encoder.set_compute_pipeline_state(&pipeline_state);
-
-    encoder.set_buffer(0, Some(&input_buffer), 0);
-    encoder.set_buffer(1, Some(&output_buffer), 0);
-
-    let threads_per_threadgroup = MTLSize::new(10, 1, 1);
-    let threadgroup_size = MTLSize::new(1, 1, 1);
-    encoder.dispatch_threads(threads_per_threadgroup, threadgroup_size);
-    encoder.end_encoding();
-    command_buffer.commit();
-    command_buffer.wait_until_completed();
 
     let result_points: Vec<G> = points_from_gpu_buffer(&output_buffer, num_limbs);
     for i in 0..points.len() {
         assert_eq!(points[i] * ScalarField::from(2 as u64), result_points[i]);
     }
 
-    // Drop the buffers after reading the results
-    drop(input_buffer);
-    drop(output_buffer);
-    drop(command_queue);
+    helper.drop_all_buffers();
 }

--- a/mopro-msm/src/msm/metal_msm/tests/curve/jacobian_data_conversion.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/curve/jacobian_data_conversion.rs
@@ -76,4 +76,9 @@ fn test_jacobian_dataflow() {
     for i in 0..points.len() {
         assert_eq!(points[i] * ScalarField::from(2 as u64), result_points[i]);
     }
+
+    // Drop the buffers after reading the results
+    drop(input_buffer);
+    drop(output_buffer);
+    drop(command_queue);
 }

--- a/mopro-msm/src/msm/metal_msm/tests/curve/jacobian_dbl_2009_l.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/curve/jacobian_dbl_2009_l.rs
@@ -136,4 +136,13 @@ pub fn test_jacobian_dbl_2009_l() {
 
     let result = G::new(result_x.into(), result_y.into(), result_z.into());
     assert!(result == expected);
+
+    // Drop the buffers after reading the results
+    drop(axr_buf);
+    drop(ayr_buf);
+    drop(azr_buf);
+    drop(result_xr_buf);
+    drop(result_yr_buf);
+    drop(result_zr_buf);
+    drop(command_queue);
 }

--- a/mopro-msm/src/msm/metal_msm/tests/curve/jacobian_dbl_2009_l.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/curve/jacobian_dbl_2009_l.rs
@@ -1,33 +1,31 @@
-// adapted from https://github.com/geometryxyz/msl-secp256k1
-
 use ark_bn254::{Fq as BaseField, Fr as ScalarField, G1Affine as GAffine, G1Projective as G};
 use ark_ec::AffineRepr;
-use metal::*;
-
-use crate::msm::metal_msm::host::gpu::{
-    create_buffer, create_empty_buffer, get_default_device, read_buffer,
-};
-use crate::msm::metal_msm::host::shader::{compile_metal, write_constants};
-use crate::msm::metal_msm::utils::limbs_conversion::GenericLimbConversion;
-use crate::msm::metal_msm::utils::mont_params::{calc_mont_radix, calc_nsafe, calc_rinv_and_n0};
 use ark_ff::{BigInt, PrimeField};
 use ark_std::{rand::thread_rng, UniformRand};
 use num_bigint::BigUint;
+
+use crate::msm::metal_msm::tests::common::*;
+use crate::msm::metal_msm::utils::limbs_conversion::GenericLimbConversion;
 
 #[test]
 #[serial_test::serial]
 pub fn test_jacobian_dbl_2009_l() {
     let log_limb_size = 16;
-    let p: BigUint = BaseField::MODULUS.try_into().unwrap();
-
     let modulus_bits = BaseField::MODULUS_BIT_SIZE as u32;
     let num_limbs = ((modulus_bits + log_limb_size - 1) / log_limb_size) as usize;
 
-    let r = calc_mont_radix(num_limbs, log_limb_size);
-    let res = calc_rinv_and_n0(&p, &r, log_limb_size);
-    let rinv = res.0;
-    let n0 = res.1;
-    let nsafe = calc_nsafe(log_limb_size);
+    let config = MetalTestConfig {
+        log_limb_size,
+        num_limbs,
+        shader_file: "curve/jacobian_dbl_2009_l.metal".to_string(),
+        kernel_name: "run".to_string(),
+    };
+
+    let mut helper = MetalTestHelper::new();
+    let constants = get_or_calc_constants(num_limbs, log_limb_size);
+    let p = &constants.p;
+    let r = &constants.r;
+    let rinv = &constants.rinv;
 
     let base_point = GAffine::generator().into_group();
     let mut rng = thread_rng();
@@ -39,9 +37,9 @@ pub fn test_jacobian_dbl_2009_l() {
     let ay: BigUint = a.y.into();
     let az: BigUint = a.z.into();
 
-    let axr = (&ax * &r) % &p;
-    let ayr = (&ay * &r) % &p;
-    let azr = (&az * &r) % &p;
+    let axr = (&ax * r) % p;
+    let ayr = (&ay * r) % p;
+    let azr = (&az * r) % p;
 
     let axr_limbs = ark_ff::BigInt::<4>::try_from(axr)
         .unwrap()
@@ -53,72 +51,29 @@ pub fn test_jacobian_dbl_2009_l() {
         .unwrap()
         .to_limbs(num_limbs, log_limb_size);
 
-    let device = get_default_device();
-    let axr_buf = create_buffer(&device, &axr_limbs);
-    let ayr_buf = create_buffer(&device, &ayr_limbs);
-    let azr_buf = create_buffer(&device, &azr_limbs);
-    let result_xr_buf = create_empty_buffer(&device, num_limbs);
-    let result_yr_buf = create_empty_buffer(&device, num_limbs);
-    let result_zr_buf = create_empty_buffer(&device, num_limbs);
+    // Create buffers
+    let axr_buf = helper.create_input_buffer(&axr_limbs);
+    let ayr_buf = helper.create_input_buffer(&ayr_limbs);
+    let azr_buf = helper.create_input_buffer(&azr_limbs);
+    let result_xr_buf = helper.create_output_buffer(num_limbs);
+    let result_yr_buf = helper.create_output_buffer(num_limbs);
+    let result_zr_buf = helper.create_output_buffer(num_limbs);
 
-    let command_queue = device.new_command_queue();
-    let command_buffer = command_queue.new_command_buffer();
+    // Setup thread group sizes
+    let thread_group_count = helper.create_thread_group_size(1, 1, 1);
+    let thread_group_size = helper.create_thread_group_size(1, 1, 1);
 
-    let compute_pass_descriptor = ComputePassDescriptor::new();
-    let encoder = command_buffer.compute_command_encoder_with_descriptor(compute_pass_descriptor);
-
-    write_constants(
-        "../mopro-msm/src/msm/metal_msm/shader",
-        num_limbs,
-        log_limb_size,
-        n0,
-        nsafe,
+    helper.execute_shader(
+        &config,
+        &[&axr_buf, &ayr_buf, &azr_buf],
+        &[&result_xr_buf, &result_yr_buf, &result_zr_buf],
+        &thread_group_count,
+        &thread_group_size,
     );
-    let library_path = compile_metal(
-        "../mopro-msm/src/msm/metal_msm/shader/curve",
-        "jacobian_dbl_2009_l.metal",
-    );
-    let library = device.new_library_with_file(library_path).unwrap();
-    let kernel = library.get_function("run", None).unwrap();
 
-    let pipeline_state_descriptor = ComputePipelineDescriptor::new();
-    pipeline_state_descriptor.set_compute_function(Some(&kernel));
-
-    let pipeline_state = device
-        .new_compute_pipeline_state_with_function(
-            pipeline_state_descriptor.compute_function().unwrap(),
-        )
-        .unwrap();
-
-    encoder.set_compute_pipeline_state(&pipeline_state);
-    encoder.set_buffer(0, Some(&axr_buf), 0);
-    encoder.set_buffer(1, Some(&ayr_buf), 0);
-    encoder.set_buffer(2, Some(&azr_buf), 0);
-    encoder.set_buffer(3, Some(&result_xr_buf), 0);
-    encoder.set_buffer(4, Some(&result_yr_buf), 0);
-    encoder.set_buffer(5, Some(&result_zr_buf), 0);
-
-    let thread_group_count = MTLSize {
-        width: 1,
-        height: 1,
-        depth: 1,
-    };
-
-    let thread_group_size = MTLSize {
-        width: 1,
-        height: 1,
-        depth: 1,
-    };
-
-    encoder.dispatch_thread_groups(thread_group_count, thread_group_size);
-    encoder.end_encoding();
-
-    command_buffer.commit();
-    command_buffer.wait_until_completed();
-
-    let result_xr_limbs: Vec<u32> = read_buffer(&result_xr_buf, num_limbs);
-    let result_yr_limbs: Vec<u32> = read_buffer(&result_yr_buf, num_limbs);
-    let result_zr_limbs: Vec<u32> = read_buffer(&result_zr_buf, num_limbs);
+    let result_xr_limbs = helper.read_results(&result_xr_buf, num_limbs);
+    let result_yr_limbs = helper.read_results(&result_yr_buf, num_limbs);
+    let result_zr_limbs = helper.read_results(&result_zr_buf, num_limbs);
 
     let result_xr: BigUint = BigInt::<4>::from_limbs(&result_xr_limbs, log_limb_size)
         .try_into()
@@ -130,19 +85,12 @@ pub fn test_jacobian_dbl_2009_l() {
         .try_into()
         .unwrap();
 
-    let result_x = (&result_xr * &rinv) % &p;
-    let result_y = (&result_yr * &rinv) % &p;
-    let result_z = (&result_zr * &rinv) % &p;
+    let result_x = (&result_xr * rinv) % p;
+    let result_y = (&result_yr * rinv) % p;
+    let result_z = (&result_zr * rinv) % p;
 
     let result = G::new(result_x.into(), result_y.into(), result_z.into());
     assert!(result == expected);
 
-    // Drop the buffers after reading the results
-    drop(axr_buf);
-    drop(ayr_buf);
-    drop(azr_buf);
-    drop(result_xr_buf);
-    drop(result_yr_buf);
-    drop(result_zr_buf);
-    drop(command_queue);
+    helper.drop_all_buffers();
 }

--- a/mopro-msm/src/msm/metal_msm/tests/curve/jacobian_madd_2007_bl.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/curve/jacobian_madd_2007_bl.rs
@@ -1,33 +1,31 @@
-// adapted from https://github.com/geometryxyz/msl-secp256k1
-
 use ark_bn254::{Fq as BaseField, Fr as ScalarField, G1Affine as GAffine, G1Projective as G};
 use ark_ec::{AffineRepr, CurveGroup};
-use metal::*;
-
-use crate::msm::metal_msm::host::gpu::{
-    create_buffer, create_empty_buffer, get_default_device, read_buffer,
-};
-use crate::msm::metal_msm::host::shader::{compile_metal, write_constants};
-use crate::msm::metal_msm::utils::limbs_conversion::GenericLimbConversion;
-use crate::msm::metal_msm::utils::mont_params::{calc_mont_radix, calc_nsafe, calc_rinv_and_n0};
 use ark_ff::{BigInt, PrimeField};
 use ark_std::{rand::thread_rng, UniformRand};
 use num_bigint::BigUint;
 
+use crate::msm::metal_msm::tests::common::*;
+use crate::msm::metal_msm::utils::limbs_conversion::GenericLimbConversion;
+
 #[test]
 #[serial_test::serial]
-pub fn test_jacobian_add_2007_bl() {
+pub fn test_jacobian_madd_2007_bl() {
     let log_limb_size = 16;
-    let p: BigUint = BaseField::MODULUS.try_into().unwrap();
-
     let modulus_bits = BaseField::MODULUS_BIT_SIZE as u32;
     let num_limbs = ((modulus_bits + log_limb_size - 1) / log_limb_size) as usize;
 
-    let r = calc_mont_radix(num_limbs, log_limb_size);
-    let res = calc_rinv_and_n0(&p, &r, log_limb_size);
-    let rinv = res.0;
-    let n0 = res.1;
-    let nsafe = calc_nsafe(log_limb_size);
+    let config = MetalTestConfig {
+        log_limb_size,
+        num_limbs,
+        shader_file: "curve/jacobian_madd_2007_bl.metal".to_string(),
+        kernel_name: "run".to_string(),
+    };
+
+    let mut helper = MetalTestHelper::new();
+    let constants = get_or_calc_constants(num_limbs, log_limb_size);
+    let p = &constants.p;
+    let r = &constants.r;
+    let rinv = &constants.rinv;
 
     // Generate 2 random affine points
     let (a, b) = {
@@ -57,109 +55,53 @@ pub fn test_jacobian_add_2007_bl() {
     let bx: BigUint = b.x.into();
     let by: BigUint = b.y.into();
 
-    let axr = (&ax * &r) % &p;
-    let ayr = (&ay * &r) % &p;
-    let azr = (&az * &r) % &p;
-    let bxr = (&bx * &r) % &p;
-    let byr = (&by * &r) % &p;
+    let axr = (ax * r) % p;
+    let ayr = (ay * r) % p;
+    let azr = (az * r) % p;
+    let bxr = (bx * r) % p;
+    let byr = (by * r) % p;
 
-    let axr_limbs = ark_ff::BigInt::<4>::try_from(axr.clone())
+    let axr_limbs = ark_ff::BigInt::<4>::try_from(axr)
         .unwrap()
         .to_limbs(num_limbs, log_limb_size);
-    let ayr_limbs = ark_ff::BigInt::<4>::try_from(ayr.clone())
+    let ayr_limbs = ark_ff::BigInt::<4>::try_from(ayr)
         .unwrap()
         .to_limbs(num_limbs, log_limb_size);
-    let azr_limbs = ark_ff::BigInt::<4>::try_from(azr.clone())
+    let azr_limbs = ark_ff::BigInt::<4>::try_from(azr)
         .unwrap()
         .to_limbs(num_limbs, log_limb_size);
-    let bxr_limbs = ark_ff::BigInt::<4>::try_from(bxr.clone())
+    let bxr_limbs = ark_ff::BigInt::<4>::try_from(bxr)
         .unwrap()
         .to_limbs(num_limbs, log_limb_size);
-    let byr_limbs = ark_ff::BigInt::<4>::try_from(byr.clone())
+    let byr_limbs = ark_ff::BigInt::<4>::try_from(byr)
         .unwrap()
         .to_limbs(num_limbs, log_limb_size);
 
-    let device = get_default_device();
-    let axr_buf = create_buffer(&device, &axr_limbs);
-    let ayr_buf = create_buffer(&device, &ayr_limbs);
-    let azr_buf = create_buffer(&device, &azr_limbs);
-    let bxr_buf = create_buffer(&device, &bxr_limbs);
-    let byr_buf = create_buffer(&device, &byr_limbs);
-    let result_xr_buf = create_empty_buffer(&device, num_limbs);
-    let result_yr_buf = create_empty_buffer(&device, num_limbs);
-    let result_zr_buf = create_empty_buffer(&device, num_limbs);
+    // Create buffers
+    let axr_buf = helper.create_input_buffer(&axr_limbs);
+    let ayr_buf = helper.create_input_buffer(&ayr_limbs);
+    let azr_buf = helper.create_input_buffer(&azr_limbs);
+    let bxr_buf = helper.create_input_buffer(&bxr_limbs);
+    let byr_buf = helper.create_input_buffer(&byr_limbs);
+    let result_xr_buf = helper.create_output_buffer(num_limbs);
+    let result_yr_buf = helper.create_output_buffer(num_limbs);
+    let result_zr_buf = helper.create_output_buffer(num_limbs);
 
-    let command_queue = device.new_command_queue();
-    let command_buffer = command_queue.new_command_buffer();
+    // Setup thread group sizes
+    let thread_group_count = helper.create_thread_group_size(1, 1, 1);
+    let thread_group_size = helper.create_thread_group_size(1, 1, 1);
 
-    let compute_pass_descriptor = ComputePassDescriptor::new();
-    let encoder = command_buffer.compute_command_encoder_with_descriptor(compute_pass_descriptor);
-
-    write_constants(
-        "../mopro-msm/src/msm/metal_msm/shader",
-        num_limbs,
-        log_limb_size,
-        n0,
-        nsafe,
+    helper.execute_shader(
+        &config,
+        &[&axr_buf, &ayr_buf, &azr_buf, &bxr_buf, &byr_buf],
+        &[&result_xr_buf, &result_yr_buf, &result_zr_buf],
+        &thread_group_count,
+        &thread_group_size,
     );
-    let library_path = compile_metal(
-        "../mopro-msm/src/msm/metal_msm/shader/curve",
-        "jacobian_madd_2007_bl.metal",
-    );
-    let library = device.new_library_with_file(library_path).unwrap();
-    let kernel = library.get_function("run", None).unwrap();
 
-    let pipeline_state_descriptor = ComputePipelineDescriptor::new();
-    pipeline_state_descriptor.set_compute_function(Some(&kernel));
-
-    let pipeline_state = device
-        .new_compute_pipeline_state_with_function(
-            pipeline_state_descriptor.compute_function().unwrap(),
-        )
-        .unwrap();
-
-    encoder.set_compute_pipeline_state(&pipeline_state);
-    encoder.set_buffer(0, Some(&axr_buf), 0);
-    encoder.set_buffer(1, Some(&ayr_buf), 0);
-    encoder.set_buffer(2, Some(&azr_buf), 0);
-    encoder.set_buffer(3, Some(&bxr_buf), 0);
-    encoder.set_buffer(4, Some(&byr_buf), 0);
-    encoder.set_buffer(5, Some(&result_xr_buf), 0);
-    encoder.set_buffer(6, Some(&result_yr_buf), 0);
-    encoder.set_buffer(7, Some(&result_zr_buf), 0);
-
-    let thread_group_count = MTLSize {
-        width: 1,
-        height: 1,
-        depth: 1,
-    };
-
-    let thread_group_size = MTLSize {
-        width: 1,
-        height: 1,
-        depth: 1,
-    };
-
-    encoder.dispatch_thread_groups(thread_group_count, thread_group_size);
-    encoder.end_encoding();
-
-    command_buffer.commit();
-    command_buffer.wait_until_completed();
-
-    let result_xr_limbs: Vec<u32> = read_buffer(&result_xr_buf, num_limbs);
-    let result_yr_limbs: Vec<u32> = read_buffer(&result_yr_buf, num_limbs);
-    let result_zr_limbs: Vec<u32> = read_buffer(&result_zr_buf, num_limbs);
-
-    // Drop the buffers after reading the results
-    drop(axr_buf);
-    drop(ayr_buf);
-    drop(azr_buf);
-    drop(bxr_buf);
-    drop(byr_buf);
-    drop(result_xr_buf);
-    drop(result_yr_buf);
-    drop(result_zr_buf);
-    drop(command_queue);
+    let result_xr_limbs = helper.read_results(&result_xr_buf, num_limbs);
+    let result_yr_limbs = helper.read_results(&result_yr_buf, num_limbs);
+    let result_zr_limbs = helper.read_results(&result_zr_buf, num_limbs);
 
     let result_xr: BigUint = BigInt::<4>::from_limbs(&result_xr_limbs, log_limb_size)
         .try_into()
@@ -171,10 +113,12 @@ pub fn test_jacobian_add_2007_bl() {
         .try_into()
         .unwrap();
 
-    let result_x = (result_xr * &rinv) % &p;
-    let result_y = (result_yr * &rinv) % &p;
-    let result_z = (result_zr * &rinv) % &p;
+    let result_x = (result_xr * rinv) % p;
+    let result_y = (result_yr * rinv) % p;
+    let result_z = (result_zr * rinv) % p;
 
     let result = G::new(result_x.into(), result_y.into(), result_z.into());
     assert!(result == expected);
+
+    helper.drop_all_buffers();
 }

--- a/mopro-msm/src/msm/metal_msm/tests/curve/jacobian_madd_2007_bl.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/curve/jacobian_madd_2007_bl.rs
@@ -150,6 +150,17 @@ pub fn test_jacobian_add_2007_bl() {
     let result_yr_limbs: Vec<u32> = read_buffer(&result_yr_buf, num_limbs);
     let result_zr_limbs: Vec<u32> = read_buffer(&result_zr_buf, num_limbs);
 
+    // Drop the buffers after reading the results
+    drop(axr_buf);
+    drop(ayr_buf);
+    drop(azr_buf);
+    drop(bxr_buf);
+    drop(byr_buf);
+    drop(result_xr_buf);
+    drop(result_yr_buf);
+    drop(result_zr_buf);
+    drop(command_queue);
+
     let result_xr: BigUint = BigInt::<4>::from_limbs(&result_xr_limbs, log_limb_size)
         .try_into()
         .unwrap();

--- a/mopro-msm/src/msm/metal_msm/tests/curve/jacobian_neg.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/curve/jacobian_neg.rs
@@ -118,6 +118,15 @@ pub fn test_jacobian_neg() {
     let result_yr_limbs: Vec<u32> = read_buffer(&result_yr_buf, num_limbs);
     let result_zr_limbs: Vec<u32> = read_buffer(&result_zr_buf, num_limbs);
 
+    // Drop the buffers after reading the results
+    drop(axr_buf);
+    drop(ayr_buf);
+    drop(azr_buf);
+    drop(result_xr_buf);
+    drop(result_yr_buf);
+    drop(result_zr_buf);
+    drop(command_queue);
+
     let result_xr: BigUint = BigInt::<4>::from_limbs(&result_xr_limbs, log_limb_size)
         .try_into()
         .unwrap();

--- a/mopro-msm/src/msm/metal_msm/tests/curve/jacobian_neg.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/curve/jacobian_neg.rs
@@ -1,31 +1,31 @@
 use ark_bn254::{Fq as BaseField, Fr as ScalarField, G1Affine as GAffine, G1Projective as G};
 use ark_ec::AffineRepr;
-use metal::*;
-
-use crate::msm::metal_msm::host::gpu::{
-    create_buffer, create_empty_buffer, get_default_device, read_buffer,
-};
-use crate::msm::metal_msm::host::shader::{compile_metal, write_constants};
-use crate::msm::metal_msm::utils::limbs_conversion::GenericLimbConversion;
-use crate::msm::metal_msm::utils::mont_params::{calc_mont_radix, calc_nsafe, calc_rinv_and_n0};
 use ark_ff::{BigInt, PrimeField};
 use ark_std::{rand::thread_rng, UniformRand};
 use num_bigint::BigUint;
+
+use crate::msm::metal_msm::tests::common::*;
+use crate::msm::metal_msm::utils::limbs_conversion::GenericLimbConversion;
 
 #[test]
 #[serial_test::serial]
 pub fn test_jacobian_neg() {
     let log_limb_size = 16;
-    let p: BigUint = BaseField::MODULUS.try_into().unwrap();
-
     let modulus_bits = BaseField::MODULUS_BIT_SIZE as u32;
     let num_limbs = ((modulus_bits + log_limb_size - 1) / log_limb_size) as usize;
 
-    let r = calc_mont_radix(num_limbs, log_limb_size);
-    let res = calc_rinv_and_n0(&p, &r, log_limb_size);
-    let rinv = res.0;
-    let n0 = res.1;
-    let nsafe = calc_nsafe(log_limb_size);
+    let config = MetalTestConfig {
+        log_limb_size,
+        num_limbs,
+        shader_file: "curve/jacobian_neg.metal".to_string(),
+        kernel_name: "run".to_string(),
+    };
+
+    let mut helper = MetalTestHelper::new();
+    let constants = get_or_calc_constants(num_limbs, log_limb_size);
+    let p = &constants.p;
+    let r = &constants.r;
+    let rinv = &constants.rinv;
 
     let base_point = GAffine::generator().into_group();
     let mut rng = thread_rng();
@@ -37,9 +37,9 @@ pub fn test_jacobian_neg() {
     let ay: BigUint = a.y.into();
     let az: BigUint = a.z.into();
 
-    let axr = (&ax * &r) % &p;
-    let ayr = (&ay * &r) % &p;
-    let azr = (&az * &r) % &p;
+    let axr = (ax * r) % p;
+    let ayr = (ay * r) % p;
+    let azr = (az * r) % p;
 
     let axr_limbs = ark_ff::BigInt::<4>::try_from(axr)
         .unwrap()
@@ -51,81 +51,29 @@ pub fn test_jacobian_neg() {
         .unwrap()
         .to_limbs(num_limbs, log_limb_size);
 
-    let device = get_default_device();
-    let axr_buf = create_buffer(&device, &axr_limbs);
-    let ayr_buf = create_buffer(&device, &ayr_limbs);
-    let azr_buf = create_buffer(&device, &azr_limbs);
-    let result_xr_buf = create_empty_buffer(&device, num_limbs);
-    let result_yr_buf = create_empty_buffer(&device, num_limbs);
-    let result_zr_buf = create_empty_buffer(&device, num_limbs);
+    // Create buffers
+    let axr_buf = helper.create_input_buffer(&axr_limbs);
+    let ayr_buf = helper.create_input_buffer(&ayr_limbs);
+    let azr_buf = helper.create_input_buffer(&azr_limbs);
+    let result_xr_buf = helper.create_output_buffer(num_limbs);
+    let result_yr_buf = helper.create_output_buffer(num_limbs);
+    let result_zr_buf = helper.create_output_buffer(num_limbs);
 
-    let command_queue = device.new_command_queue();
-    let command_buffer = command_queue.new_command_buffer();
+    // Setup thread group sizes
+    let thread_group_count = helper.create_thread_group_size(1, 1, 1);
+    let thread_group_size = helper.create_thread_group_size(1, 1, 1);
 
-    let compute_pass_descriptor = ComputePassDescriptor::new();
-    let encoder = command_buffer.compute_command_encoder_with_descriptor(compute_pass_descriptor);
-
-    write_constants(
-        "../mopro-msm/src/msm/metal_msm/shader",
-        num_limbs,
-        log_limb_size,
-        n0,
-        nsafe,
+    helper.execute_shader(
+        &config,
+        &[&axr_buf, &ayr_buf, &azr_buf],
+        &[&result_xr_buf, &result_yr_buf, &result_zr_buf],
+        &thread_group_count,
+        &thread_group_size,
     );
-    let library_path = compile_metal(
-        "../mopro-msm/src/msm/metal_msm/shader/curve",
-        "jacobian_neg.metal",
-    );
-    let library = device.new_library_with_file(library_path).unwrap();
-    let kernel = library.get_function("run", None).unwrap();
 
-    let pipeline_state_descriptor = ComputePipelineDescriptor::new();
-    pipeline_state_descriptor.set_compute_function(Some(&kernel));
-
-    let pipeline_state = device
-        .new_compute_pipeline_state_with_function(
-            pipeline_state_descriptor.compute_function().unwrap(),
-        )
-        .unwrap();
-
-    encoder.set_compute_pipeline_state(&pipeline_state);
-    encoder.set_buffer(0, Some(&axr_buf), 0);
-    encoder.set_buffer(1, Some(&ayr_buf), 0);
-    encoder.set_buffer(2, Some(&azr_buf), 0);
-    encoder.set_buffer(3, Some(&result_xr_buf), 0);
-    encoder.set_buffer(4, Some(&result_yr_buf), 0);
-    encoder.set_buffer(5, Some(&result_zr_buf), 0);
-
-    let thread_group_count = MTLSize {
-        width: 1,
-        height: 1,
-        depth: 1,
-    };
-
-    let thread_group_size = MTLSize {
-        width: 1,
-        height: 1,
-        depth: 1,
-    };
-
-    encoder.dispatch_thread_groups(thread_group_count, thread_group_size);
-    encoder.end_encoding();
-
-    command_buffer.commit();
-    command_buffer.wait_until_completed();
-
-    let result_xr_limbs: Vec<u32> = read_buffer(&result_xr_buf, num_limbs);
-    let result_yr_limbs: Vec<u32> = read_buffer(&result_yr_buf, num_limbs);
-    let result_zr_limbs: Vec<u32> = read_buffer(&result_zr_buf, num_limbs);
-
-    // Drop the buffers after reading the results
-    drop(axr_buf);
-    drop(ayr_buf);
-    drop(azr_buf);
-    drop(result_xr_buf);
-    drop(result_yr_buf);
-    drop(result_zr_buf);
-    drop(command_queue);
+    let result_xr_limbs = helper.read_results(&result_xr_buf, num_limbs);
+    let result_yr_limbs = helper.read_results(&result_yr_buf, num_limbs);
+    let result_zr_limbs = helper.read_results(&result_zr_buf, num_limbs);
 
     let result_xr: BigUint = BigInt::<4>::from_limbs(&result_xr_limbs, log_limb_size)
         .try_into()
@@ -137,10 +85,12 @@ pub fn test_jacobian_neg() {
         .try_into()
         .unwrap();
 
-    let result_x = (&result_xr * &rinv) % &p;
-    let result_y = (&result_yr * &rinv) % &p;
-    let result_z = (&result_zr * &rinv) % &p;
+    let result_x = (&result_xr * rinv) % p;
+    let result_y = (&result_yr * rinv) % p;
+    let result_z = (&result_zr * rinv) % p;
 
     let result = G::new(result_x.into(), result_y.into(), result_z.into());
     assert!(result == expected);
+
+    helper.drop_all_buffers();
 }

--- a/mopro-msm/src/msm/metal_msm/tests/curve/jacobian_scalar_mul.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/curve/jacobian_scalar_mul.rs
@@ -97,6 +97,12 @@ fn jacobian_scalar_mul_kernel(point: G, scalar: u32, name: &str) -> G {
 
     let result_slice = read_buffer(&result_buf, num_limbs * 3);
 
+    // Drop the buffers after reading the results
+    drop(input_buf);
+    drop(scalar_buf);
+    drop(result_buf);
+    drop(command_queue);
+
     let result_xr = &result_slice[..num_limbs];
     let result_yr = &result_slice[num_limbs..2 * num_limbs];
     let result_zr = &result_slice[2 * num_limbs..];

--- a/mopro-msm/src/msm/metal_msm/tests/curve/jacobian_scalar_mul.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/curve/jacobian_scalar_mul.rs
@@ -1,37 +1,37 @@
 use ark_bn254::{Fq as BaseField, Fr as ScalarField, G1Affine as GAffine, G1Projective as G};
 use ark_ec::AffineRepr;
-use metal::*;
-
-use crate::msm::metal_msm::host::gpu::{
-    create_buffer, create_empty_buffer, get_default_device, read_buffer,
-};
-use crate::msm::metal_msm::host::shader::{compile_metal, write_constants};
-use crate::msm::metal_msm::utils::limbs_conversion::GenericLimbConversion;
-use crate::msm::metal_msm::utils::mont_params::{calc_mont_radix, calc_nsafe, calc_rinv_and_n0};
 use ark_ff::{BigInt, PrimeField};
 use num_bigint::BigUint;
 use rand::{self, Rng};
 
+use crate::msm::metal_msm::tests::common::*;
+use crate::msm::metal_msm::utils::limbs_conversion::GenericLimbConversion;
+
 fn jacobian_scalar_mul_kernel(point: G, scalar: u32, name: &str) -> G {
     let log_limb_size = 16;
-    let p: BigUint = BaseField::MODULUS.try_into().unwrap();
-
     let modulus_bits = BaseField::MODULUS_BIT_SIZE as u32;
     let num_limbs = ((modulus_bits + log_limb_size - 1) / log_limb_size) as usize;
 
-    let r = calc_mont_radix(num_limbs, log_limb_size);
-    let res = calc_rinv_and_n0(&p, &r, log_limb_size);
-    let rinv = res.0;
-    let n0 = res.1;
-    let nsafe = calc_nsafe(log_limb_size);
+    let config = MetalTestConfig {
+        log_limb_size,
+        num_limbs,
+        shader_file: format!("curve/{}.metal", name),
+        kernel_name: "run".to_string(),
+    };
+
+    let mut helper = MetalTestHelper::new();
+    let constants = get_or_calc_constants(num_limbs, log_limb_size);
+    let p = &constants.p;
+    let r = &constants.r;
+    let rinv = &constants.rinv;
 
     let ax: BigUint = point.x.into();
     let ay: BigUint = point.y.into();
     let az: BigUint = point.z.into();
 
-    let axr = (&ax * &r) % &p;
-    let ayr = (&ay * &r) % &p;
-    let azr = (&az * &r) % &p;
+    let axr = (ax * r) % p;
+    let ayr = (ay * r) % p;
+    let azr = (az * r) % p;
 
     let axr_limbs = ark_ff::BigInt::<4>::try_from(axr)
         .unwrap()
@@ -43,86 +43,56 @@ fn jacobian_scalar_mul_kernel(point: G, scalar: u32, name: &str) -> G {
         .unwrap()
         .to_limbs(num_limbs, log_limb_size);
 
-    let device = get_default_device();
-    let command_queue = device.new_command_queue();
-
-    let mut point_data = vec![0u32; num_limbs * 3];
-    point_data[..num_limbs].copy_from_slice(&axr_limbs);
-    point_data[num_limbs..2 * num_limbs].copy_from_slice(&ayr_limbs);
-    point_data[2 * num_limbs..].copy_from_slice(&azr_limbs);
-
-    // Create buffers using gpu.rs functions
-    let input_buf = create_buffer(&device, &point_data);
-    let scalar_data = vec![scalar];
-    let scalar_buf = create_buffer(&device, &scalar_data);
-    let result_buf = create_empty_buffer(&device, num_limbs * 3);
-
-    write_constants(
-        "../mopro-msm/src/msm/metal_msm/shader",
-        num_limbs,
-        log_limb_size,
-        n0,
-        nsafe,
+    // Create input buffers
+    let point_buf = helper.create_input_buffer(
+        &[
+            axr_limbs.as_slice(),
+            ayr_limbs.as_slice(),
+            azr_limbs.as_slice(),
+        ]
+        .concat(),
     );
-    let library_path = compile_metal(
-        "../mopro-msm/src/msm/metal_msm/shader/curve",
-        &format!("{}.metal", name),
+    let scalar_buf = helper.create_input_buffer(&vec![scalar]);
+    let result_buf = helper.create_output_buffer(num_limbs * 3);
+
+    // Setup thread group sizes
+    let thread_group_count = helper.create_thread_group_size(1, 1, 1);
+    let thread_group_size = helper.create_thread_group_size(1, 1, 1);
+
+    helper.execute_shader(
+        &config,
+        &[&point_buf, &scalar_buf],
+        &[&result_buf],
+        &thread_group_count,
+        &thread_group_size,
     );
-    let library = device.new_library_with_file(library_path).unwrap();
-    let kernel = library.get_function("run", None).unwrap();
 
-    let pipeline_state_descriptor = ComputePipelineDescriptor::new();
-    pipeline_state_descriptor.set_compute_function(Some(&kernel));
-    let pipeline_state = device
-        .new_compute_pipeline_state_with_function(
-            pipeline_state_descriptor.compute_function().unwrap(),
-        )
-        .unwrap();
+    // Read results
+    let result_data = helper.read_results(&result_buf, num_limbs * 3);
 
-    let command_buffer = command_queue.new_command_buffer();
-    let compute_pass_descriptor = ComputePassDescriptor::new();
-    let encoder = command_buffer.compute_command_encoder_with_descriptor(compute_pass_descriptor);
-    encoder.set_compute_pipeline_state(&pipeline_state);
+    let result_xr = &result_data[..num_limbs];
+    let result_yr = &result_data[num_limbs..2 * num_limbs];
+    let result_zr = &result_data[2 * num_limbs..];
 
-    encoder.set_buffer(0, Some(&input_buf), 0);
-    encoder.set_buffer(1, Some(&scalar_buf), 0);
-    encoder.set_buffer(2, Some(&result_buf), 0);
+    let result_x =
+        ((BigUint::try_from(BigInt::<4>::from_limbs(result_xr, log_limb_size)).unwrap() * rinv)
+            % p)
+            .try_into()
+            .unwrap();
+    let result_y =
+        ((BigUint::try_from(BigInt::<4>::from_limbs(result_yr, log_limb_size)).unwrap() * rinv)
+            % p)
+            .try_into()
+            .unwrap();
+    let result_z =
+        ((BigUint::try_from(BigInt::<4>::from_limbs(result_zr, log_limb_size)).unwrap() * rinv)
+            % p)
+            .try_into()
+            .unwrap();
 
-    let grid_size = MTLSize::new(1, 1, 1);
-    let threadgroup_size = MTLSize::new(1, 1, 1);
-    encoder.dispatch_threads(grid_size, threadgroup_size);
-    encoder.end_encoding();
-    command_buffer.commit();
-    command_buffer.wait_until_completed();
+    helper.drop_all_buffers();
 
-    let result_slice = read_buffer(&result_buf, num_limbs * 3);
-
-    // Drop the buffers after reading the results
-    drop(input_buf);
-    drop(scalar_buf);
-    drop(result_buf);
-    drop(command_queue);
-
-    let result_xr = &result_slice[..num_limbs];
-    let result_yr = &result_slice[num_limbs..2 * num_limbs];
-    let result_zr = &result_slice[2 * num_limbs..];
-
-    let result_x = (BigUint::try_from(BigInt::<4>::from_limbs(result_xr, log_limb_size)).unwrap()
-        * &rinv)
-        % &p;
-    let result_y = (BigUint::try_from(BigInt::<4>::from_limbs(result_yr, log_limb_size)).unwrap()
-        * &rinv)
-        % &p;
-    let result_z = (BigUint::try_from(BigInt::<4>::from_limbs(result_zr, log_limb_size)).unwrap()
-        * &rinv)
-        % &p;
-
-    let result_x: BaseField = result_x.try_into().unwrap();
-    let result_y: BaseField = result_y.try_into().unwrap();
-    let result_z: BaseField = result_z.try_into().unwrap();
-
-    let result = G::new_unchecked(result_x, result_y, result_z);
-    result
+    G::new_unchecked(result_x, result_y, result_z)
 }
 
 #[test]
@@ -138,17 +108,14 @@ pub fn test_jacobian_scalar_mul() {
 #[test]
 #[serial_test::serial]
 pub fn test_jacobian_scalar_mul_random() {
-    // random point
     let base_point = GAffine::generator().into_group();
     let scalar = rand::thread_rng().gen::<u32>();
     let scalar_field = ScalarField::from(scalar);
     let point = base_point * scalar_field;
 
-    // random scalar
     let rand_scalar = rand::thread_rng().gen::<u32>();
     let rand_scalar_field = ScalarField::from(rand_scalar);
 
-    // random point * random scalar
     let expected = point * rand_scalar_field;
     let result = jacobian_scalar_mul_kernel(point, rand_scalar, "jacobian_scalar_mul");
     assert!(expected == result);

--- a/mopro-msm/src/msm/metal_msm/tests/cuzk/barrett_reduction.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/cuzk/barrett_reduction.rs
@@ -165,4 +165,10 @@ pub fn test_field_mul_with_mont_params() {
         result, a_in_field.0,
         "result is not equal to arkworks result in Montgomery form"
     );
+
+    // Drop the buffers after reading the results
+    drop(a_buf);
+    drop(r_buf);
+    drop(res_buf);
+    drop(command_queue);
 }

--- a/mopro-msm/src/msm/metal_msm/tests/cuzk/convert_point_coords_and_decompose_scalars.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/cuzk/convert_point_coords_and_decompose_scalars.rs
@@ -1,27 +1,30 @@
-use crate::msm::metal_msm::host::gpu::{
-    create_buffer, create_empty_buffer, get_default_device, read_buffer,
-};
-use crate::msm::metal_msm::host::shader::{compile_metal, write_constants};
-use crate::msm::metal_msm::utils::limbs_conversion::GenericLimbConversion;
-use crate::msm::metal_msm::utils::mont_params::{calc_mont_radix, calc_nsafe, calc_rinv_and_n0};
 use ark_bn254::{Fq as BaseField, Fr as ScalarField, G1Projective as G};
 use ark_ec::{CurveGroup, Group};
 use ark_ff::{BigInt, PrimeField};
-use metal::*;
 use num_bigint::{BigUint, RandBigInt};
 use rand::thread_rng;
+
+use crate::msm::metal_msm::tests::common::*;
+use crate::msm::metal_msm::utils::limbs_conversion::GenericLimbConversion;
 
 #[test]
 #[serial_test::serial]
 fn test_point_coords_conversion() {
-    // BN254 parameters
+    // Setup test config
     let log_limb_size = 16;
     let num_limbs = 16;
-    let p: BigUint = BaseField::MODULUS.try_into().unwrap();
 
-    let r = calc_mont_radix(num_limbs, log_limb_size);
-    let (_, n0) = calc_rinv_and_n0(&p, &r, log_limb_size);
-    let nsafe = calc_nsafe(log_limb_size);
+    let config = MetalTestConfig {
+        log_limb_size,
+        num_limbs,
+        shader_file: "cuzk/convert_point_coords_and_decompose_scalars.metal".to_string(),
+        kernel_name: "convert_point_coords_and_decompose_scalars".to_string(),
+    };
+
+    let mut helper = MetalTestHelper::new();
+    let constants = get_or_calc_constants(num_limbs, log_limb_size);
+    let p = &constants.p;
+    let r = &constants.r;
 
     // We only need one scalar for the kernel call, but we won't test it here
     // So let's just supply zeros for the scalar array
@@ -33,8 +36,8 @@ fn test_point_coords_conversion() {
     let y: BigUint = point.y.into_bigint().try_into().unwrap();
 
     // Host-side: compute x_mont, y_mont
-    let x_mont = (&x * &r) % &p;
-    let y_mont = (&y * &r) % &p;
+    let x_mont = (&x * r) % p;
+    let y_mont = (&y * r) % p;
 
     // Convert them to ark_ff BigInt<4>, then to limbs
     let x_mont_in_ark: BigInt<4> = x_mont.clone().try_into().unwrap();
@@ -42,7 +45,7 @@ fn test_point_coords_conversion() {
     let x_mont_in_ark_limbs = x_mont_in_ark.to_limbs(num_limbs, log_limb_size);
     let y_mont_in_ark_limbs = y_mont_in_ark.to_limbs(num_limbs, log_limb_size);
 
-    // Convert unreduced x,y into `num_limbs` “halfword” limbs
+    // Convert unreduced x,y into `num_limbs` "halfword" limbs
     let x_in_ark: BigInt<4> = x.clone().try_into().unwrap();
     let y_in_ark: BigInt<4> = y.clone().try_into().unwrap();
     let x_limb = x_in_ark.to_limbs(num_limbs, log_limb_size);
@@ -63,89 +66,36 @@ fn test_point_coords_conversion() {
     let coords = [x_packed, y_packed].concat();
 
     // Setup Metal buffers
-    let device = get_default_device();
-    let coords_buf = create_buffer(&device, &coords);
-    let scalars_buf = create_buffer(&device, &scalars); // all zero
-    let input_size_buf = create_buffer(&device, &vec![1u32]); // only 1 point
+    let coords_buf = helper.create_input_buffer(&coords);
+    let scalars_buf = helper.create_input_buffer(&scalars);
+    let input_size_buf = helper.create_input_buffer(&vec![1u32]);
 
     // Prepare output buffers for the kernel
-    let point_x_buf = create_empty_buffer(&device, num_limbs);
-    let point_y_buf = create_empty_buffer(&device, num_limbs);
+    let point_x_buf = helper.create_output_buffer(num_limbs);
+    let point_y_buf = helper.create_output_buffer(num_limbs);
+    let chunks_buf = helper.create_output_buffer(num_limbs);
 
-    // We also need a chunks buffer, but we won't actually check it in this test
-    let chunks_buf = create_empty_buffer(&device, num_limbs);
+    // Setup thread group sizes
+    let thread_group_count = helper.create_thread_group_size(1, 1, 1);
+    let thread_group_size = helper.create_thread_group_size(1, 1, 1);
 
-    // Build the pipeline
-    let command_queue = device.new_command_queue();
-    let command_buffer = command_queue.new_command_buffer();
-    let compute_pass_descriptor = ComputePassDescriptor::new();
-    let encoder = command_buffer.compute_command_encoder_with_descriptor(compute_pass_descriptor);
-
-    // Compile your metal source
-    write_constants(
-        "../mopro-msm/src/msm/metal_msm/shader",
-        num_limbs,
-        log_limb_size,
-        n0,
-        nsafe,
+    // Execute the shader
+    helper.execute_shader(
+        &config,
+        &[&coords_buf, &scalars_buf, &input_size_buf],
+        &[&point_x_buf, &point_y_buf, &chunks_buf],
+        &thread_group_count,
+        &thread_group_size,
     );
-    let library_path = compile_metal(
-        "../mopro-msm/src/msm/metal_msm/shader/cuzk",
-        "convert_point_coords_and_decompose_scalars.metal",
-    );
-    let library = device.new_library_with_file(library_path).unwrap();
-    let kernel = library
-        .get_function("convert_point_coords_and_decompose_scalars", None)
-        .unwrap();
-
-    let pipeline_state_descriptor = ComputePipelineDescriptor::new();
-    pipeline_state_descriptor.set_compute_function(Some(&kernel));
-    let pipeline_state = device
-        .new_compute_pipeline_state_with_function(
-            pipeline_state_descriptor.compute_function().unwrap(),
-        )
-        .unwrap();
-
-    encoder.set_compute_pipeline_state(&pipeline_state);
-
-    // Match buffer indices to kernel signature
-    encoder.set_buffer(0, Some(&coords_buf), 0);
-    encoder.set_buffer(1, Some(&scalars_buf), 0);
-    encoder.set_buffer(2, Some(&input_size_buf), 0);
-    encoder.set_buffer(3, Some(&point_x_buf), 0);
-    encoder.set_buffer(4, Some(&point_y_buf), 0);
-    encoder.set_buffer(5, Some(&chunks_buf), 0);
-
-    // Dispatch
-    let tg_count = MTLSize {
-        width: 1,
-        height: 1,
-        depth: 1,
-    };
-    let tg_size = MTLSize {
-        width: 1,
-        height: 1,
-        depth: 1,
-    };
-    encoder.dispatch_thread_groups(tg_count, tg_size);
-    encoder.end_encoding();
-
-    command_buffer.commit();
-    command_buffer.wait_until_completed();
 
     // Read back X,Y results and compare
-    let x_result = read_buffer(&point_x_buf, num_limbs);
-    let y_result = read_buffer(&point_y_buf, num_limbs);
+    let x_result = helper.read_results(&point_x_buf, num_limbs);
+    let y_result = helper.read_results(&point_y_buf, num_limbs);
 
-    // Drop the buffers after reading the results
-    drop(coords_buf);
-    drop(scalars_buf);
-    drop(input_size_buf);
-    drop(point_x_buf);
-    drop(point_y_buf);
-    drop(chunks_buf);
-    drop(command_queue);
+    // Clean up resources
+    helper.drop_all_buffers();
 
+    // Verify results
     assert_eq!(x_result, x_mont_in_ark_limbs, "X conversion mismatch");
     assert_eq!(y_result, y_mont_in_ark_limbs, "Y conversion mismatch");
 }
@@ -153,7 +103,7 @@ fn test_point_coords_conversion() {
 #[test]
 #[serial_test::serial]
 fn test_scalar_decomposition() {
-    // BN254 parameters
+    // Setup test config
     let log_limb_size = 16;
     let num_limbs = 16;
     let chunk_size = if BaseField::MODULUS_BIT_SIZE / 32 >= 65536 {
@@ -164,10 +114,14 @@ fn test_scalar_decomposition() {
     let num_subtasks = (256f32 / chunk_size as f32).ceil() as usize;
     let num_columns = 1 << chunk_size; // 2^chunk_size
 
-    let p: BigUint = BaseField::MODULUS.try_into().unwrap();
-    let r = calc_mont_radix(num_limbs, log_limb_size);
-    let (_, n0) = calc_rinv_and_n0(&p, &r, log_limb_size);
-    let nsafe = calc_nsafe(log_limb_size);
+    let config = MetalTestConfig {
+        log_limb_size,
+        num_limbs,
+        shader_file: "cuzk/convert_point_coords_and_decompose_scalars.metal".to_string(),
+        kernel_name: "convert_point_coords_and_decompose_scalars".to_string(),
+    };
+
+    let mut helper = MetalTestHelper::new();
 
     // For scalar test, we can provide dummy coords (X=0, Y=0)
     let coords = vec![0u32; 16]; // 16 zeros
@@ -183,77 +137,30 @@ fn test_scalar_decomposition() {
         .to_limbs(num_limbs, log_limb_size);
 
     // Setup Metal buffers
-    let device = get_default_device();
-    let coords_buf = create_buffer(&device, &coords); // dummy
-    let scalars_buf = create_buffer(&device, &scalars); // real scalar
-    let input_size_buf = create_buffer(&device, &vec![1u32]); // only 1 scalar
+    let coords_buf = helper.create_input_buffer(&coords);
+    let scalars_buf = helper.create_input_buffer(&scalars);
+    let input_size_buf = helper.create_input_buffer(&vec![1u32]);
 
     // We'll ignore X,Y outputs, but we must pass them
-    let point_x_buf = create_empty_buffer(&device, num_limbs);
-    let point_y_buf = create_empty_buffer(&device, num_limbs);
+    let point_x_buf = helper.create_output_buffer(num_limbs);
+    let point_y_buf = helper.create_output_buffer(num_limbs);
+    let chunks_buf = helper.create_output_buffer(num_subtasks);
 
-    // The important output: chunk decomposition
-    let chunks_buf = create_empty_buffer(&device, num_subtasks);
+    // Setup thread group sizes
+    let thread_group_count = helper.create_thread_group_size(1, 1, 1);
+    let thread_group_size = helper.create_thread_group_size(1, 1, 1);
 
-    // Build the pipeline
-    let command_queue = device.new_command_queue();
-    let command_buffer = command_queue.new_command_buffer();
-    let compute_pass_descriptor = ComputePassDescriptor::new();
-    let encoder = command_buffer.compute_command_encoder_with_descriptor(compute_pass_descriptor);
-
-    // Compile your metal source
-    write_constants(
-        "../mopro-msm/src/msm/metal_msm/shader",
-        num_limbs,
-        log_limb_size,
-        n0,
-        nsafe,
+    // Execute the shader
+    helper.execute_shader(
+        &config,
+        &[&coords_buf, &scalars_buf, &input_size_buf],
+        &[&point_x_buf, &point_y_buf, &chunks_buf],
+        &thread_group_count,
+        &thread_group_size,
     );
-    let library_path = compile_metal(
-        "../mopro-msm/src/msm/metal_msm/shader/cuzk",
-        "convert_point_coords_and_decompose_scalars.metal",
-    );
-    let library = device.new_library_with_file(library_path).unwrap();
-    let kernel = library
-        .get_function("convert_point_coords_and_decompose_scalars", None)
-        .unwrap();
-
-    let pipeline_state_descriptor = ComputePipelineDescriptor::new();
-    pipeline_state_descriptor.set_compute_function(Some(&kernel));
-    let pipeline_state = device
-        .new_compute_pipeline_state_with_function(
-            pipeline_state_descriptor.compute_function().unwrap(),
-        )
-        .unwrap();
-
-    encoder.set_compute_pipeline_state(&pipeline_state);
-
-    // Buffer indices to match kernel
-    encoder.set_buffer(0, Some(&coords_buf), 0);
-    encoder.set_buffer(1, Some(&scalars_buf), 0);
-    encoder.set_buffer(2, Some(&input_size_buf), 0);
-    encoder.set_buffer(3, Some(&point_x_buf), 0);
-    encoder.set_buffer(4, Some(&point_y_buf), 0);
-    encoder.set_buffer(5, Some(&chunks_buf), 0);
-
-    let tg_count = MTLSize {
-        width: 1,
-        height: 1,
-        depth: 1,
-    };
-    let tg_size = MTLSize {
-        width: 1,
-        height: 1,
-        depth: 1,
-    };
-    encoder.dispatch_thread_groups(tg_count, tg_size);
-    encoder.end_encoding();
-
-    command_buffer.commit();
-    command_buffer.wait_until_completed();
 
     // Read back the chunk data from GPU
-    let gpu_chunks = read_buffer(&chunks_buf, num_subtasks);
+    let gpu_chunks = helper.read_results(&chunks_buf, num_subtasks);
 
     // Now replicate the GPU logic in Rust:
     // (1) build scalar_bytes[16]
@@ -289,17 +196,17 @@ fn test_scalar_decomposition() {
         }
     }
 
-    // (C) Extract chunk_size-bit words for all but the last chunk
+    // Calculate expected chunks
     let mut cpu_chunks = vec![0u32; num_subtasks];
     for i in 0..(num_subtasks - 1) {
         cpu_chunks[i] = extract_word_from_bytes_le_mock(&scalar_bytes, i as u32, chunk_size as u32);
     }
 
-    // (D) Last chunk for 254 bits: top 2 bits are unused
+    // Last chunk for 254 bits: top 2 bits are unused
     let shift_254 = ((num_subtasks as u32 * chunk_size as u32 - 254) + 16) - chunk_size as u32;
     cpu_chunks[num_subtasks - 1] = scalar_bytes[0] >> shift_254;
 
-    // (E) Sign logic
+    // Sign logic
     let l = num_columns;
     let s = l / 2;
     let mut carry = 0u32;
@@ -320,6 +227,10 @@ fn test_scalar_decomposition() {
         cpu_chunks[i] = (cpu_signed_slices[i] + s as i32) as u32;
     }
 
+    // Clean up resources
+    helper.drop_all_buffers();
+
+    // Verify results
     assert_eq!(
         gpu_chunks, cpu_chunks,
         "Scalar decomposition mismatch between GPU and CPU!"

--- a/mopro-msm/src/msm/metal_msm/tests/cuzk/convert_point_coords_and_decompose_scalars.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/cuzk/convert_point_coords_and_decompose_scalars.rs
@@ -137,6 +137,15 @@ fn test_point_coords_conversion() {
     let x_result = read_buffer(&point_x_buf, num_limbs);
     let y_result = read_buffer(&point_y_buf, num_limbs);
 
+    // Drop the buffers after reading the results
+    drop(coords_buf);
+    drop(scalars_buf);
+    drop(input_size_buf);
+    drop(point_x_buf);
+    drop(point_y_buf);
+    drop(chunks_buf);
+    drop(command_queue);
+
     assert_eq!(x_result, x_mont_in_ark_limbs, "X conversion mismatch");
     assert_eq!(y_result, y_mont_in_ark_limbs, "Y conversion mismatch");
 }

--- a/mopro-msm/src/msm/metal_msm/tests/cuzk/pbpr.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/cuzk/pbpr.rs
@@ -1,15 +1,13 @@
-use crate::msm::metal_msm::host::gpu::{create_buffer, get_default_device};
-use crate::msm::metal_msm::host::shader::{compile_metal, write_constants};
-use crate::msm::metal_msm::utils::data_conversion::raw_reduction;
-use crate::msm::metal_msm::utils::limbs_conversion::GenericLimbConversion;
-use crate::msm::metal_msm::utils::mont_params::{calc_mont_radix, MontgomeryParams};
 use ark_bn254::{Fq as BaseField, Fr as ScalarField, G1Projective as G};
 use ark_ec::Group;
 use ark_ff::{BigInt, PrimeField};
 use ark_std::{rand::thread_rng, UniformRand, Zero};
-use metal::*;
 use num_bigint::BigUint;
 use rayon::prelude::*;
+
+use crate::msm::metal_msm::tests::common::*;
+use crate::msm::metal_msm::utils::data_conversion::raw_reduction;
+use crate::msm::metal_msm::utils::limbs_conversion::GenericLimbConversion;
 
 fn closest_power_of_two(n: usize) -> usize {
     if n <= 1 {
@@ -33,14 +31,14 @@ fn closest_power_of_two(n: usize) -> usize {
 /// Implement parallel bucket reduction in GPU using separated buffers internally
 fn gpu_parallel_bpr(buckets: &Vec<G>) -> G {
     /// Converts a bucket vector into three separated vectors for the x, y, and z coordinates
-    /// Each coordinate is represented as a vector of u32 values in Montgomery form
     fn buckets_to_separated_coords(
         buckets: &Vec<G>,
         num_limbs: usize,
+        log_limb_size: u32,
     ) -> (Vec<u32>, Vec<u32>, Vec<u32>) {
-        let log_limb_size: u32 = 16;
-        let p: BigUint = BaseField::MODULUS.try_into().unwrap();
-        let r = calc_mont_radix(num_limbs, log_limb_size);
+        let constants = get_or_calc_constants(num_limbs, log_limb_size);
+        let p = &constants.p;
+        let r = &constants.r;
 
         // Pre-allocate vectors for the limbs
         let total_limbs = buckets.len() * num_limbs;
@@ -54,9 +52,9 @@ fn gpu_parallel_bpr(buckets: &Vec<G>) -> G {
             let py: BigUint = point.y.into();
             let pz: BigUint = point.z.into();
 
-            let pxr = (&px * &r) % &p;
-            let pyr = (&py * &r) % &p;
-            let pzr = (&pz * &r) % &p;
+            let pxr = (&px * r) % p;
+            let pyr = (&py * r) % p;
+            let pzr = (&pz * r) % p;
 
             // Convert to limbs
             let pxr_limbs = BigInt::<4>::try_from(pxr)
@@ -84,8 +82,8 @@ fn gpu_parallel_bpr(buckets: &Vec<G>) -> G {
         y_buffer: &[u32],
         z_buffer: &[u32],
         num_limbs: usize,
+        log_limb_size: u32,
     ) -> Vec<G> {
-        let log_limb_size = 16;
         let coord_size = num_limbs;
         let total_u32s = x_buffer.len() as usize;
         let num_points = total_u32s / coord_size;
@@ -118,80 +116,42 @@ fn gpu_parallel_bpr(buckets: &Vec<G>) -> G {
         points
     }
 
-    let mont_params = MontgomeryParams::default();
-    let log_limb_size: u32 = 16;
-    let num_limbs = mont_params.num_limbs;
-    let n0 = mont_params.n0;
-    let nsafe = mont_params.nsafe;
-
-    let device = get_default_device();
+    // Configure Metal test parameters
+    let log_limb_size = 16;
+    let num_limbs = 16;
     let bucket_size = buckets.len();
 
-    // Convert buckets to separated coordinate arrays
-    let (buckets_x, buckets_y, buckets_z) = buckets_to_separated_coords(buckets, num_limbs);
-
-    // Create buffers for coordinates
-    let buckets_x_buffer = create_buffer(&device, &buckets_x);
-    let buckets_y_buffer = create_buffer(&device, &buckets_y);
-    let buckets_z_buffer = create_buffer(&device, &buckets_z);
-
-    // Compile shader and create pipeline
-    let library_path = compile_metal("../mopro-msm/src/msm/metal_msm/shader/cuzk", "pbpr.metal");
-    let library = device.new_library_with_file(library_path).unwrap();
-    let kernel = library.get_function("parallel_bpr", None).unwrap();
-
-    let pipeline_state_descriptor = ComputePipelineDescriptor::new();
-    pipeline_state_descriptor.set_compute_function(Some(&kernel));
-
-    let pipeline_state = device
-        .new_compute_pipeline_state_with_function(
-            pipeline_state_descriptor.compute_function().unwrap(),
-        )
-        .unwrap();
-
-    // Get thread dimensions
-    let thread_group_width = pipeline_state.thread_execution_width();
-    let thread_group_height =
-        pipeline_state.max_total_threads_per_threadgroup() / thread_group_width;
-    let max_group_threads = pipeline_state.max_total_threads_per_threadgroup();
-    let optimal_threads = max_group_threads;
-
-    // Calculate total threads needed
-    let candidate = if bucket_size < optimal_threads as usize {
-        bucket_size
-    } else {
-        optimal_threads as usize // This is wrong, since we're workloading just a single TG,
-                                 // The thing is that this gives the best performance so far
-                                 // But we need to introduce cross kernel synchronisation to improve this.
+    let config = MetalTestConfig {
+        log_limb_size,
+        num_limbs,
+        shader_file: "cuzk/pbpr.metal".to_string(),
+        kernel_name: "parallel_bpr".to_string(),
     };
 
+    let mut helper = MetalTestHelper::new();
+
+    // Convert buckets to separated coordinate arrays
+    let (buckets_x, buckets_y, buckets_z) =
+        buckets_to_separated_coords(buckets, num_limbs, log_limb_size);
+
+    // Create input buffers
+    let buckets_x_buf = helper.create_input_buffer(&buckets_x);
+    let buckets_y_buf = helper.create_input_buffer(&buckets_y);
+    let buckets_z_buf = helper.create_input_buffer(&buckets_z);
+
+    // Calculate thread dimensions
+    let candidate = if bucket_size < 256 { bucket_size } else { 256 }; // Use 256 as default max threads
     let total_threads = closest_power_of_two(candidate);
 
-    // Calculate grid dimensions
-    let grid_width = (total_threads as f64).sqrt().ceil() as u64;
-    let grid_height = (total_threads as u64 + grid_width - 1) / grid_width;
-
-    let threads_per_thread_group = MTLSize {
-        width: thread_group_width,
-        height: thread_group_height,
-        depth: 1,
-    };
-
-    let threads_total = MTLSize {
-        width: grid_width,
-        height: grid_height,
-        depth: 1,
-    };
-
-    // Create output buffers
+    // Create zero point buffers for output
     let zero_point = G::zero();
-    let (zero_x, zero_y, zero_z) = buckets_to_separated_coords(&vec![zero_point], num_limbs);
+    let (zero_x, zero_y, zero_z) =
+        buckets_to_separated_coords(&vec![zero_point], num_limbs, log_limb_size);
 
-    // Fill the buffers with zero points
+    // Initialize output buffers with zero points
     let mut m_shared_x = vec![0u32; total_threads * num_limbs];
     let mut m_shared_y = vec![0u32; total_threads * num_limbs];
     let mut m_shared_z = vec![0u32; total_threads * num_limbs];
-
     let mut s_shared_x = vec![0u32; total_threads * num_limbs];
     let mut s_shared_y = vec![0u32; total_threads * num_limbs];
     let mut s_shared_z = vec![0u32; total_threads * num_limbs];
@@ -202,135 +162,63 @@ fn gpu_parallel_bpr(buckets: &Vec<G>) -> G {
             m_shared_x[i * num_limbs + j] = zero_x[j];
             m_shared_y[i * num_limbs + j] = zero_y[j];
             m_shared_z[i * num_limbs + j] = zero_z[j];
-
             s_shared_x[i * num_limbs + j] = zero_x[j];
             s_shared_y[i * num_limbs + j] = zero_y[j];
             s_shared_z[i * num_limbs + j] = zero_z[j];
         }
     }
 
-    let m_shared_x_buffer = create_buffer(&device, &m_shared_x);
-    let m_shared_y_buffer = create_buffer(&device, &m_shared_y);
-    let m_shared_z_buffer = create_buffer(&device, &m_shared_z);
-
-    let s_shared_x_buffer = create_buffer(&device, &s_shared_x);
-    let s_shared_y_buffer = create_buffer(&device, &s_shared_y);
-    let s_shared_z_buffer = create_buffer(&device, &s_shared_z);
+    // Create output buffers
+    let m_shared_x_buf = helper.create_input_buffer(&m_shared_x);
+    let m_shared_y_buf = helper.create_input_buffer(&m_shared_y);
+    let m_shared_z_buf = helper.create_input_buffer(&m_shared_z);
+    let s_shared_x_buf = helper.create_input_buffer(&s_shared_x);
+    let s_shared_y_buf = helper.create_input_buffer(&s_shared_y);
+    let s_shared_z_buf = helper.create_input_buffer(&s_shared_z);
 
     // Create parameter buffers
-    let grid_width_buffer = create_buffer(&device, &vec![grid_width as u32]);
-    let total_threads_buffer = create_buffer(&device, &vec![total_threads as u32]);
+    let grid_width = (total_threads as f64).sqrt().ceil() as u64;
+    let grid_width_buf = helper.create_input_buffer(&vec![grid_width as u32]);
+    let total_threads_buf = helper.create_input_buffer(&vec![total_threads as u32]);
     let num_subtask = (bucket_size + total_threads - 1) / total_threads;
-    let num_subtask_buffer = create_buffer(&device, &vec![num_subtask as u32]);
+    let num_subtask_buf = helper.create_input_buffer(&vec![num_subtask as u32]);
 
-    // Set up command queue and encoder
-    let command_queue = device.new_command_queue();
-    let command_buffer = command_queue.new_command_buffer();
-    let encoder =
-        command_buffer.compute_command_encoder_with_descriptor(ComputePassDescriptor::new());
+    // Setup thread group sizes
+    let thread_group_width = 32; // Default thread group width
+    let thread_group_height = 1;
+    let grid_height = (total_threads as u64 + grid_width - 1) / grid_width;
 
-    // Write constants
-    write_constants(
-        "../mopro-msm/src/msm/metal_msm/shader",
-        num_limbs,
-        log_limb_size,
-        n0,
-        nsafe,
+    let threads_per_thread_group =
+        helper.create_thread_group_size(thread_group_width, thread_group_height, 1);
+
+    let threads_total = helper.create_thread_group_size(grid_width, grid_height, 1);
+
+    // Execute shader
+    helper.execute_shader(
+        &config,
+        &[
+            &buckets_x_buf,
+            &buckets_y_buf,
+            &buckets_z_buf,
+            &m_shared_x_buf,
+            &m_shared_y_buf,
+            &m_shared_z_buf,
+            &s_shared_x_buf,
+            &s_shared_y_buf,
+            &s_shared_z_buf,
+            &grid_width_buf,
+            &total_threads_buf,
+            &num_subtask_buf,
+        ],
+        &[], // No separate output buffers - results are in the shared buffers
+        &threads_total,
+        &threads_per_thread_group,
     );
 
-    encoder.set_compute_pipeline_state(&pipeline_state);
-
-    // Set kernel arguments
-    encoder.set_buffer(0, Some(&buckets_x_buffer), 0);
-    encoder.set_buffer(1, Some(&buckets_y_buffer), 0);
-    encoder.set_buffer(2, Some(&buckets_z_buffer), 0);
-    encoder.set_buffer(3, Some(&m_shared_x_buffer), 0);
-    encoder.set_buffer(4, Some(&m_shared_y_buffer), 0);
-    encoder.set_buffer(5, Some(&m_shared_z_buffer), 0);
-    encoder.set_buffer(6, Some(&s_shared_x_buffer), 0);
-    encoder.set_buffer(7, Some(&s_shared_y_buffer), 0);
-    encoder.set_buffer(8, Some(&s_shared_z_buffer), 0);
-    encoder.set_buffer(9, Some(&grid_width_buffer), 0);
-    encoder.set_buffer(10, Some(&total_threads_buffer), 0);
-    encoder.set_buffer(11, Some(&num_subtask_buffer), 0);
-
-    // Dispatch threads
-    encoder.dispatch_threads(threads_total, threads_per_thread_group);
-    encoder.end_encoding();
-    command_buffer.commit();
-    command_buffer.wait_until_completed();
-
     // Read results back
-    let s_shared_x_ptr = s_shared_x_buffer.contents() as *const u32;
-    let s_shared_y_ptr = s_shared_y_buffer.contents() as *const u32;
-    let s_shared_z_ptr = s_shared_z_buffer.contents() as *const u32;
-
-    let mut s_shared_x_result = vec![0u32; total_threads * num_limbs];
-    let mut s_shared_y_result = vec![0u32; total_threads * num_limbs];
-    let mut s_shared_z_result = vec![0u32; total_threads * num_limbs];
-
-    unsafe {
-        std::ptr::copy_nonoverlapping(
-            s_shared_x_ptr,
-            s_shared_x_result.as_mut_ptr(),
-            total_threads * num_limbs,
-        );
-        std::ptr::copy_nonoverlapping(
-            s_shared_y_ptr,
-            s_shared_y_result.as_mut_ptr(),
-            total_threads * num_limbs,
-        );
-        std::ptr::copy_nonoverlapping(
-            s_shared_z_ptr,
-            s_shared_z_result.as_mut_ptr(),
-            total_threads * num_limbs,
-        );
-    }
-
-    // Read results back
-    let m_shared_x_ptr = m_shared_x_buffer.contents() as *const u32;
-    let m_shared_y_ptr = m_shared_y_buffer.contents() as *const u32;
-    let m_shared_z_ptr = m_shared_z_buffer.contents() as *const u32;
-
-    // Drop the buffers after reading the results
-    drop(buckets_x_buffer);
-    drop(buckets_y_buffer);
-    drop(buckets_z_buffer);
-    drop(m_shared_x_buffer);
-    drop(m_shared_y_buffer);
-    drop(m_shared_z_buffer);
-    drop(s_shared_x_buffer);
-    drop(s_shared_y_buffer);
-    drop(s_shared_z_buffer);
-    drop(grid_width_buffer);
-    drop(total_threads_buffer);
-    drop(num_subtask_buffer);
-    drop(command_queue);
-
-    let mut m_shared_x_result = vec![0u32; total_threads * num_limbs];
-    let mut m_shared_y_result = vec![0u32; total_threads * num_limbs];
-    let mut m_shared_z_result = vec![0u32; total_threads * num_limbs];
-
-    unsafe {
-        std::ptr::copy_nonoverlapping(
-            m_shared_x_ptr,
-            m_shared_x_result.as_mut_ptr(),
-            total_threads * num_limbs,
-        );
-        std::ptr::copy_nonoverlapping(
-            m_shared_y_ptr,
-            m_shared_y_result.as_mut_ptr(),
-            total_threads * num_limbs,
-        );
-        std::ptr::copy_nonoverlapping(
-            m_shared_z_ptr,
-            m_shared_z_result.as_mut_ptr(),
-            total_threads * num_limbs,
-        );
-    }
-
-    // for debug
-    // let m_shared_points = points_from_separated_buffers(&m_shared_x_result, &m_shared_y_result, &m_shared_z_result, num_limbs);
+    let s_shared_x_result = helper.read_results(&s_shared_x_buf, total_threads * num_limbs);
+    let s_shared_y_result = helper.read_results(&s_shared_y_buf, total_threads * num_limbs);
+    let s_shared_z_result = helper.read_results(&s_shared_z_buf, total_threads * num_limbs);
 
     // Convert results back to points
     let s_shared_points = points_from_separated_buffers(
@@ -338,7 +226,11 @@ fn gpu_parallel_bpr(buckets: &Vec<G>) -> G {
         &s_shared_y_result,
         &s_shared_z_result,
         num_limbs,
+        log_limb_size,
     );
+
+    // Clean up
+    helper.drop_all_buffers();
 
     // Sum the points
     s_shared_points.iter().sum::<G>()
@@ -408,15 +300,18 @@ pub fn test_pbpr_simple_input() {
 #[serial_test::serial]
 fn test_pbpr_random_inputs() {
     let generator = G::generator();
-    let mut rng = thread_rng();
-    let bucket_size = vec![5, 6, 7, 8, 9, 10];
+    let c: u32 = 10;
+    let bucket_size = 1 << c;
 
-    for size in bucket_size {
-        let buckets = (0..(1 << size))
-            .map(|_| generator * ScalarField::rand(&mut rng))
-            .collect::<Vec<G>>();
-        let naive_result = cpu_naive_bpr(&buckets);
-        let gpu_pbpr_result = gpu_parallel_bpr(&buckets);
-        assert_eq!(gpu_pbpr_result, naive_result);
-    }
+    let mut rng = thread_rng();
+    let buckets = (1..=bucket_size)
+        .map(|_| generator * ScalarField::rand(&mut rng))
+        .collect::<Vec<G>>();
+
+    let cpu_naive_result = cpu_naive_bpr(&buckets);
+    let cpu_pbpr_result = cpu_parallel_bpr(&buckets);
+    let gpu_pbpr_result = gpu_parallel_bpr(&buckets);
+
+    assert_eq!(gpu_pbpr_result, cpu_naive_result);
+    assert_eq!(gpu_pbpr_result, cpu_pbpr_result);
 }

--- a/mopro-msm/src/msm/metal_msm/tests/cuzk/pbpr.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/cuzk/pbpr.rs
@@ -280,27 +280,9 @@ fn cpu_parallel_bpr(buckets: &Vec<G>) -> G {
 
 #[test]
 #[serial_test::serial]
-pub fn test_pbpr_simple_input() {
-    let generator = G::generator();
-    let c: u32 = 10;
-    let bucket_size = 1 << c;
-    let buckets = (1..=bucket_size)
-        .map(|i| generator * ScalarField::from(i as u64))
-        .collect::<Vec<G>>();
-
-    let cpu_naive_result = cpu_naive_bpr(&buckets);
-    let cpu_pbpr_result = cpu_parallel_bpr(&buckets);
-    let gpu_pbpr_result = gpu_parallel_bpr(&buckets);
-
-    assert_eq!(gpu_pbpr_result, cpu_naive_result);
-    assert_eq!(gpu_pbpr_result, cpu_pbpr_result);
-}
-
-#[test]
-#[serial_test::serial]
 fn test_pbpr_random_inputs() {
     let generator = G::generator();
-    let c: u32 = 10;
+    let c: u32 = 5;
     let bucket_size = 1 << c;
 
     let mut rng = thread_rng();

--- a/mopro-msm/src/msm/metal_msm/tests/cuzk/pbpr.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/cuzk/pbpr.rs
@@ -292,6 +292,21 @@ fn gpu_parallel_bpr(buckets: &Vec<G>) -> G {
     let m_shared_y_ptr = m_shared_y_buffer.contents() as *const u32;
     let m_shared_z_ptr = m_shared_z_buffer.contents() as *const u32;
 
+    // Drop the buffers after reading the results
+    drop(buckets_x_buffer);
+    drop(buckets_y_buffer);
+    drop(buckets_z_buffer);
+    drop(m_shared_x_buffer);
+    drop(m_shared_y_buffer);
+    drop(m_shared_z_buffer);
+    drop(s_shared_x_buffer);
+    drop(s_shared_y_buffer);
+    drop(s_shared_z_buffer);
+    drop(grid_width_buffer);
+    drop(total_threads_buffer);
+    drop(num_subtask_buffer);
+    drop(command_queue);
+
     let mut m_shared_x_result = vec![0u32; total_threads * num_limbs];
     let mut m_shared_y_result = vec![0u32; total_threads * num_limbs];
     let mut m_shared_z_result = vec![0u32; total_threads * num_limbs];

--- a/mopro-msm/src/msm/metal_msm/tests/cuzk/smvp.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/cuzk/smvp.rs
@@ -160,6 +160,17 @@ fn test_smvp() {
     let bucket_y_out_limbs: Vec<u32> = read_buffer(&bucket_y_buf, 8 * num_limbs);
     let bucket_z_out_limbs: Vec<u32> = read_buffer(&bucket_z_buf, 8 * num_limbs);
 
+    // Drop the buffers after reading the results
+    drop(row_ptr_buf);
+    drop(val_idx_buf);
+    drop(new_point_x_buf);
+    drop(new_point_y_buf);
+    drop(bucket_x_buf);
+    drop(bucket_y_buf);
+    drop(bucket_z_buf);
+    drop(params_buf);
+    drop(command_queue);
+
     // ------------------------------------------------------------------
     // CPU reference check and smvp logic
     //

--- a/mopro-msm/src/msm/metal_msm/tests/cuzk/transpose.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/cuzk/transpose.rs
@@ -96,6 +96,14 @@ fn test_sparse_matrix_transposition() {
         let csc_val_idxs: Vec<u32> =
             read_buffer(&all_csc_val_idxs_buf, num_subtasks * input_size as usize);
 
+        // Drop the buffers after reading the results
+        drop(all_csr_col_idx_buf);
+        drop(all_csc_col_ptr_buf);
+        drop(all_csc_val_idxs_buf);
+        drop(all_curr_buf);
+        drop(params_buf);
+        drop(command_queue);
+
         // Validate each subtask
         for subtask in 0..num_subtasks {
             let offset = subtask * (n as usize + 1);

--- a/mopro-msm/src/msm/metal_msm/tests/field/ff_add.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/field/ff_add.rs
@@ -123,4 +123,10 @@ pub fn test_ff_add() {
 
     assert!(result == expected);
     assert!(result_limbs == expected_limbs);
+
+    // Drop the buffers after reading the results
+    drop(a_buf);
+    drop(b_buf);
+    drop(result_buf);
+    drop(command_queue);
 }

--- a/mopro-msm/src/msm/metal_msm/tests/field/ff_add.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/field/ff_add.rs
@@ -1,29 +1,29 @@
-// adapted from: https://github.com/geometryxyz/msl-secp256k1
-
-use crate::msm::metal_msm::host::gpu::{
-    create_buffer, create_empty_buffer, get_default_device, read_buffer,
-};
-use crate::msm::metal_msm::host::shader::{compile_metal, write_constants};
+use crate::msm::metal_msm::tests::common::*;
 use crate::msm::metal_msm::utils::limbs_conversion::GenericLimbConversion;
+
 use ark_bn254::Fq as BaseField;
 use ark_ff::{BigInt, BigInteger, PrimeField, UniformRand};
 use ark_std::rand;
-use metal::*;
 
 #[test]
 #[serial_test::serial]
 pub fn test_ff_add() {
-    let log_limb_size = 16;
-    let num_limbs = 16;
+    let config = MetalTestConfig {
+        log_limb_size: 16,
+        num_limbs: 16,
+        shader_file: "field/ff_add.metal".to_string(),
+        kernel_name: "run".to_string(),
+    };
 
-    // Scalar field modulus for bn254
+    let mut helper = MetalTestHelper::new();
+
     let p = BaseField::MODULUS;
 
     let mut rng = rand::thread_rng();
     let mut a = BigInt::<4>::rand(&mut rng);
     let mut b = BigInt::<4>::rand(&mut rng);
 
-    // Reduce a and b if they are greater than or equal to the prime field modulus
+    // a % p
     while a >= p {
         a.sub_with_borrow(&p);
     }
@@ -38,12 +38,11 @@ pub fn test_ff_add() {
     assert!(a < p, "a must be less than p");
     assert!(b < p, "b must be less than p");
 
-    let device = get_default_device();
-    let a_buf = create_buffer(&device, &a.to_limbs(num_limbs, log_limb_size));
-    let b_buf = create_buffer(&device, &b.to_limbs(num_limbs, log_limb_size));
-    let result_buf = create_empty_buffer(&device, num_limbs);
+    let a_buf = helper.create_input_buffer(&a.to_limbs(config.num_limbs, config.log_limb_size));
+    let b_buf = helper.create_input_buffer(&b.to_limbs(config.num_limbs, config.log_limb_size));
+    let result_buf = helper.create_output_buffer(config.num_limbs);
 
-    // Perform (a + b) % p
+    // Calculate expected result: (a + b) % p
     let mut expected = a.clone();
     expected.add_with_carry(&b);
 
@@ -51,7 +50,7 @@ pub fn test_ff_add() {
     while expected >= p {
         expected.sub_with_borrow(&p);
     }
-    // Ensure expected is non-negative and less than p
+
     assert!(
         expected >= BigInt::from(0u64),
         "expected must be non-negative"
@@ -64,69 +63,24 @@ pub fn test_ff_add() {
     let expected_field = a_field + b_field;
     assert!(expected_field == expected.into());
 
-    let expected_limbs = expected.to_limbs(num_limbs, log_limb_size);
+    let expected_limbs = expected.to_limbs(config.num_limbs, config.log_limb_size);
 
-    let command_queue = device.new_command_queue();
-    let command_buffer = command_queue.new_command_buffer();
+    let thread_group_count = helper.create_thread_group_size(1, 1, 1);
+    let thread_group_size = helper.create_thread_group_size(1, 1, 1);
 
-    let compute_pass_descriptor = ComputePassDescriptor::new();
-    let encoder = command_buffer.compute_command_encoder_with_descriptor(compute_pass_descriptor);
-
-    write_constants(
-        "../mopro-msm/src/msm/metal_msm/shader",
-        num_limbs,
-        log_limb_size,
-        0,
-        0,
+    helper.execute_shader(
+        &config,
+        &[&a_buf, &b_buf],
+        &[&result_buf],
+        &thread_group_count,
+        &thread_group_size,
     );
-    let library_path = compile_metal(
-        "../mopro-msm/src/msm/metal_msm/shader/field",
-        "ff_add.metal",
-    );
-    let library = device.new_library_with_file(library_path).unwrap();
-    let kernel = library.get_function("run", None).unwrap();
 
-    let pipeline_state_descriptor = ComputePipelineDescriptor::new();
-    pipeline_state_descriptor.set_compute_function(Some(&kernel));
-
-    let pipeline_state = device
-        .new_compute_pipeline_state_with_function(
-            pipeline_state_descriptor.compute_function().unwrap(),
-        )
-        .unwrap();
-
-    encoder.set_compute_pipeline_state(&pipeline_state);
-    encoder.set_buffer(0, Some(&a_buf), 0);
-    encoder.set_buffer(1, Some(&b_buf), 0);
-    encoder.set_buffer(2, Some(&result_buf), 0);
-
-    let thread_group_count = MTLSize {
-        width: 1,
-        height: 1,
-        depth: 1,
-    };
-
-    let thread_group_size = MTLSize {
-        width: 1,
-        height: 1,
-        depth: 1,
-    };
-
-    encoder.dispatch_thread_groups(thread_group_count, thread_group_size);
-    encoder.end_encoding();
-
-    command_buffer.commit();
-    command_buffer.wait_until_completed();
-
-    let result_limbs: Vec<u32> = read_buffer(&result_buf, num_limbs);
-    let result = BigInt::from_limbs(&result_limbs, log_limb_size);
+    let result_limbs = helper.read_results(&result_buf, config.num_limbs);
+    let result = BigInt::from_limbs(&result_limbs, config.log_limb_size);
 
     assert!(result == expected);
     assert!(result_limbs == expected_limbs);
 
-    // Drop the buffers after reading the results
-    drop(a_buf);
-    drop(b_buf);
-    drop(result_buf);
-    drop(command_queue);
+    helper.drop_all_buffers();
 }

--- a/mopro-msm/src/msm/metal_msm/tests/field/ff_reduce.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/field/ff_reduce.rs
@@ -95,6 +95,11 @@ pub fn test_ff_reduce_a_less_than_p() {
 
     assert!(result == a);
     assert!(result_limbs == a_limbs);
+
+    // Drop the buffers after reading the results
+    drop(a_buf);
+    drop(result_buf);
+    drop(command_queue);
 }
 
 #[test]
@@ -193,4 +198,9 @@ pub fn test_ff_reduce_a_greater_than_p_less_than_2p() {
 
     assert!(result == expected);
     assert!(result_limbs == expected_limbs);
+
+    // Drop the buffers after reading the results
+    drop(a_buf);
+    drop(result_buf);
+    drop(command_queue);
 }

--- a/mopro-msm/src/msm/metal_msm/tests/field/ff_reduce.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/field/ff_reduce.rs
@@ -1,206 +1,116 @@
-use crate::msm::metal_msm::host::gpu::{
-    create_buffer, create_empty_buffer, get_default_device, read_buffer,
-};
-use crate::msm::metal_msm::host::shader::{compile_metal, write_constants};
+use crate::msm::metal_msm::tests::common::*;
 use crate::msm::metal_msm::utils::limbs_conversion::GenericLimbConversion;
+
 use ark_bn254::Fq as BaseField;
 use ark_ff::{BigInt, BigInteger, PrimeField, UniformRand};
 use ark_std::rand;
-use metal::*;
 
 #[test]
 #[serial_test::serial]
 pub fn test_ff_reduce_a_less_than_p() {
-    let log_limb_size = 16;
-    let num_limbs = 16;
-
-    // Scalar field modulus for bn254
-    let p = BaseField::MODULUS;
-
-    let mut rng = rand::thread_rng();
-    let raw_a = BigInt::<4>::rand(&mut rng);
-
-    // Ensure a is non-negative
-    assert!(raw_a >= BigInt::from(0u64), "a must be non-negative");
-
-    // Perform a % p
-    let mut a = raw_a.clone();
-
-    // While result >= p, subtract p
-    while a >= p {
-        a.sub_with_borrow(&p);
-    }
-    // Ensure expected is non-negative and less than p
-    assert!(a >= BigInt::from(0u64), "a must be non-negative");
-    assert!(a < p, "a must be less than p");
-
-    let a_limbs = a.to_limbs(num_limbs, log_limb_size);
-    let device = get_default_device();
-    let a_buf = create_buffer(&device, &a_limbs);
-    let result_buf = create_empty_buffer(&device, num_limbs);
-
-    let command_queue = device.new_command_queue();
-    let command_buffer = command_queue.new_command_buffer();
-
-    let compute_pass_descriptor = ComputePassDescriptor::new();
-    let encoder = command_buffer.compute_command_encoder_with_descriptor(compute_pass_descriptor);
-
-    write_constants(
-        "../mopro-msm/src/msm/metal_msm/shader",
-        num_limbs,
-        log_limb_size,
-        0,
-        0,
-    );
-    let library_path = compile_metal(
-        "../mopro-msm/src/msm/metal_msm/shader/field",
-        "ff_reduce.metal",
-    );
-    let library = device.new_library_with_file(library_path).unwrap();
-    let kernel = library.get_function("run", None).unwrap();
-
-    let pipeline_state_descriptor = ComputePipelineDescriptor::new();
-    pipeline_state_descriptor.set_compute_function(Some(&kernel));
-
-    let pipeline_state = device
-        .new_compute_pipeline_state_with_function(
-            pipeline_state_descriptor.compute_function().unwrap(),
-        )
-        .unwrap();
-
-    encoder.set_compute_pipeline_state(&pipeline_state);
-    encoder.set_buffer(0, Some(&a_buf), 0);
-    encoder.set_buffer(1, Some(&result_buf), 0);
-
-    let thread_group_count = MTLSize {
-        width: 1,
-        height: 1,
-        depth: 1,
+    let config = MetalTestConfig {
+        log_limb_size: 16,
+        num_limbs: 16,
+        shader_file: "field/ff_reduce.metal".to_string(),
+        kernel_name: "run".to_string(),
     };
 
-    let thread_group_size = MTLSize {
-        width: 1,
-        height: 1,
-        depth: 1,
-    };
+    let mut helper = MetalTestHelper::new();
 
-    encoder.dispatch_thread_groups(thread_group_count, thread_group_size);
-    encoder.end_encoding();
+    let (a, expected) = generate_test_values(false);
 
-    command_buffer.commit();
-    command_buffer.wait_until_completed();
+    let a_buf = helper.create_input_buffer(&a.to_limbs(config.num_limbs, config.log_limb_size));
+    let result_buf = helper.create_output_buffer(config.num_limbs);
 
-    let result_limbs: Vec<u32> = read_buffer(&result_buf, num_limbs);
-    let result = BigInt::from_limbs(&result_limbs, log_limb_size);
+    let expected_limbs = expected.to_limbs(config.num_limbs, config.log_limb_size);
 
-    assert!(result == a);
-    assert!(result_limbs == a_limbs);
+    let thread_group_count = helper.create_thread_group_size(1, 1, 1);
+    let thread_group_size = helper.create_thread_group_size(1, 1, 1);
 
-    // Drop the buffers after reading the results
-    drop(a_buf);
-    drop(result_buf);
-    drop(command_queue);
+    helper.execute_shader(
+        &config,
+        &[&a_buf],
+        &[&result_buf],
+        &thread_group_count,
+        &thread_group_size,
+    );
+
+    let result_limbs = helper.read_results(&result_buf, config.num_limbs);
+    let result = BigInt::from_limbs(&result_limbs, config.log_limb_size);
+
+    assert_eq!(result, expected);
+    assert_eq!(result_limbs, expected_limbs);
+
+    helper.drop_all_buffers();
 }
 
 #[test]
 #[serial_test::serial]
 pub fn test_ff_reduce_a_greater_than_p_less_than_2p() {
-    let log_limb_size = 16;
-    let num_limbs = 16;
+    let config = MetalTestConfig {
+        log_limb_size: 16,
+        num_limbs: 16,
+        shader_file: "field/ff_reduce.metal".to_string(),
+        kernel_name: "run".to_string(),
+    };
 
-    // Scalar field modulus for bn254
+    let mut helper = MetalTestHelper::new();
+
+    let (a, expected) = generate_test_values(true);
+
+    let a_buf = helper.create_input_buffer(&a.to_limbs(config.num_limbs, config.log_limb_size));
+    let result_buf = helper.create_output_buffer(config.num_limbs);
+
+    let expected_limbs = expected.to_limbs(config.num_limbs, config.log_limb_size);
+
+    let thread_group_count = helper.create_thread_group_size(1, 1, 1);
+    let thread_group_size = helper.create_thread_group_size(1, 1, 1);
+
+    helper.execute_shader(
+        &config,
+        &[&a_buf],
+        &[&result_buf],
+        &thread_group_count,
+        &thread_group_size,
+    );
+
+    let result_limbs = helper.read_results(&result_buf, config.num_limbs);
+    let result = BigInt::from_limbs(&result_limbs, config.log_limb_size);
+
+    assert_eq!(result, expected);
+    assert_eq!(result_limbs, expected_limbs);
+
+    helper.drop_all_buffers();
+}
+
+fn generate_test_values(in_range_p_to_2p: bool) -> (BigInt<4>, BigInt<4>) {
     let p = BaseField::MODULUS;
-    let mut two_p = p.clone();
-    two_p.add_with_carry(&p);
 
     let mut rng = rand::thread_rng();
     let raw_a = BigInt::<4>::rand(&mut rng);
-
-    // Ensure a is non-negative
     assert!(raw_a >= BigInt::from(0u64), "a must be non-negative");
 
-    // Perform a % p
+    // a % p
     let mut a = raw_a.clone();
-
-    // While result >= p, subtract p
     while a >= p {
         a.sub_with_borrow(&p);
     }
+
+    // At this point, a is in range [0, p)
     let expected = a.clone();
-    let expected_limbs = a.to_limbs(num_limbs, log_limb_size);
 
-    // Adding p to a to ensure a is in the range [p, 2p)
-    a.add_with_carry(&p);
+    // add p to a if we want to test the range [p, 2p)
+    if in_range_p_to_2p {
+        a.add_with_carry(&p);
+        let mut two_p = p.clone();
+        two_p.add_with_carry(&p);
 
-    // Ensure expected is non-negative and less than p
-    assert!(a >= BigInt::from(0u64), "a must be non-negative");
-    assert!(a < two_p, "a must be less than 2p");
-    assert!(a >= p, "a must be greater than or equal to p");
+        assert!(a >= p, "a must be greater than or equal to p");
+        assert!(a < two_p, "a must be less than 2p");
+    } else {
+        assert!(a >= BigInt::from(0u64), "a must be non-negative");
+        assert!(a < p, "a must be less than p");
+    }
 
-    let a_limbs = a.to_limbs(num_limbs, log_limb_size);
-    let device = get_default_device();
-    let a_buf = create_buffer(&device, &a_limbs);
-    let result_buf = create_empty_buffer(&device, num_limbs);
-
-    let command_queue = device.new_command_queue();
-    let command_buffer = command_queue.new_command_buffer();
-
-    let compute_pass_descriptor = ComputePassDescriptor::new();
-    let encoder = command_buffer.compute_command_encoder_with_descriptor(compute_pass_descriptor);
-
-    write_constants(
-        "../mopro-msm/src/msm/metal_msm/shader",
-        num_limbs,
-        log_limb_size,
-        0,
-        0,
-    );
-    let library_path = compile_metal(
-        "../mopro-msm/src/msm/metal_msm/shader/field",
-        "ff_reduce.metal",
-    );
-    let library = device.new_library_with_file(library_path).unwrap();
-    let kernel = library.get_function("run", None).unwrap();
-
-    let pipeline_state_descriptor = ComputePipelineDescriptor::new();
-    pipeline_state_descriptor.set_compute_function(Some(&kernel));
-
-    let pipeline_state = device
-        .new_compute_pipeline_state_with_function(
-            pipeline_state_descriptor.compute_function().unwrap(),
-        )
-        .unwrap();
-
-    encoder.set_compute_pipeline_state(&pipeline_state);
-    encoder.set_buffer(0, Some(&a_buf), 0);
-    encoder.set_buffer(1, Some(&result_buf), 0);
-
-    let thread_group_count = MTLSize {
-        width: 1,
-        height: 1,
-        depth: 1,
-    };
-
-    let thread_group_size = MTLSize {
-        width: 1,
-        height: 1,
-        depth: 1,
-    };
-
-    encoder.dispatch_thread_groups(thread_group_count, thread_group_size);
-    encoder.end_encoding();
-
-    command_buffer.commit();
-    command_buffer.wait_until_completed();
-
-    let result_limbs: Vec<u32> = read_buffer(&result_buf, num_limbs);
-    let result = BigInt::from_limbs(&result_limbs, log_limb_size);
-
-    assert!(result == expected);
-    assert!(result_limbs == expected_limbs);
-
-    // Drop the buffers after reading the results
-    drop(a_buf);
-    drop(result_buf);
-    drop(command_queue);
+    (a, expected)
 }

--- a/mopro-msm/src/msm/metal_msm/tests/field/ff_sub.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/field/ff_sub.rs
@@ -1,29 +1,29 @@
-// adapted from: https://github.com/geometryxyz/msl-secp256k1
-
-use crate::msm::metal_msm::host::gpu::{
-    create_buffer, create_empty_buffer, get_default_device, read_buffer,
-};
-use crate::msm::metal_msm::host::shader::{compile_metal, write_constants};
+use crate::msm::metal_msm::tests::common::*;
 use crate::msm::metal_msm::utils::limbs_conversion::GenericLimbConversion;
+
 use ark_bn254::Fq as BaseField;
 use ark_ff::{BigInt, BigInteger, PrimeField, UniformRand};
 use ark_std::rand;
-use metal::*;
 
 #[test]
 #[serial_test::serial]
 pub fn test_ff_sub() {
-    let log_limb_size = 16;
-    let num_limbs = 16;
+    let config = MetalTestConfig {
+        log_limb_size: 16,
+        num_limbs: 16,
+        shader_file: "field/ff_sub.metal".to_string(),
+        kernel_name: "run".to_string(),
+    };
 
-    // Scalar field modulus for bn254
+    let mut helper = MetalTestHelper::new();
+
     let p = BaseField::MODULUS;
 
     let mut rng = rand::thread_rng();
     let mut a = BigInt::<4>::rand(&mut rng);
     let mut b = BigInt::<4>::rand(&mut rng);
 
-    // Reduce a and b if they are greater than or equal to the prime field modulus
+    // a % p
     while a >= p {
         a.sub_with_borrow(&p);
     }
@@ -38,10 +38,9 @@ pub fn test_ff_sub() {
     assert!(a < p, "a must be less than p");
     assert!(b < p, "b must be less than p");
 
-    let device = get_default_device();
-    let a_buf = create_buffer(&device, &a.to_limbs(num_limbs, log_limb_size));
-    let b_buf = create_buffer(&device, &b.to_limbs(num_limbs, log_limb_size));
-    let result_buf = create_empty_buffer(&device, num_limbs);
+    let a_buf = helper.create_input_buffer(&a.to_limbs(config.num_limbs, config.log_limb_size));
+    let b_buf = helper.create_input_buffer(&b.to_limbs(config.num_limbs, config.log_limb_size));
+    let result_buf = helper.create_output_buffer(config.num_limbs);
 
     // (a - b) % p
     let mut expected = a.clone();
@@ -68,69 +67,24 @@ pub fn test_ff_sub() {
     let expected_field = a_field - b_field;
     assert!(expected_field == expected.into());
 
-    let expected_limbs = expected.to_limbs(num_limbs, log_limb_size);
+    let expected_limbs = expected.to_limbs(config.num_limbs, config.log_limb_size);
 
-    let command_queue = device.new_command_queue();
-    let command_buffer = command_queue.new_command_buffer();
+    let thread_group_count = helper.create_thread_group_size(1, 1, 1);
+    let thread_group_size = helper.create_thread_group_size(1, 1, 1);
 
-    let compute_pass_descriptor = ComputePassDescriptor::new();
-    let encoder = command_buffer.compute_command_encoder_with_descriptor(compute_pass_descriptor);
-
-    write_constants(
-        "../mopro-msm/src/msm/metal_msm/shader",
-        num_limbs,
-        log_limb_size,
-        0,
-        0,
+    helper.execute_shader(
+        &config,
+        &[&a_buf, &b_buf],
+        &[&result_buf],
+        &thread_group_count,
+        &thread_group_size,
     );
-    let library_path = compile_metal(
-        "../mopro-msm/src/msm/metal_msm/shader/field",
-        "ff_sub.metal",
-    );
-    let library = device.new_library_with_file(library_path).unwrap();
-    let kernel = library.get_function("run", None).unwrap();
 
-    let pipeline_state_descriptor = ComputePipelineDescriptor::new();
-    pipeline_state_descriptor.set_compute_function(Some(&kernel));
-
-    let pipeline_state = device
-        .new_compute_pipeline_state_with_function(
-            pipeline_state_descriptor.compute_function().unwrap(),
-        )
-        .unwrap();
-
-    encoder.set_compute_pipeline_state(&pipeline_state);
-    encoder.set_buffer(0, Some(&a_buf), 0);
-    encoder.set_buffer(1, Some(&b_buf), 0);
-    encoder.set_buffer(2, Some(&result_buf), 0);
-
-    let thread_group_count = MTLSize {
-        width: 1,
-        height: 1,
-        depth: 1,
-    };
-
-    let thread_group_size = MTLSize {
-        width: 1,
-        height: 1,
-        depth: 1,
-    };
-
-    encoder.dispatch_thread_groups(thread_group_count, thread_group_size);
-    encoder.end_encoding();
-
-    command_buffer.commit();
-    command_buffer.wait_until_completed();
-
-    let result_limbs: Vec<u32> = read_buffer(&result_buf, num_limbs);
-    let result = BigInt::from_limbs(&result_limbs, log_limb_size);
+    let result_limbs = helper.read_results(&result_buf, config.num_limbs);
+    let result = BigInt::from_limbs(&result_limbs, config.log_limb_size);
 
     assert!(result == expected);
     assert!(result_limbs == expected_limbs);
 
-    // Drop the buffers after reading the results
-    drop(a_buf);
-    drop(b_buf);
-    drop(result_buf);
-    drop(command_queue);
+    helper.drop_all_buffers();
 }

--- a/mopro-msm/src/msm/metal_msm/tests/field/ff_sub.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/field/ff_sub.rs
@@ -127,4 +127,10 @@ pub fn test_ff_sub() {
 
     assert!(result == expected);
     assert!(result_limbs == expected_limbs);
+
+    // Drop the buffers after reading the results
+    drop(a_buf);
+    drop(b_buf);
+    drop(result_buf);
+    drop(command_queue);
 }

--- a/mopro-msm/src/msm/metal_msm/tests/misc/get_constant.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/misc/get_constant.rs
@@ -72,6 +72,10 @@ pub fn test_get_n0() {
 
     assert_eq!(result, expected);
     assert_eq!(result_limbs, expected_limbs);
+
+    // Drop the buffers after reading the results
+    drop(result_buf);
+    drop(command_queue);
 }
 
 #[test]
@@ -132,6 +136,10 @@ pub fn test_get_p() {
 
     assert_eq!(result_limbs, expected_limbs);
     assert_eq!(result, expected);
+
+    // Drop the buffers after reading the results
+    drop(result_buf);
+    drop(command_queue);
 }
 
 /// for 16-bit limbs, r has 257 bits
@@ -195,6 +203,10 @@ pub fn test_get_r() {
 
     assert_eq!(result_limbs, expected_limbs);
     assert_eq!(result, expected);
+
+    // Drop the buffers after reading the results
+    drop(result_buf);
+    drop(command_queue);
 }
 
 #[test]
@@ -255,6 +267,10 @@ pub fn test_get_p_wide() {
 
     assert_eq!(result_limbs, expected_limbs);
     assert_eq!(result, expected);
+
+    // Drop the buffers after reading the results
+    drop(result_buf);
+    drop(command_queue);
 }
 
 #[test]
@@ -321,6 +337,12 @@ pub fn test_get_bn254_zero() {
     let result = G::new(result_x.into(), result_y.into(), result_z.into());
     let expected = G::zero();
     assert!(result == expected);
+
+    // Drop the buffers after reading the results
+    drop(result_x_buf);
+    drop(result_y_buf);
+    drop(result_z_buf);
+    drop(command_queue);
 }
 
 #[test]
@@ -387,6 +409,12 @@ pub fn test_get_bn254_one() {
     let result = G::new(result_x.into(), result_y.into(), result_z.into());
     let expected = G::generator();
     assert!(result == expected);
+
+    // Drop the buffers after reading the results
+    drop(result_x_buf);
+    drop(result_y_buf);
+    drop(result_z_buf);
+    drop(command_queue);
 }
 
 #[test]
@@ -466,6 +494,12 @@ pub fn test_get_bn254_zero_mont() {
     let result = G::new(result_x.into(), result_y.into(), result_z.into());
     let expected = G::zero();
     assert!(result == expected);
+
+    // Drop the buffers after reading the results
+    drop(result_xr_buf);
+    drop(result_yr_buf);
+    drop(result_zr_buf);
+    drop(command_queue);
 }
 
 #[test]
@@ -545,6 +579,12 @@ pub fn test_get_bn254_one_mont() {
     let result = G::new(result_x.into(), result_y.into(), result_z.into());
     let expected = G::generator();
     assert!(result == expected);
+
+    // Drop the buffers after reading the results
+    drop(result_xr_buf);
+    drop(result_yr_buf);
+    drop(result_zr_buf);
+    drop(command_queue);
 }
 
 #[test]
@@ -606,6 +646,10 @@ pub fn test_get_mu() {
 
     assert_eq!(result_limbs, expected_limbs);
     assert_eq!(result, expected_mu);
+
+    // Drop the buffers after reading the results
+    drop(result_buf);
+    drop(command_queue);
 }
 
 // Helper to calculate constants

--- a/mopro-msm/src/msm/metal_msm/tests/misc/get_constant.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/misc/get_constant.rs
@@ -1,673 +1,368 @@
-use crate::msm::metal_msm::host::gpu::{create_empty_buffer, get_default_device, read_buffer};
-use crate::msm::metal_msm::host::shader::{compile_metal, write_constants};
-use crate::msm::metal_msm::utils::barrett_params::calc_barrett_mu;
+use crate::msm::metal_msm::tests::common::*;
 use crate::msm::metal_msm::utils::limbs_conversion::GenericLimbConversion;
-use crate::msm::metal_msm::utils::mont_params::{calc_mont_radix, calc_nsafe, calc_rinv_and_n0};
+
 use ark_bn254::{Fq as BaseField, G1Projective as G};
 use ark_ec::Group;
 use ark_ff::{BigInt, PrimeField, Zero};
-use metal::*;
 use num_bigint::BigUint;
 
 const NUM_LIMBS: usize = 16;
 const NUM_LIMBS_WIDE: usize = 17;
 const LOG_LIMB_SIZE: u32 = 16;
+const SHADER_FILE: &str = "misc/test_get_constant.metal";
 
 #[test]
 #[serial_test::serial]
 pub fn test_get_n0() {
-    prepare_constants(NUM_LIMBS, LOG_LIMB_SIZE);
+    let config = MetalTestConfig {
+        log_limb_size: LOG_LIMB_SIZE,
+        num_limbs: NUM_LIMBS,
+        shader_file: SHADER_FILE.to_string(),
+        kernel_name: "test_get_n0".to_string(),
+    };
 
-    let device = get_default_device();
-    let result_buf = create_empty_buffer(&device, NUM_LIMBS);
+    let mut helper = MetalTestHelper::new();
+    let result_buf = helper.create_output_buffer(config.num_limbs);
 
-    let command_queue = device.new_command_queue();
-    let command_buffer = command_queue.new_command_buffer();
-    let compute_pass_descriptor = ComputePassDescriptor::new();
-    let encoder = command_buffer.compute_command_encoder_with_descriptor(compute_pass_descriptor);
+    let thread_group_count = helper.create_thread_group_size(1, 1, 1);
+    let thread_group_size = helper.create_thread_group_size(1, 1, 1);
 
-    let library_path = compile_metal(
-        "../mopro-msm/src/msm/metal_msm/shader/misc",
-        "test_get_constant.metal",
+    helper.execute_shader(
+        &config,
+        &[],
+        &[&result_buf],
+        &thread_group_count,
+        &thread_group_size,
     );
-    let library = device.new_library_with_file(library_path).unwrap();
-    let kernel = library.get_function("test_get_n0", None).unwrap();
 
-    let pipeline_state_descriptor = ComputePipelineDescriptor::new();
-    pipeline_state_descriptor.set_compute_function(Some(&kernel));
+    let result_limbs = helper.read_results(&result_buf, config.num_limbs);
+    let result = BigInt::<4>::from_limbs(&result_limbs, config.log_limb_size);
 
-    let pipeline_state = device
-        .new_compute_pipeline_state_with_function(
-            pipeline_state_descriptor.compute_function().unwrap(),
-        )
-        .unwrap();
-
-    encoder.set_compute_pipeline_state(&pipeline_state);
-    encoder.set_buffer(0, Some(&result_buf), 0);
-
-    let thread_group_count = MTLSize {
-        width: 1,
-        height: 1,
-        depth: 1,
-    };
-
-    let thread_group_size = MTLSize {
-        width: 1,
-        height: 1,
-        depth: 1,
-    };
-
-    encoder.dispatch_thread_groups(thread_group_count, thread_group_size);
-    encoder.end_encoding();
-
-    command_buffer.commit();
-    command_buffer.wait_until_completed();
-
-    let result_limbs: Vec<u32> = read_buffer(&result_buf, NUM_LIMBS);
-    let result = BigInt::<4>::from_limbs(&result_limbs, LOG_LIMB_SIZE);
-
-    let (_, _, _, n0, _) = calc_constants(NUM_LIMBS, LOG_LIMB_SIZE);
-    let expected = BigInt::<4>::from(n0);
-    let expected_limbs = expected.to_limbs(NUM_LIMBS, LOG_LIMB_SIZE);
+    let constants = get_or_calc_constants(NUM_LIMBS, LOG_LIMB_SIZE);
+    let expected = BigInt::<4>::from(constants.n0);
+    let expected_limbs = expected.to_limbs(config.num_limbs, config.log_limb_size);
 
     assert_eq!(result, expected);
     assert_eq!(result_limbs, expected_limbs);
-
-    // Drop the buffers after reading the results
-    drop(result_buf);
-    drop(command_queue);
+    helper.drop_all_buffers();
 }
 
 #[test]
 #[serial_test::serial]
 pub fn test_get_p() {
-    prepare_constants(NUM_LIMBS, LOG_LIMB_SIZE);
+    let config = MetalTestConfig {
+        log_limb_size: LOG_LIMB_SIZE,
+        num_limbs: NUM_LIMBS,
+        shader_file: SHADER_FILE.to_string(),
+        kernel_name: "test_get_p".to_string(),
+    };
 
-    let device = get_default_device();
-    let result_buf = create_empty_buffer(&device, NUM_LIMBS);
+    let mut helper = MetalTestHelper::new();
+    let result_buf = helper.create_output_buffer(config.num_limbs);
 
-    let command_queue = device.new_command_queue();
-    let command_buffer = command_queue.new_command_buffer();
-    let compute_pass_descriptor = ComputePassDescriptor::new();
-    let encoder = command_buffer.compute_command_encoder_with_descriptor(compute_pass_descriptor);
+    let thread_group_count = helper.create_thread_group_size(1, 1, 1);
+    let thread_group_size = helper.create_thread_group_size(1, 1, 1);
 
-    let library_path = compile_metal(
-        "../mopro-msm/src/msm/metal_msm/shader/misc",
-        "test_get_constant.metal",
+    helper.execute_shader(
+        &config,
+        &[],
+        &[&result_buf],
+        &thread_group_count,
+        &thread_group_size,
     );
-    let library = device.new_library_with_file(library_path).unwrap();
-    let kernel = library.get_function("test_get_p", None).unwrap();
 
-    let pipeline_state_descriptor = ComputePipelineDescriptor::new();
-    pipeline_state_descriptor.set_compute_function(Some(&kernel));
-
-    let pipeline_state = device
-        .new_compute_pipeline_state_with_function(
-            pipeline_state_descriptor.compute_function().unwrap(),
-        )
-        .unwrap();
-
-    encoder.set_compute_pipeline_state(&pipeline_state);
-    encoder.set_buffer(0, Some(&result_buf), 0);
-
-    let thread_group_count = MTLSize {
-        width: 1,
-        height: 1,
-        depth: 1,
-    };
-
-    let thread_group_size = MTLSize {
-        width: 1,
-        height: 1,
-        depth: 1,
-    };
-
-    encoder.dispatch_thread_groups(thread_group_count, thread_group_size);
-    encoder.end_encoding();
-
-    command_buffer.commit();
-    command_buffer.wait_until_completed();
-
-    let result_limbs: Vec<u32> = read_buffer(&result_buf, NUM_LIMBS);
-    let result = BigInt::from_limbs(&result_limbs, LOG_LIMB_SIZE);
+    let result_limbs = helper.read_results(&result_buf, config.num_limbs);
+    let result = BigInt::from_limbs(&result_limbs, config.log_limb_size);
 
     let expected = BaseField::MODULUS;
     let expected_limbs = expected.to_limbs(NUM_LIMBS, LOG_LIMB_SIZE);
 
     assert_eq!(result_limbs, expected_limbs);
     assert_eq!(result, expected);
-
-    // Drop the buffers after reading the results
-    drop(result_buf);
-    drop(command_queue);
+    helper.drop_all_buffers();
 }
 
-/// for 16-bit limbs, r has 257 bits
 #[test]
 #[serial_test::serial]
 pub fn test_get_r() {
-    prepare_constants(NUM_LIMBS, LOG_LIMB_SIZE);
+    let config = MetalTestConfig {
+        log_limb_size: LOG_LIMB_SIZE,
+        num_limbs: NUM_LIMBS,
+        shader_file: SHADER_FILE.to_string(),
+        kernel_name: "test_get_r".to_string(),
+    };
 
-    let device = get_default_device();
-    let result_buf = create_empty_buffer(&device, NUM_LIMBS_WIDE);
+    let mut helper = MetalTestHelper::new();
+    let result_buf = helper.create_output_buffer(NUM_LIMBS_WIDE);
 
-    let command_queue = device.new_command_queue();
-    let command_buffer = command_queue.new_command_buffer();
-    let compute_pass_descriptor = ComputePassDescriptor::new();
-    let encoder = command_buffer.compute_command_encoder_with_descriptor(compute_pass_descriptor);
+    let thread_group_count = helper.create_thread_group_size(1, 1, 1);
+    let thread_group_size = helper.create_thread_group_size(1, 1, 1);
 
-    let library_path = compile_metal(
-        "../mopro-msm/src/msm/metal_msm/shader/misc",
-        "test_get_constant.metal",
+    helper.execute_shader(
+        &config,
+        &[],
+        &[&result_buf],
+        &thread_group_count,
+        &thread_group_size,
     );
-    let library = device.new_library_with_file(library_path).unwrap();
-    let kernel = library.get_function("test_get_r", None).unwrap();
 
-    let pipeline_state_descriptor = ComputePipelineDescriptor::new();
-    pipeline_state_descriptor.set_compute_function(Some(&kernel));
+    let result_limbs = helper.read_results(&result_buf, NUM_LIMBS_WIDE);
+    let result = BigInt::<6>::from_limbs(&result_limbs, config.log_limb_size);
 
-    let pipeline_state = device
-        .new_compute_pipeline_state_with_function(
-            pipeline_state_descriptor.compute_function().unwrap(),
-        )
-        .unwrap();
-
-    encoder.set_compute_pipeline_state(&pipeline_state);
-    encoder.set_buffer(0, Some(&result_buf), 0);
-
-    let thread_group_count = MTLSize {
-        width: 1,
-        height: 1,
-        depth: 1,
-    };
-
-    let thread_group_size = MTLSize {
-        width: 1,
-        height: 1,
-        depth: 1,
-    };
-
-    encoder.dispatch_thread_groups(thread_group_count, thread_group_size);
-    encoder.end_encoding();
-
-    command_buffer.commit();
-    command_buffer.wait_until_completed();
-
-    let result_limbs: Vec<u32> = read_buffer(&result_buf, NUM_LIMBS_WIDE);
-    let result = BigInt::<6>::from_limbs(&result_limbs, LOG_LIMB_SIZE);
-
-    let expected: BigInt<6> = calc_mont_radix(NUM_LIMBS, LOG_LIMB_SIZE)
-        .try_into()
-        .unwrap();
+    let constants = get_or_calc_constants(NUM_LIMBS, LOG_LIMB_SIZE);
+    let expected: BigInt<6> = constants.r.try_into().unwrap();
     let expected_limbs = expected.to_limbs(NUM_LIMBS_WIDE, LOG_LIMB_SIZE);
 
     assert_eq!(result_limbs, expected_limbs);
     assert_eq!(result, expected);
-
-    // Drop the buffers after reading the results
-    drop(result_buf);
-    drop(command_queue);
+    helper.drop_all_buffers();
 }
 
 #[test]
 #[serial_test::serial]
 pub fn test_get_p_wide() {
-    prepare_constants(NUM_LIMBS, LOG_LIMB_SIZE);
+    let config = MetalTestConfig {
+        log_limb_size: LOG_LIMB_SIZE,
+        num_limbs: NUM_LIMBS_WIDE,
+        shader_file: SHADER_FILE.to_string(),
+        kernel_name: "test_get_p_wide".to_string(),
+    };
 
-    let device = get_default_device();
-    let result_buf = create_empty_buffer(&device, NUM_LIMBS_WIDE);
+    let mut helper = MetalTestHelper::new();
+    let result_buf = helper.create_output_buffer(config.num_limbs);
 
-    let command_queue = device.new_command_queue();
-    let command_buffer = command_queue.new_command_buffer();
-    let compute_pass_descriptor = ComputePassDescriptor::new();
-    let encoder = command_buffer.compute_command_encoder_with_descriptor(compute_pass_descriptor);
+    let thread_group_count = helper.create_thread_group_size(1, 1, 1);
+    let thread_group_size = helper.create_thread_group_size(1, 1, 1);
 
-    let library_path = compile_metal(
-        "../mopro-msm/src/msm/metal_msm/shader/misc",
-        "test_get_constant.metal",
+    helper.execute_shader(
+        &config,
+        &[],
+        &[&result_buf],
+        &thread_group_count,
+        &thread_group_size,
     );
-    let library = device.new_library_with_file(library_path).unwrap();
-    let kernel = library.get_function("test_get_p_wide", None).unwrap();
 
-    let pipeline_state_descriptor = ComputePipelineDescriptor::new();
-    pipeline_state_descriptor.set_compute_function(Some(&kernel));
-
-    let pipeline_state = device
-        .new_compute_pipeline_state_with_function(
-            pipeline_state_descriptor.compute_function().unwrap(),
-        )
-        .unwrap();
-
-    encoder.set_compute_pipeline_state(&pipeline_state);
-    encoder.set_buffer(0, Some(&result_buf), 0);
-
-    let thread_group_count = MTLSize {
-        width: 1,
-        height: 1,
-        depth: 1,
-    };
-
-    let thread_group_size = MTLSize {
-        width: 1,
-        height: 1,
-        depth: 1,
-    };
-
-    encoder.dispatch_thread_groups(thread_group_count, thread_group_size);
-    encoder.end_encoding();
-
-    command_buffer.commit();
-    command_buffer.wait_until_completed();
-
-    let result_limbs: Vec<u32> = read_buffer(&result_buf, NUM_LIMBS_WIDE);
-    let result = BigInt::from_limbs(&result_limbs, LOG_LIMB_SIZE);
+    let result_limbs = helper.read_results(&result_buf, config.num_limbs);
+    let result = BigInt::from_limbs(&result_limbs, config.log_limb_size);
 
     let expected = BaseField::MODULUS;
     let expected_limbs = expected.to_limbs(NUM_LIMBS_WIDE, LOG_LIMB_SIZE);
 
     assert_eq!(result_limbs, expected_limbs);
     assert_eq!(result, expected);
-
-    // Drop the buffers after reading the results
-    drop(result_buf);
-    drop(command_queue);
+    helper.drop_all_buffers();
 }
 
 #[test]
 #[serial_test::serial]
 pub fn test_get_bn254_zero() {
-    prepare_constants(NUM_LIMBS, LOG_LIMB_SIZE);
+    let config = MetalTestConfig {
+        log_limb_size: LOG_LIMB_SIZE,
+        num_limbs: NUM_LIMBS,
+        shader_file: SHADER_FILE.to_string(),
+        kernel_name: "test_get_bn254_zero".to_string(),
+    };
 
-    let device = get_default_device();
-    let result_x_buf = create_empty_buffer(&device, NUM_LIMBS);
-    let result_y_buf = create_empty_buffer(&device, NUM_LIMBS);
-    let result_z_buf = create_empty_buffer(&device, NUM_LIMBS);
+    let mut helper = MetalTestHelper::new();
+    let x_buf = helper.create_output_buffer(config.num_limbs);
+    let y_buf = helper.create_output_buffer(config.num_limbs);
+    let z_buf = helper.create_output_buffer(config.num_limbs);
 
-    let command_queue = device.new_command_queue();
-    let command_buffer = command_queue.new_command_buffer();
-    let compute_pass_descriptor = ComputePassDescriptor::new();
-    let encoder = command_buffer.compute_command_encoder_with_descriptor(compute_pass_descriptor);
+    let thread_group_count = helper.create_thread_group_size(1, 1, 1);
+    let thread_group_size = helper.create_thread_group_size(1, 1, 1);
 
-    let library_path = compile_metal(
-        "../mopro-msm/src/msm/metal_msm/shader/misc",
-        "test_get_constant.metal",
+    helper.execute_shader(
+        &config,
+        &[],
+        &[&x_buf, &y_buf, &z_buf],
+        &thread_group_count,
+        &thread_group_size,
     );
-    let library = device.new_library_with_file(library_path).unwrap();
-    let kernel = library.get_function("test_get_bn254_zero", None).unwrap();
 
-    let pipeline_state_descriptor = ComputePipelineDescriptor::new();
-    pipeline_state_descriptor.set_compute_function(Some(&kernel));
+    let x_limbs = helper.read_results(&x_buf, config.num_limbs);
+    let y_limbs = helper.read_results(&y_buf, config.num_limbs);
+    let z_limbs = helper.read_results(&z_buf, config.num_limbs);
 
-    let pipeline_state = device
-        .new_compute_pipeline_state_with_function(
-            pipeline_state_descriptor.compute_function().unwrap(),
-        )
-        .unwrap();
-
-    encoder.set_compute_pipeline_state(&pipeline_state);
-    encoder.set_buffer(0, Some(&result_x_buf), 0);
-    encoder.set_buffer(1, Some(&result_y_buf), 0);
-    encoder.set_buffer(2, Some(&result_z_buf), 0);
-
-    let thread_group_count = MTLSize {
-        width: 1,
-        height: 1,
-        depth: 1,
-    };
-
-    let thread_group_size = MTLSize {
-        width: 1,
-        height: 1,
-        depth: 1,
-    };
-
-    encoder.dispatch_thread_groups(thread_group_count, thread_group_size);
-    encoder.end_encoding();
-
-    command_buffer.commit();
-    command_buffer.wait_until_completed();
-
-    let result_x_limbs: Vec<u32> = read_buffer(&result_x_buf, NUM_LIMBS);
-    let result_y_limbs: Vec<u32> = read_buffer(&result_y_buf, NUM_LIMBS);
-    let result_z_limbs: Vec<u32> = read_buffer(&result_z_buf, NUM_LIMBS);
-    let result_x = BigInt::<4>::from_limbs(&result_x_limbs, LOG_LIMB_SIZE);
-    let result_y = BigInt::<4>::from_limbs(&result_y_limbs, LOG_LIMB_SIZE);
-    let result_z = BigInt::<4>::from_limbs(&result_z_limbs, LOG_LIMB_SIZE);
+    let result_x = BigInt::<4>::from_limbs(&x_limbs, config.log_limb_size);
+    let result_y = BigInt::<4>::from_limbs(&y_limbs, config.log_limb_size);
+    let result_z = BigInt::<4>::from_limbs(&z_limbs, config.log_limb_size);
 
     let result = G::new(result_x.into(), result_y.into(), result_z.into());
     let expected = G::zero();
     assert!(result == expected);
-
-    // Drop the buffers after reading the results
-    drop(result_x_buf);
-    drop(result_y_buf);
-    drop(result_z_buf);
-    drop(command_queue);
+    helper.drop_all_buffers();
 }
 
 #[test]
 #[serial_test::serial]
 pub fn test_get_bn254_one() {
-    prepare_constants(NUM_LIMBS, LOG_LIMB_SIZE);
+    let config = MetalTestConfig {
+        log_limb_size: LOG_LIMB_SIZE,
+        num_limbs: NUM_LIMBS,
+        shader_file: SHADER_FILE.to_string(),
+        kernel_name: "test_get_bn254_one".to_string(),
+    };
 
-    let device = get_default_device();
-    let result_x_buf = create_empty_buffer(&device, NUM_LIMBS);
-    let result_y_buf = create_empty_buffer(&device, NUM_LIMBS);
-    let result_z_buf = create_empty_buffer(&device, NUM_LIMBS);
+    let mut helper = MetalTestHelper::new();
+    let x_buf = helper.create_output_buffer(config.num_limbs);
+    let y_buf = helper.create_output_buffer(config.num_limbs);
+    let z_buf = helper.create_output_buffer(config.num_limbs);
 
-    let command_queue = device.new_command_queue();
-    let command_buffer = command_queue.new_command_buffer();
-    let compute_pass_descriptor = ComputePassDescriptor::new();
-    let encoder = command_buffer.compute_command_encoder_with_descriptor(compute_pass_descriptor);
+    let thread_group_count = helper.create_thread_group_size(1, 1, 1);
+    let thread_group_size = helper.create_thread_group_size(1, 1, 1);
 
-    let library_path = compile_metal(
-        "../mopro-msm/src/msm/metal_msm/shader/misc",
-        "test_get_constant.metal",
+    helper.execute_shader(
+        &config,
+        &[],
+        &[&x_buf, &y_buf, &z_buf],
+        &thread_group_count,
+        &thread_group_size,
     );
-    let library = device.new_library_with_file(library_path).unwrap();
-    let kernel = library.get_function("test_get_bn254_one", None).unwrap();
 
-    let pipeline_state_descriptor = ComputePipelineDescriptor::new();
-    pipeline_state_descriptor.set_compute_function(Some(&kernel));
+    let x_limbs = helper.read_results(&x_buf, config.num_limbs);
+    let y_limbs = helper.read_results(&y_buf, config.num_limbs);
+    let z_limbs = helper.read_results(&z_buf, config.num_limbs);
 
-    let pipeline_state = device
-        .new_compute_pipeline_state_with_function(
-            pipeline_state_descriptor.compute_function().unwrap(),
-        )
-        .unwrap();
-
-    encoder.set_compute_pipeline_state(&pipeline_state);
-    encoder.set_buffer(0, Some(&result_x_buf), 0);
-    encoder.set_buffer(1, Some(&result_y_buf), 0);
-    encoder.set_buffer(2, Some(&result_z_buf), 0);
-
-    let thread_group_count = MTLSize {
-        width: 1,
-        height: 1,
-        depth: 1,
-    };
-
-    let thread_group_size = MTLSize {
-        width: 1,
-        height: 1,
-        depth: 1,
-    };
-
-    encoder.dispatch_thread_groups(thread_group_count, thread_group_size);
-    encoder.end_encoding();
-
-    command_buffer.commit();
-    command_buffer.wait_until_completed();
-
-    let result_x_limbs: Vec<u32> = read_buffer(&result_x_buf, NUM_LIMBS);
-    let result_y_limbs: Vec<u32> = read_buffer(&result_y_buf, NUM_LIMBS);
-    let result_z_limbs: Vec<u32> = read_buffer(&result_z_buf, NUM_LIMBS);
-    let result_x = BigInt::<4>::from_limbs(&result_x_limbs, LOG_LIMB_SIZE);
-    let result_y = BigInt::<4>::from_limbs(&result_y_limbs, LOG_LIMB_SIZE);
-    let result_z = BigInt::<4>::from_limbs(&result_z_limbs, LOG_LIMB_SIZE);
-
+    let result_x = BigInt::<4>::from_limbs(&x_limbs, config.log_limb_size);
+    let result_y = BigInt::<4>::from_limbs(&y_limbs, config.log_limb_size);
+    let result_z = BigInt::<4>::from_limbs(&z_limbs, config.log_limb_size);
     let result = G::new(result_x.into(), result_y.into(), result_z.into());
     let expected = G::generator();
     assert!(result == expected);
-
-    // Drop the buffers after reading the results
-    drop(result_x_buf);
-    drop(result_y_buf);
-    drop(result_z_buf);
-    drop(command_queue);
 }
 
 #[test]
 #[serial_test::serial]
 pub fn test_get_bn254_zero_mont() {
-    prepare_constants(NUM_LIMBS, LOG_LIMB_SIZE);
+    let config = MetalTestConfig {
+        log_limb_size: LOG_LIMB_SIZE,
+        num_limbs: NUM_LIMBS,
+        shader_file: SHADER_FILE.to_string(),
+        kernel_name: "test_get_bn254_zero_mont".to_string(),
+    };
 
-    let device = get_default_device();
-    let result_xr_buf = create_empty_buffer(&device, NUM_LIMBS);
-    let result_yr_buf = create_empty_buffer(&device, NUM_LIMBS);
-    let result_zr_buf = create_empty_buffer(&device, NUM_LIMBS);
+    let mut helper = MetalTestHelper::new();
+    let x_buf = helper.create_output_buffer(config.num_limbs);
+    let y_buf = helper.create_output_buffer(config.num_limbs);
+    let z_buf = helper.create_output_buffer(config.num_limbs);
 
-    let command_queue = device.new_command_queue();
-    let command_buffer = command_queue.new_command_buffer();
-    let compute_pass_descriptor = ComputePassDescriptor::new();
-    let encoder = command_buffer.compute_command_encoder_with_descriptor(compute_pass_descriptor);
+    let thread_group_count = helper.create_thread_group_size(1, 1, 1);
+    let thread_group_size = helper.create_thread_group_size(1, 1, 1);
 
-    let library_path = compile_metal(
-        "../mopro-msm/src/msm/metal_msm/shader/misc",
-        "test_get_constant.metal",
+    helper.execute_shader(
+        &config,
+        &[],
+        &[&x_buf, &y_buf, &z_buf],
+        &thread_group_count,
+        &thread_group_size,
     );
-    let library = device.new_library_with_file(library_path).unwrap();
-    let kernel = library
-        .get_function("test_get_bn254_zero_mont", None)
-        .unwrap();
 
-    let pipeline_state_descriptor = ComputePipelineDescriptor::new();
-    pipeline_state_descriptor.set_compute_function(Some(&kernel));
+    let x_limbs = helper.read_results(&x_buf, config.num_limbs);
+    let y_limbs = helper.read_results(&y_buf, config.num_limbs);
+    let z_limbs = helper.read_results(&z_buf, config.num_limbs);
 
-    let pipeline_state = device
-        .new_compute_pipeline_state_with_function(
-            pipeline_state_descriptor.compute_function().unwrap(),
-        )
-        .unwrap();
-
-    encoder.set_compute_pipeline_state(&pipeline_state);
-    encoder.set_buffer(0, Some(&result_xr_buf), 0);
-    encoder.set_buffer(1, Some(&result_yr_buf), 0);
-    encoder.set_buffer(2, Some(&result_zr_buf), 0);
-
-    let thread_group_count = MTLSize {
-        width: 1,
-        height: 1,
-        depth: 1,
-    };
-
-    let thread_group_size = MTLSize {
-        width: 1,
-        height: 1,
-        depth: 1,
-    };
-
-    encoder.dispatch_thread_groups(thread_group_count, thread_group_size);
-    encoder.end_encoding();
-
-    command_buffer.commit();
-    command_buffer.wait_until_completed();
-
-    let result_xr_limbs: Vec<u32> = read_buffer(&result_xr_buf, NUM_LIMBS);
-    let result_yr_limbs: Vec<u32> = read_buffer(&result_yr_buf, NUM_LIMBS);
-    let result_zr_limbs: Vec<u32> = read_buffer(&result_zr_buf, NUM_LIMBS);
-    let result_xr: BigUint = BigInt::<4>::from_limbs(&result_xr_limbs, LOG_LIMB_SIZE)
+    let result_x: BigUint = BigInt::<4>::from_limbs(&x_limbs, config.log_limb_size)
         .try_into()
         .unwrap();
-    let result_yr: BigUint = BigInt::<4>::from_limbs(&result_yr_limbs, LOG_LIMB_SIZE)
+    let result_y: BigUint = BigInt::<4>::from_limbs(&y_limbs, config.log_limb_size)
         .try_into()
         .unwrap();
-    let result_zr: BigUint = BigInt::<4>::from_limbs(&result_zr_limbs, LOG_LIMB_SIZE)
+    let result_z: BigUint = BigInt::<4>::from_limbs(&z_limbs, config.log_limb_size)
         .try_into()
         .unwrap();
 
-    let (p, _, rinv, _, _) = calc_constants(NUM_LIMBS, LOG_LIMB_SIZE);
-    let result_x = (result_xr * &rinv) % &p;
-    let result_y = (result_yr * &rinv) % &p;
-    let result_z = (result_zr * &rinv) % &p;
+    let constants = get_or_calc_constants(NUM_LIMBS, LOG_LIMB_SIZE);
+    let result_x = (result_x * &constants.rinv) % &constants.p;
+    let result_y = (result_y * &constants.rinv) % &constants.p;
+    let result_z = (result_z * &constants.rinv) % &constants.p;
 
     let result = G::new(result_x.into(), result_y.into(), result_z.into());
     let expected = G::zero();
     assert!(result == expected);
-
-    // Drop the buffers after reading the results
-    drop(result_xr_buf);
-    drop(result_yr_buf);
-    drop(result_zr_buf);
-    drop(command_queue);
 }
 
 #[test]
 #[serial_test::serial]
 pub fn test_get_bn254_one_mont() {
-    prepare_constants(NUM_LIMBS, LOG_LIMB_SIZE);
+    let config = MetalTestConfig {
+        log_limb_size: LOG_LIMB_SIZE,
+        num_limbs: NUM_LIMBS,
+        shader_file: SHADER_FILE.to_string(),
+        kernel_name: "test_get_bn254_one_mont".to_string(),
+    };
 
-    let device = get_default_device();
-    let result_xr_buf = create_empty_buffer(&device, NUM_LIMBS);
-    let result_yr_buf = create_empty_buffer(&device, NUM_LIMBS);
-    let result_zr_buf = create_empty_buffer(&device, NUM_LIMBS);
+    let mut helper = MetalTestHelper::new();
+    let x_buf = helper.create_output_buffer(config.num_limbs);
+    let y_buf = helper.create_output_buffer(config.num_limbs);
+    let z_buf = helper.create_output_buffer(config.num_limbs);
 
-    let command_queue = device.new_command_queue();
-    let command_buffer = command_queue.new_command_buffer();
-    let compute_pass_descriptor = ComputePassDescriptor::new();
-    let encoder = command_buffer.compute_command_encoder_with_descriptor(compute_pass_descriptor);
+    let thread_group_count = helper.create_thread_group_size(1, 1, 1);
+    let thread_group_size = helper.create_thread_group_size(1, 1, 1);
 
-    let library_path = compile_metal(
-        "../mopro-msm/src/msm/metal_msm/shader/misc",
-        "test_get_constant.metal",
+    helper.execute_shader(
+        &config,
+        &[],
+        &[&x_buf, &y_buf, &z_buf],
+        &thread_group_count,
+        &thread_group_size,
     );
-    let library = device.new_library_with_file(library_path).unwrap();
-    let kernel = library
-        .get_function("test_get_bn254_one_mont", None)
-        .unwrap();
 
-    let pipeline_state_descriptor = ComputePipelineDescriptor::new();
-    pipeline_state_descriptor.set_compute_function(Some(&kernel));
+    let x_limbs = helper.read_results(&x_buf, config.num_limbs);
+    let y_limbs = helper.read_results(&y_buf, config.num_limbs);
+    let z_limbs = helper.read_results(&z_buf, config.num_limbs);
 
-    let pipeline_state = device
-        .new_compute_pipeline_state_with_function(
-            pipeline_state_descriptor.compute_function().unwrap(),
-        )
-        .unwrap();
-
-    encoder.set_compute_pipeline_state(&pipeline_state);
-    encoder.set_buffer(0, Some(&result_xr_buf), 0);
-    encoder.set_buffer(1, Some(&result_yr_buf), 0);
-    encoder.set_buffer(2, Some(&result_zr_buf), 0);
-
-    let thread_group_count = MTLSize {
-        width: 1,
-        height: 1,
-        depth: 1,
-    };
-
-    let thread_group_size = MTLSize {
-        width: 1,
-        height: 1,
-        depth: 1,
-    };
-
-    encoder.dispatch_thread_groups(thread_group_count, thread_group_size);
-    encoder.end_encoding();
-
-    command_buffer.commit();
-    command_buffer.wait_until_completed();
-
-    let result_xr_limbs: Vec<u32> = read_buffer(&result_xr_buf, NUM_LIMBS);
-    let result_yr_limbs: Vec<u32> = read_buffer(&result_yr_buf, NUM_LIMBS);
-    let result_zr_limbs: Vec<u32> = read_buffer(&result_zr_buf, NUM_LIMBS);
-    let result_xr: BigUint = BigInt::<4>::from_limbs(&result_xr_limbs, LOG_LIMB_SIZE)
+    let result_x: BigUint = BigInt::<4>::from_limbs(&x_limbs, config.log_limb_size)
         .try_into()
         .unwrap();
-    let result_yr: BigUint = BigInt::<4>::from_limbs(&result_yr_limbs, LOG_LIMB_SIZE)
+    let result_y: BigUint = BigInt::<4>::from_limbs(&y_limbs, config.log_limb_size)
         .try_into()
         .unwrap();
-    let result_zr: BigUint = BigInt::<4>::from_limbs(&result_zr_limbs, LOG_LIMB_SIZE)
+    let result_z: BigUint = BigInt::<4>::from_limbs(&z_limbs, config.log_limb_size)
         .try_into()
         .unwrap();
 
-    let (p, _, rinv, _, _) = calc_constants(NUM_LIMBS, LOG_LIMB_SIZE);
-    let result_x = (result_xr * &rinv) % &p;
-    let result_y = (result_yr * &rinv) % &p;
-    let result_z = (result_zr * &rinv) % &p;
+    let constants = get_or_calc_constants(NUM_LIMBS, LOG_LIMB_SIZE);
+    let result_x = (result_x * &constants.rinv) % &constants.p;
+    let result_y = (result_y * &constants.rinv) % &constants.p;
+    let result_z = (result_z * &constants.rinv) % &constants.p;
 
     let result = G::new(result_x.into(), result_y.into(), result_z.into());
     let expected = G::generator();
     assert!(result == expected);
-
-    // Drop the buffers after reading the results
-    drop(result_xr_buf);
-    drop(result_yr_buf);
-    drop(result_zr_buf);
-    drop(command_queue);
 }
 
 #[test]
 #[serial_test::serial]
 pub fn test_get_mu() {
-    prepare_constants(NUM_LIMBS, LOG_LIMB_SIZE);
+    let config = MetalTestConfig {
+        log_limb_size: LOG_LIMB_SIZE,
+        num_limbs: NUM_LIMBS,
+        shader_file: SHADER_FILE.to_string(),
+        kernel_name: "test_get_mu".to_string(),
+    };
 
-    let device = get_default_device();
-    let result_buf = create_empty_buffer(&device, NUM_LIMBS);
+    let mut helper = MetalTestHelper::new();
 
-    let command_queue = device.new_command_queue();
-    let command_buffer = command_queue.new_command_buffer();
-    let compute_pass_descriptor = ComputePassDescriptor::new();
-    let encoder = command_buffer.compute_command_encoder_with_descriptor(compute_pass_descriptor);
+    let result_buf = helper.create_output_buffer(config.num_limbs);
 
-    let library_path = compile_metal(
-        "../mopro-msm/src/msm/metal_msm/shader/misc",
-        "test_get_constant.metal",
+    let thread_group_count = helper.create_thread_group_size(1, 1, 1);
+    let thread_group_size = helper.create_thread_group_size(1, 1, 1);
+
+    helper.execute_shader(
+        &config,
+        &[],
+        &[&result_buf],
+        &thread_group_count,
+        &thread_group_size,
     );
-    let library = device.new_library_with_file(library_path).unwrap();
-    let kernel = library.get_function("test_get_mu", None).unwrap();
 
-    let pipeline_state_descriptor = ComputePipelineDescriptor::new();
-    pipeline_state_descriptor.set_compute_function(Some(&kernel));
+    let result_limbs = helper.read_results(&result_buf, config.num_limbs);
+    let result = BigInt::<4>::from_limbs(&result_limbs, config.log_limb_size);
 
-    let pipeline_state = device
-        .new_compute_pipeline_state_with_function(
-            pipeline_state_descriptor.compute_function().unwrap(),
-        )
-        .unwrap();
-
-    encoder.set_compute_pipeline_state(&pipeline_state);
-    encoder.set_buffer(0, Some(&result_buf), 0);
-
-    let thread_group_count = MTLSize {
-        width: 1,
-        height: 1,
-        depth: 1,
-    };
-
-    let thread_group_size = MTLSize {
-        width: 1,
-        height: 1,
-        depth: 1,
-    };
-
-    encoder.dispatch_thread_groups(thread_group_count, thread_group_size);
-    encoder.end_encoding();
-
-    command_buffer.commit();
-    command_buffer.wait_until_completed();
-
-    let result_limbs: Vec<u32> = read_buffer(&result_buf, NUM_LIMBS);
-    let result = BigInt::from_limbs(&result_limbs, LOG_LIMB_SIZE);
-
-    let p: BigUint = BaseField::MODULUS.try_into().unwrap();
-    let expected_mu: BigInt<4> = calc_barrett_mu(&p).try_into().unwrap();
+    let constants = get_or_calc_constants(NUM_LIMBS, LOG_LIMB_SIZE);
+    let expected_mu: BigInt<4> = constants.mu.try_into().unwrap();
     let expected_limbs = expected_mu.to_limbs(NUM_LIMBS, LOG_LIMB_SIZE);
 
-    assert_eq!(result_limbs, expected_limbs);
+    assert_eq!(*result_limbs, expected_limbs);
     assert_eq!(result, expected_mu);
-
-    // Drop the buffers after reading the results
-    drop(result_buf);
-    drop(command_queue);
-}
-
-// Helper to calculate constants
-fn calc_constants(num_limbs: usize, log_limb_size: u32) -> (BigUint, BigUint, BigUint, u32, usize) {
-    let p: BigUint = BaseField::MODULUS.try_into().unwrap();
-    let r = calc_mont_radix(num_limbs, log_limb_size);
-    let (rinv, n0) = calc_rinv_and_n0(&p, &r, log_limb_size);
-    let nsafe = calc_nsafe(log_limb_size);
-    (p, r, rinv, n0, nsafe)
-}
-
-fn prepare_constants(num_limbs: usize, log_limb_size: u32) {
-    let (_, _, _, n0, nsafe) = calc_constants(num_limbs, log_limb_size);
-    write_constants(
-        "../mopro-msm/src/msm/metal_msm/shader",
-        num_limbs,
-        log_limb_size,
-        n0,
-        nsafe,
-    );
 }

--- a/mopro-msm/src/msm/metal_msm/tests/mod.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/mod.rs
@@ -1,5 +1,7 @@
 #[cfg(test)]
 pub mod bigint;
+/// Common test utilities
+pub mod common;
 #[cfg(test)]
 pub mod curve;
 #[cfg(test)]

--- a/mopro-msm/src/msm/metal_msm/tests/mont_backend/mont_benchmarks.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/mont_backend/mont_benchmarks.rs
@@ -158,12 +158,17 @@ pub fn benchmark(log_limb_size: u32, shader_file: &str) -> Result<i64, String> {
         panic!("Pointer is null");
     }
 
+    // Drop the buffers after reading the results
+    drop(a_buf);
+    drop(b_buf);
+    drop(cost_buf);
+    drop(result_buf);
+    drop(command_queue);
+
     let result = BigInt::<4>::from_limbs(&result_limbs, log_limb_size);
     if result == expected.try_into().unwrap() && result_limbs == expected_limbs {
         Ok(elapsed)
     } else {
         Err("Benchmark failed: results do not match expected values".to_string())
     }
-
-    // return elapsed;
 }

--- a/mopro-msm/src/msm/metal_msm/tests/mont_backend/mont_mul_cios.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/mont_backend/mont_mul_cios.rs
@@ -1,15 +1,9 @@
-// adapted from: https://github.com/geometryxyz/msl-secp256k1
-
-use crate::msm::metal_msm::host::gpu::{
-    create_buffer, create_empty_buffer, get_default_device, read_buffer,
-};
-use crate::msm::metal_msm::host::shader::{compile_metal, write_constants};
+use crate::msm::metal_msm::tests::common::*;
 use crate::msm::metal_msm::utils::limbs_conversion::GenericLimbConversion;
-use crate::msm::metal_msm::utils::mont_params::{calc_mont_radix, calc_nsafe, calc_rinv_and_n0};
+
 use ark_bn254::Fq as BaseField;
 use ark_ff::{BigInt, PrimeField};
-use metal::*;
-use num_bigint::{BigUint, RandBigInt};
+use num_bigint::RandBigInt;
 use rand::thread_rng;
 
 #[test]
@@ -28,21 +22,27 @@ pub fn do_test(log_limb_size: u32) {
     let modulus_bits = BaseField::MODULUS_BIT_SIZE as u32;
     let num_limbs = ((modulus_bits + log_limb_size - 1) / log_limb_size) as usize;
 
-    let r = calc_mont_radix(num_limbs, log_limb_size);
-    let p: BigUint = BaseField::MODULUS.try_into().unwrap();
-    let nsafe = calc_nsafe(log_limb_size);
+    let config = MetalTestConfig {
+        log_limb_size,
+        num_limbs,
+        shader_file: "mont_backend/mont_mul_cios.metal".to_string(),
+        kernel_name: "run".to_string(),
+    };
 
-    let res = calc_rinv_and_n0(&p, &r, log_limb_size);
-    let n0 = res.1;
+    let mut helper = MetalTestHelper::new();
+    let constants = get_or_calc_constants(num_limbs, log_limb_size);
 
+    // Generate random values
     let mut rng = thread_rng();
-    let a = rng.gen_biguint_below(&p);
-    let b = rng.gen_biguint_below(&p);
+    let a = rng.gen_biguint_below(&constants.p);
+    let b = rng.gen_biguint_below(&constants.p);
 
-    let a_r = &a * &r % &p;
-    let b_r = &b * &r % &p;
-    let expected = (&a * &b * &r) % &p;
+    // Convert to Montgomery domain
+    let a_r = (&a * &constants.r) % &constants.p;
+    let b_r = (&b * &constants.r) % &constants.p;
+    let expected = (&a * &b * &constants.r) % &constants.p;
 
+    // Convert to Arkworks types
     let a_r_in_ark = BaseField::from_bigint(a_r.clone().try_into().unwrap()).unwrap();
     let b_r_in_ark = BaseField::from_bigint(b_r.clone().try_into().unwrap()).unwrap();
     let expected_in_ark = BaseField::from_bigint(expected.clone().try_into().unwrap()).unwrap();
@@ -50,78 +50,28 @@ pub fn do_test(log_limb_size: u32) {
         .into_bigint()
         .to_limbs(num_limbs, log_limb_size);
 
-    let device = get_default_device();
-    let a_buf = create_buffer(
-        &device,
-        &a_r_in_ark.into_bigint().to_limbs(num_limbs, log_limb_size),
+    let a_buf =
+        helper.create_input_buffer(&a_r_in_ark.into_bigint().to_limbs(num_limbs, log_limb_size));
+    let b_buf =
+        helper.create_input_buffer(&b_r_in_ark.into_bigint().to_limbs(num_limbs, log_limb_size));
+    let result_buf = helper.create_output_buffer(num_limbs);
+
+    let thread_group_count = helper.create_thread_group_size(1, 1, 1);
+    let thread_group_size = helper.create_thread_group_size(1, 1, 1);
+
+    helper.execute_shader(
+        &config,
+        &[&a_buf, &b_buf],
+        &[&result_buf],
+        &thread_group_count,
+        &thread_group_size,
     );
-    let b_buf = create_buffer(
-        &device,
-        &b_r_in_ark.into_bigint().to_limbs(num_limbs, log_limb_size),
-    );
-    let result_buf = create_empty_buffer(&device, num_limbs);
 
-    let command_queue = device.new_command_queue();
-    let command_buffer = command_queue.new_command_buffer();
-
-    let compute_pass_descriptor = ComputePassDescriptor::new();
-    let encoder = command_buffer.compute_command_encoder_with_descriptor(compute_pass_descriptor);
-
-    write_constants(
-        "../mopro-msm/src/msm/metal_msm/shader",
-        num_limbs,
-        log_limb_size,
-        n0,
-        nsafe,
-    );
-    let library_path = compile_metal(
-        "../mopro-msm/src/msm/metal_msm/shader/mont_backend",
-        "mont_mul_cios.metal",
-    );
-    let library = device.new_library_with_file(library_path).unwrap();
-    let kernel = library.get_function("run", None).unwrap();
-
-    let pipeline_state_descriptor = ComputePipelineDescriptor::new();
-    pipeline_state_descriptor.set_compute_function(Some(&kernel));
-
-    let pipeline_state = device
-        .new_compute_pipeline_state_with_function(
-            pipeline_state_descriptor.compute_function().unwrap(),
-        )
-        .unwrap();
-
-    encoder.set_compute_pipeline_state(&pipeline_state);
-    encoder.set_buffer(0, Some(&a_buf), 0);
-    encoder.set_buffer(1, Some(&b_buf), 0);
-    encoder.set_buffer(2, Some(&result_buf), 0);
-
-    let thread_group_count = MTLSize {
-        width: 1,
-        height: 1,
-        depth: 1,
-    };
-
-    let thread_group_size = MTLSize {
-        width: 1,
-        height: 1,
-        depth: 1,
-    };
-
-    encoder.dispatch_thread_groups(thread_group_count, thread_group_size);
-    encoder.end_encoding();
-
-    command_buffer.commit();
-    command_buffer.wait_until_completed();
-
-    let result_limbs: Vec<u32> = read_buffer(&result_buf, num_limbs);
+    let result_limbs = helper.read_results(&result_buf, num_limbs);
     let result = BigInt::<4>::from_limbs(&result_limbs, log_limb_size);
 
     assert!(result == expected.try_into().unwrap());
     assert!(result_limbs == expected_limbs);
 
-    // Drop the buffers after reading the results
-    drop(a_buf);
-    drop(b_buf);
-    drop(result_buf);
-    drop(command_queue);
+    helper.drop_all_buffers();
 }

--- a/mopro-msm/src/msm/metal_msm/tests/mont_backend/mont_mul_cios.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/mont_backend/mont_mul_cios.rs
@@ -118,4 +118,10 @@ pub fn do_test(log_limb_size: u32) {
 
     assert!(result == expected.try_into().unwrap());
     assert!(result_limbs == expected_limbs);
+
+    // Drop the buffers after reading the results
+    drop(a_buf);
+    drop(b_buf);
+    drop(result_buf);
+    drop(command_queue);
 }

--- a/mopro-msm/src/msm/metal_msm/tests/mont_backend/mont_mul_modified.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/mont_backend/mont_mul_modified.rs
@@ -112,4 +112,10 @@ pub fn do_test(log_limb_size: u32) {
 
     assert!(result == expected.try_into().unwrap());
     assert!(result_limbs == expected_limbs);
+
+    // Drop the buffers after reading the results
+    drop(a_buf);
+    drop(b_buf);
+    drop(result_buf);
+    drop(command_queue);
 }

--- a/mopro-msm/src/msm/metal_msm/tests/mont_backend/mont_mul_modified.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/mont_backend/mont_mul_modified.rs
@@ -1,15 +1,9 @@
-// adapted from: https://github.com/geometryxyz/msl-secp256k1
-
-use crate::msm::metal_msm::host::gpu::{
-    create_buffer, create_empty_buffer, get_default_device, read_buffer,
-};
-use crate::msm::metal_msm::host::shader::{compile_metal, write_constants};
+use crate::msm::metal_msm::tests::common::*;
 use crate::msm::metal_msm::utils::limbs_conversion::GenericLimbConversion;
-use crate::msm::metal_msm::utils::mont_params::{calc_mont_radix, calc_nsafe, calc_rinv_and_n0};
+
 use ark_bn254::Fq as BaseField;
 use ark_ff::{BigInt, PrimeField};
-use metal::*;
-use num_bigint::{BigUint, RandBigInt};
+use num_bigint::RandBigInt;
 use rand::thread_rng;
 
 #[test]
@@ -22,21 +16,27 @@ pub fn do_test(log_limb_size: u32) {
     let modulus_bits = BaseField::MODULUS_BIT_SIZE as u32;
     let num_limbs = ((modulus_bits + log_limb_size - 1) / log_limb_size) as usize;
 
-    let r = calc_mont_radix(num_limbs, log_limb_size);
-    let p: BigUint = BaseField::MODULUS.try_into().unwrap();
-    let nsafe = calc_nsafe(log_limb_size);
+    let config = MetalTestConfig {
+        log_limb_size,
+        num_limbs,
+        shader_file: "mont_backend/mont_mul_modified.metal".to_string(),
+        kernel_name: "run".to_string(),
+    };
 
-    let res = calc_rinv_and_n0(&p, &r, log_limb_size);
-    let n0 = res.1;
+    let mut helper = MetalTestHelper::new();
+    let constants = get_or_calc_constants(num_limbs, log_limb_size);
 
+    // Generate random values
     let mut rng = thread_rng();
-    let a = rng.gen_biguint_below(&p);
-    let b = rng.gen_biguint_below(&p);
+    let a = rng.gen_biguint_below(&constants.p);
+    let b = rng.gen_biguint_below(&constants.p);
 
-    let a_r = &a * &r % &p;
-    let b_r = &b * &r % &p;
-    let expected = (&a * &b * &r) % &p;
+    // Convert to Montgomery domain
+    let a_r = (&a * &constants.r) % &constants.p;
+    let b_r = (&b * &constants.r) % &constants.p;
+    let expected = (&a * &b * &constants.r) % &constants.p;
 
+    // Convert to Arkworks types
     let a_r_in_ark = BaseField::from_bigint(a_r.clone().try_into().unwrap()).unwrap();
     let b_r_in_ark = BaseField::from_bigint(b_r.clone().try_into().unwrap()).unwrap();
     let expected_in_ark = BaseField::from_bigint(expected.clone().try_into().unwrap()).unwrap();
@@ -44,78 +44,28 @@ pub fn do_test(log_limb_size: u32) {
         .into_bigint()
         .to_limbs(num_limbs, log_limb_size);
 
-    let device = get_default_device();
-    let a_buf = create_buffer(
-        &device,
-        &a_r_in_ark.into_bigint().to_limbs(num_limbs, log_limb_size),
+    let a_buf =
+        helper.create_input_buffer(&a_r_in_ark.into_bigint().to_limbs(num_limbs, log_limb_size));
+    let b_buf =
+        helper.create_input_buffer(&b_r_in_ark.into_bigint().to_limbs(num_limbs, log_limb_size));
+    let result_buf = helper.create_output_buffer(num_limbs);
+
+    let thread_group_count = helper.create_thread_group_size(1, 1, 1);
+    let thread_group_size = helper.create_thread_group_size(1, 1, 1);
+
+    helper.execute_shader(
+        &config,
+        &[&a_buf, &b_buf],
+        &[&result_buf],
+        &thread_group_count,
+        &thread_group_size,
     );
-    let b_buf = create_buffer(
-        &device,
-        &b_r_in_ark.into_bigint().to_limbs(num_limbs, log_limb_size),
-    );
-    let result_buf = create_empty_buffer(&device, num_limbs);
 
-    let command_queue = device.new_command_queue();
-    let command_buffer = command_queue.new_command_buffer();
-
-    let compute_pass_descriptor = ComputePassDescriptor::new();
-    let encoder = command_buffer.compute_command_encoder_with_descriptor(compute_pass_descriptor);
-
-    write_constants(
-        "../mopro-msm/src/msm/metal_msm/shader",
-        num_limbs,
-        log_limb_size,
-        n0,
-        nsafe,
-    );
-    let library_path = compile_metal(
-        "../mopro-msm/src/msm/metal_msm/shader/mont_backend",
-        "mont_mul_modified.metal",
-    );
-    let library = device.new_library_with_file(library_path).unwrap();
-    let kernel = library.get_function("run", None).unwrap();
-
-    let pipeline_state_descriptor = ComputePipelineDescriptor::new();
-    pipeline_state_descriptor.set_compute_function(Some(&kernel));
-
-    let pipeline_state = device
-        .new_compute_pipeline_state_with_function(
-            pipeline_state_descriptor.compute_function().unwrap(),
-        )
-        .unwrap();
-
-    encoder.set_compute_pipeline_state(&pipeline_state);
-    encoder.set_buffer(0, Some(&a_buf), 0);
-    encoder.set_buffer(1, Some(&b_buf), 0);
-    encoder.set_buffer(2, Some(&result_buf), 0);
-
-    let thread_group_count = MTLSize {
-        width: 1,
-        height: 1,
-        depth: 1,
-    };
-
-    let thread_group_size = MTLSize {
-        width: 1,
-        height: 1,
-        depth: 1,
-    };
-
-    encoder.dispatch_thread_groups(thread_group_count, thread_group_size);
-    encoder.end_encoding();
-
-    command_buffer.commit();
-    command_buffer.wait_until_completed();
-
-    let result_limbs: Vec<u32> = read_buffer(&result_buf, num_limbs);
+    let result_limbs = helper.read_results(&result_buf, num_limbs);
     let result = BigInt::<4>::from_limbs(&result_limbs, log_limb_size);
 
     assert!(result == expected.try_into().unwrap());
     assert!(result_limbs == expected_limbs);
 
-    // Drop the buffers after reading the results
-    drop(a_buf);
-    drop(b_buf);
-    drop(result_buf);
-    drop(command_queue);
+    helper.drop_all_buffers();
 }

--- a/mopro-msm/src/msm/metal_msm/tests/mont_backend/mont_mul_optimised.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/mont_backend/mont_mul_optimised.rs
@@ -1,18 +1,9 @@
-// adapted from: https://github.com/geometryxyz/msl-secp256k1
-
-// we avoid using ark_ff::BaseField here because the mont radix exceeds the range of its field
-// and we need to use num_bigint::BigUint for better flexibility
-
-use crate::msm::metal_msm::host::gpu::{
-    create_buffer, create_empty_buffer, get_default_device, read_buffer,
-};
-use crate::msm::metal_msm::host::shader::{compile_metal, write_constants};
+use crate::msm::metal_msm::tests::common::*;
 use crate::msm::metal_msm::utils::limbs_conversion::GenericLimbConversion;
-use crate::msm::metal_msm::utils::mont_params::{calc_mont_radix, calc_rinv_and_n0};
+
 use ark_bn254::Fq as BaseField;
 use ark_ff::{BigInt, PrimeField};
-use metal::*;
-use num_bigint::{BigUint, RandBigInt};
+use num_bigint::RandBigInt;
 use rand::thread_rng;
 
 #[test]
@@ -22,24 +13,30 @@ pub fn test_mont_mul_13() {
 }
 
 pub fn do_test(log_limb_size: u32) {
-    // Calculate num_limbs based on modulus size and limb size
     let modulus_bits = BaseField::MODULUS_BIT_SIZE as u32;
     let num_limbs = ((modulus_bits + log_limb_size - 1) / log_limb_size) as usize;
 
-    let r = calc_mont_radix(num_limbs, log_limb_size);
-    let p: BigUint = BaseField::MODULUS.try_into().unwrap();
+    let config = MetalTestConfig {
+        log_limb_size,
+        num_limbs,
+        shader_file: "mont_backend/mont_mul_optimised.metal".to_string(),
+        kernel_name: "run".to_string(),
+    };
 
-    let res = calc_rinv_and_n0(&p, &r, log_limb_size);
-    let n0 = res.1;
+    let mut helper = MetalTestHelper::new();
+    let constants = get_or_calc_constants(num_limbs, log_limb_size);
 
+    // Generate random values
     let mut rng = thread_rng();
-    let a = rng.gen_biguint_below(&p);
-    let b = rng.gen_biguint_below(&p);
+    let a = rng.gen_biguint_below(&constants.p);
+    let b = rng.gen_biguint_below(&constants.p);
 
-    let a_r = &a * &r % &p;
-    let b_r = &b * &r % &p;
-    let expected = (&a * &b * &r) % &p;
+    // Convert to Montgomery domain
+    let a_r = (&a * &constants.r) % &constants.p;
+    let b_r = (&b * &constants.r) % &constants.p;
+    let expected = (&a * &b * &constants.r) % &constants.p;
 
+    // Convert to Arkworks types
     let a_r_in_ark = BaseField::from_bigint(a_r.clone().try_into().unwrap()).unwrap();
     let b_r_in_ark = BaseField::from_bigint(b_r.clone().try_into().unwrap()).unwrap();
     let expected_in_ark = BaseField::from_bigint(expected.clone().try_into().unwrap()).unwrap();
@@ -47,128 +44,28 @@ pub fn do_test(log_limb_size: u32) {
         .into_bigint()
         .to_limbs(num_limbs, log_limb_size);
 
-    let device = get_default_device();
-    let a_buf = create_buffer(
-        &device,
-        &a_r_in_ark.into_bigint().to_limbs(num_limbs, log_limb_size),
+    let a_buf =
+        helper.create_input_buffer(&a_r_in_ark.into_bigint().to_limbs(num_limbs, log_limb_size));
+    let b_buf =
+        helper.create_input_buffer(&b_r_in_ark.into_bigint().to_limbs(num_limbs, log_limb_size));
+    let result_buf = helper.create_output_buffer(num_limbs);
+
+    let thread_group_count = helper.create_thread_group_size(1, 1, 1);
+    let thread_group_size = helper.create_thread_group_size(1, 1, 1);
+
+    helper.execute_shader(
+        &config,
+        &[&a_buf, &b_buf],
+        &[&result_buf],
+        &thread_group_count,
+        &thread_group_size,
     );
-    let b_buf = create_buffer(
-        &device,
-        &b_r_in_ark.into_bigint().to_limbs(num_limbs, log_limb_size),
-    );
-    let result_buf = create_empty_buffer(&device, num_limbs);
 
-    let command_queue = device.new_command_queue();
-    let command_buffer = command_queue.new_command_buffer();
-
-    let compute_pass_descriptor = ComputePassDescriptor::new();
-    let encoder = command_buffer.compute_command_encoder_with_descriptor(compute_pass_descriptor);
-
-    write_constants(
-        "../mopro-msm/src/msm/metal_msm/shader",
-        num_limbs,
-        log_limb_size,
-        n0,
-        1,
-    );
-    let library_path = compile_metal(
-        "../mopro-msm/src/msm/metal_msm/shader/mont_backend",
-        "mont_mul_optimised.metal",
-    );
-    let library = device.new_library_with_file(library_path).unwrap();
-    let kernel = library.get_function("run", None).unwrap();
-
-    let pipeline_state_descriptor = ComputePipelineDescriptor::new();
-    pipeline_state_descriptor.set_compute_function(Some(&kernel));
-
-    let pipeline_state = device
-        .new_compute_pipeline_state_with_function(
-            pipeline_state_descriptor.compute_function().unwrap(),
-        )
-        .unwrap();
-
-    encoder.set_compute_pipeline_state(&pipeline_state);
-    encoder.set_buffer(0, Some(&a_buf), 0);
-    encoder.set_buffer(1, Some(&b_buf), 0);
-    encoder.set_buffer(2, Some(&result_buf), 0);
-
-    let thread_group_count = MTLSize {
-        width: 1,
-        height: 1,
-        depth: 1,
-    };
-
-    let thread_group_size = MTLSize {
-        width: 1,
-        height: 1,
-        depth: 1,
-    };
-
-    encoder.dispatch_thread_groups(thread_group_count, thread_group_size);
-    encoder.end_encoding();
-
-    command_buffer.commit();
-    command_buffer.wait_until_completed();
-
-    let result_limbs: Vec<u32> = read_buffer(&result_buf, num_limbs);
+    let result_limbs = helper.read_results(&result_buf, num_limbs);
     let result = BigInt::<4>::from_limbs(&result_limbs, log_limb_size);
 
     assert!(result == expected.try_into().unwrap());
     assert!(result_limbs == expected_limbs);
 
-    // Drop the buffers after reading the results
-    drop(a_buf);
-    drop(b_buf);
-    drop(result_buf);
-    drop(command_queue);
-}
-
-#[test]
-#[serial_test::serial]
-pub fn test_number_conversions() {
-    // Setup parameters
-    let log_limb_size = 12;
-    let modulus_bits = BaseField::MODULUS_BIT_SIZE as u32;
-    let num_limbs = ((modulus_bits + log_limb_size - 1) / log_limb_size) as usize;
-
-    // Create test values using small numbers for clarity
-    let original_biguint = BigUint::parse_bytes(b"123456789", 10).unwrap();
-
-    // Convert BigUint to BaseField
-    let scalar_field_value =
-        BaseField::from_bigint(original_biguint.clone().try_into().unwrap()).unwrap();
-
-    // Convert BaseField to limbs
-    let limbs = scalar_field_value
-        .into_bigint()
-        .to_limbs(num_limbs, log_limb_size);
-
-    // Convert limbs back to BigUint
-    let converted_biguint: BigUint = BigInt::<4>::from_limbs(&limbs, log_limb_size)
-        .try_into()
-        .unwrap();
-
-    // Verify the round trip conversion
-    assert_eq!(
-        original_biguint, converted_biguint,
-        "Round trip conversion failed: original {} != converted {}",
-        original_biguint, converted_biguint
-    );
-
-    // Test with multiple values to ensure robustness
-    let test_values = vec![
-        BigUint::parse_bytes(b"1", 10).unwrap(),
-        BigUint::parse_bytes(b"12345", 10).unwrap(),
-        BigUint::parse_bytes(b"999999999999", 10).unwrap(),
-    ];
-
-    for value in test_values {
-        let scalar = BaseField::from_bigint(value.clone().try_into().unwrap()).unwrap();
-        let value_limbs = scalar.into_bigint().to_limbs(num_limbs, log_limb_size);
-        let converted: BigUint = BigInt::<4>::from_limbs(&value_limbs, log_limb_size)
-            .try_into()
-            .unwrap();
-
-        assert_eq!(value, converted, "Conversion failed for value {}", value);
-    }
+    helper.drop_all_buffers();
 }

--- a/mopro-msm/src/msm/metal_msm/tests/mont_backend/mont_mul_optimised.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/mont_backend/mont_mul_optimised.rs
@@ -115,6 +115,12 @@ pub fn do_test(log_limb_size: u32) {
 
     assert!(result == expected.try_into().unwrap());
     assert!(result_limbs == expected_limbs);
+
+    // Drop the buffers after reading the results
+    drop(a_buf);
+    drop(b_buf);
+    drop(result_buf);
+    drop(command_queue);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- introduce `mopro-msm/src/msm/metal_msm/tests/common.rs` for cleaner metal test structure and buffer management
- refactor current Rust host code for metal shaders' unit tests accordingly

### Kernel Parameter Reordering:
* [`mopro-msm/src/msm/metal_msm/shader/cuzk/transpose.metal`](diffhunk://#diff-48e19196b71c9643e50e810003e69371e417a86ef8059326837a4dbe2637c282L6-R9): Reordered the kernel parameters to match the new buffer indices.

### Refactoring of Bigint Test Cases:
* [`mopro-msm/src/msm/metal_msm/tests/bigint/bigint_add_unsafe.rs`](diffhunk://#diff-2f17fd548146f8ae80d8b4467a681ec3a63b4fcdbb1192dbef1fece73d05d83cL1-L19): Refactored the test case to use the `MetalTestHelper` class and moved common functionality to shared utility functions. [[1]](diffhunk://#diff-2f17fd548146f8ae80d8b4467a681ec3a63b4fcdbb1192dbef1fece73d05d83cL1-L19) [[2]](diffhunk://#diff-2f17fd548146f8ae80d8b4467a681ec3a63b4fcdbb1192dbef1fece73d05d83cL34-R54)
* [`mopro-msm/src/msm/metal_msm/tests/bigint/bigint_add_wide.rs`](diffhunk://#diff-d8800cbd572836ca6d4b0be3368ca1193347d63809a64d040112ce802db12bb4L1-R68): Refactored the test case to use the `MetalTestHelper` class and shared utility functions. Added a function to generate test values with or without overflow.
* [`mopro-msm/src/msm/metal_msm/tests/bigint/bigint_sub.rs`](diffhunk://#diff-e8f40061eb53f3ae170bfa24961d818594343acfc452db91d71eb2c70232f33aL1-L182): Refactored the test case to use the `MetalTestHelper` class and shared utility functions. Added a function to generate test values with or without underflow.