### PR TITLE
Ci/metal shaders

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -4,6 +4,7 @@ on:
     push:
         branches:
             - main
+            - ci/**
         paths-ignore:
             - "**/*.md"
     pull_request:
@@ -31,19 +32,13 @@ jobs:
             - name: Check formatting
               run: cargo fmt --all -- --check
 
-# TODO: Temporarily disable GPU benchmarks since it's under refactoring
-    # gpu-benchmarks:
-    #     runs-on: macos-latest
-    #     steps:
-    #         - uses: actions/checkout@v4
-    #         - name: Install Rust toolchain
-    #           uses: actions-rs/toolchain@v1
-    #           with:
-    #               toolchain: "1.77"
-    #               override: true
-    #         - name: Run sccache-cache
-    #           uses: mozilla-actions/sccache-action@v0.0.3
-    #         - name: Run GPU Benchmarks tests
-    #           run: |
-    #               cd mopro-msm
-    #               cargo test --release test_msm_correctness -- --nocapture
+    metal-msm-tests:
+        runs-on: macos-latest
+        steps:
+            - uses: actions/checkout@v4
+            - name: Run sccache-cache
+              uses: mozilla-actions/sccache-action@v0.0.3
+            - name: Run Metal MSM tests for Shaders
+              run: |
+                cd mopro-msm
+                cargo test msm::metal_msm::tests


### PR DESCRIPTION
- close #59 

## Summary
1. CI Workflow Changes
   - Added `metal-msm-tests` job that runs tests for Metal MSM Shaders
   - Added `ci/**` to the branches that trigger the workflow on push

2. `Host/Shader.rs` Compilation improvements
   - Only specifies Metal 3.2 and metal-logging flags if macOS version is 15.0 or higher
   - Modified the Metal compilation process to check macOS version