### PR TITLE
Perf/mont mul

### DIFF
--- a/mopro-msm/src/msm/metal_msm/shader/bigint/bigint.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/bigint/bigint.metal
@@ -5,7 +5,7 @@ using namespace metal;
 #include "../misc/get_constant.metal"
 
 
-BigIntResult bigint_add_unsafe(
+inline BigIntResult bigint_add_unsafe(
     BigInt lhs,
     BigInt rhs
 ) {
@@ -20,7 +20,7 @@ BigIntResult bigint_add_unsafe(
     return res;
 }
 
-BigIntResultWide bigint_add_wide(
+inline BigIntResultWide bigint_add_wide(
     BigInt lhs,
     BigInt rhs
 ) {
@@ -38,7 +38,7 @@ BigIntResultWide bigint_add_wide(
     return res;
 }
 
-BigIntResult bigint_sub(
+inline BigIntResult bigint_sub(
     BigInt lhs,
     BigInt rhs
 ) {
@@ -57,7 +57,7 @@ BigIntResult bigint_sub(
 }
 
 
-BigIntResultWide bigint_sub_wide(
+inline BigIntResultWide bigint_sub_wide(
     BigIntWide lhs,
     BigIntWide rhs
 ) {
@@ -75,7 +75,7 @@ BigIntResultWide bigint_sub_wide(
     return res;
 }
 
-bool bigint_gte(
+inline bool bigint_gte(
     BigInt lhs,
     BigInt rhs
 ) {
@@ -88,7 +88,7 @@ bool bigint_gte(
     return true;
 }
 
-bool bigint_wide_gte(
+inline bool bigint_wide_gte(
     BigIntWide lhs,
     BigIntWide rhs
 ) {
@@ -100,7 +100,7 @@ bool bigint_wide_gte(
     return true;
 }
 
-bool bigint_eq(
+inline bool bigint_eq(
     BigInt lhs,
     BigInt rhs
 ) {
@@ -110,7 +110,7 @@ bool bigint_eq(
     return true;
 }
 
-bool is_bigint_zero(BigInt x) {
+inline bool is_bigint_zero(BigInt x) {
     for (uint i = 0; i < NUM_LIMBS; i++) {
         if (x.limbs[i] != 0) return false;
     }
@@ -118,7 +118,7 @@ bool is_bigint_zero(BigInt x) {
 }
 
 // Conversion functions
-BigIntWide bigint_to_wide(BigInt x) {
+inline BigIntWide bigint_to_wide(BigInt x) {
     BigIntWide res = bigint_zero_wide();
     for (uint i = 0; i < NUM_LIMBS; i++) {
         res.limbs[i] = x.limbs[i];
@@ -126,7 +126,7 @@ BigIntWide bigint_to_wide(BigInt x) {
     return res;
 }
 
-BigInt bigint_from_wide(BigIntWide x) {
+inline BigInt bigint_from_wide(BigIntWide x) {
     BigInt res = bigint_zero();
     // ignore the last limb
     for (uint i = 0; i < NUM_LIMBS; i++) {

--- a/mopro-msm/src/msm/metal_msm/shader/curve/jacobian.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/curve/jacobian.metal
@@ -9,33 +9,37 @@ using namespace metal;
 #include "./utils.metal"
 
 Jacobian jacobian_dbl_2009_l(Jacobian pt) {
-    FieldElement x = pt.x;
-    FieldElement y = pt.y;
-    FieldElement z = pt.z;
+    BigInt x = pt.x;
+    BigInt y = pt.y;
+    BigInt z = pt.z;
 
-    FieldElement a = x * x;
-    FieldElement b = y * y;
-    FieldElement c = b * b;
-    FieldElement x1b = x + b;
-    FieldElement x1b2 = x1b * x1b;
-    FieldElement ac = a + c;
-    FieldElement x1b2ac = x1b2 - ac;
-    FieldElement d = x1b2ac + x1b2ac;
-    FieldElement a2 = a + a;
-    FieldElement e = a2 + a;
-    FieldElement f = e * e;
-    FieldElement d2 = d + d;
-    FieldElement x3 = f - d2;
-    FieldElement c2 = c + c;
-    FieldElement c4 = c2 + c2;
-    FieldElement c8 = c4 + c4;
-    FieldElement dx3 = d - x3;
-    FieldElement edx3 = e * dx3;
-    FieldElement y3 = edx3 - c8;
-    FieldElement y1z1 = y * z;
-    FieldElement z3 = y1z1 + y1z1;
+    BigInt a = mont_mul_cios(x, x);
+    BigInt b = mont_mul_cios(y, y);
+    BigInt c = mont_mul_cios(b, b);
+    BigInt x1b = ff_add(x, b);
+    BigInt x1b2 = mont_mul_cios(x1b, x1b);
+    BigInt ac = ff_add(a, c);
+    BigInt x1b2ac = ff_sub(x1b2, ac);
+    BigInt d = ff_add(x1b2ac, x1b2ac);
+    BigInt a2 = ff_add(a, a);
+    BigInt e = ff_add(a2, a);
+    BigInt f = mont_mul_cios(e, e);
+    BigInt d2 = ff_add(d, d);
+    BigInt x3 = ff_sub(f, d2);
+    BigInt c2 = ff_add(c, c);
+    BigInt c4 = ff_add(c2, c2);
+    BigInt c8 = ff_add(c4, c4);
+    BigInt dx3 = ff_sub(d, x3);
+    BigInt edx3 = mont_mul_cios(e, dx3);
+    BigInt y3 = ff_sub(edx3, c8);
+    BigInt y1z1 = mont_mul_cios(y, z);
+    BigInt z3 = ff_add(y1z1, y1z1);
 
-    return Jacobian{ .x = x3, .y = y3, .z = z3 };
+    Jacobian result;
+    result.x = x3;
+    result.y = y3;
+    result.z = z3;
+    return result;
 }
 
 Jacobian jacobian_add_2007_bl(Jacobian a, Jacobian b) {
@@ -43,117 +47,132 @@ Jacobian jacobian_add_2007_bl(Jacobian a, Jacobian b) {
     if (is_jacobian_zero(b)) return a;
     if (a == b) return jacobian_dbl_2009_l(a);
 
-    FieldElement x1 = a.x;
-    FieldElement y1 = a.y;
-    FieldElement z1 = a.z;
-    FieldElement x2 = b.x;
-    FieldElement y2 = b.y;
-    FieldElement z2 = b.z;
+    BigInt x1 = a.x;
+    BigInt y1 = a.y;
+    BigInt z1 = a.z;
+    BigInt x2 = b.x;
+    BigInt y2 = b.y;
+    BigInt z2 = b.z;
 
     // First compute z coordinates
-    FieldElement z1z1 = z1 * z1;
-    FieldElement z2z2 = z2 * z2;
-    FieldElement u1 = x1 * z2z2;
-    FieldElement u2 = x2 * z1z1;
-    FieldElement y1z2 = y1 * z2;
-    FieldElement s1 = y1z2 * z2z2;
+    BigInt z1z1 = mont_mul_cios(z1, z1);
+    BigInt z2z2 = mont_mul_cios(z2, z2);
+    BigInt u1 = mont_mul_cios(x1, z2z2);
+    BigInt u2 = mont_mul_cios(x2, z1z1);
+    BigInt y1z2 = mont_mul_cios(y1, z2);
+    BigInt s1 = mont_mul_cios(y1z2, z2z2);
 
-    FieldElement y2z1 = y2 * z1;
-    FieldElement s2 = y2z1 * z1z1;
-    FieldElement h = u2 - u1;
-    FieldElement h2 = h + h;
-    FieldElement i = h2 * h2;
-    FieldElement j = h * i;
+    BigInt y2z1 = mont_mul_cios(y2, z1);
+    BigInt s2 = mont_mul_cios(y2z1, z1z1);
+    BigInt h = ff_sub(u2, u1);
+    BigInt h2 = ff_add(h, h);
+    BigInt i = mont_mul_cios(h2, h2);
+    BigInt j = mont_mul_cios(h, i);
 
-    FieldElement s2s1 = s2 - s1;
-    FieldElement r = s2s1 + s2s1;
-    FieldElement v = u1 * i;
-    FieldElement v2 = v + v;
-    FieldElement r2 = r * r;
-    FieldElement jv2 = j + v2;
-    FieldElement x3 = r2 - jv2;
+    BigInt s2s1 = ff_sub(s2, s1);
+    BigInt r = ff_add(s2s1, s2s1);
+    BigInt v = mont_mul_cios(u1, i);
+    BigInt v2 = ff_add(v, v);
+    BigInt r2 = mont_mul_cios(r, r);
+    BigInt jv2 = ff_add(j, v2);
+    BigInt x3 = ff_sub(r2, jv2);
 
-    FieldElement vx3 = v - x3;
-    FieldElement rvx3 = r * vx3;
-    FieldElement s12 = s1 + s1;
-    FieldElement s12j = s12 * j;
-    FieldElement y3 = rvx3 - s12j;
+    BigInt vx3 = ff_sub(v, x3);
+    BigInt rvx3 = mont_mul_cios(r, vx3);
+    BigInt s12 = ff_add(s1, s1);
+    BigInt s12j = mont_mul_cios(s12, j);
+    BigInt y3 = ff_sub(rvx3, s12j);
 
-    FieldElement z1z2 = z1 * z2;
-    FieldElement z1z2h = z1z2 * h;
-    FieldElement z3 = z1z2h + z1z2h;
+    BigInt z1z2 = mont_mul_cios(z1, z2);
+    BigInt z1z2h = mont_mul_cios(z1z2, h);
+    BigInt z3 = ff_add(z1z2h, z1z2h);
 
-    return Jacobian{ .x = x3, .y = y3, .z = z3 };
+    Jacobian result;
+    result.x = x3;
+    result.y = y3;
+    result.z = z3;
+    return result;
 }
 
 // Notice that this algo only takes standard form instead of Montgomery form
 // http://www.hyperelliptic.org/EFD/g1p/auto-shortw-jacobian-0.html#addition-madd-2007-bl
 Jacobian jacobian_madd_2007_bl(Jacobian a, Affine b) {
-    FieldElement x1 = a.x;
-    FieldElement y1 = a.y;
-    FieldElement z1 = a.z;
-    FieldElement x2 = b.x;
-    FieldElement y2 = b.y;
+    BigInt x1 = a.x;
+    BigInt y1 = a.y;
+    BigInt z1 = a.z;
+    BigInt x2 = b.x;
+    BigInt y2 = b.y;
 
     // Z1Z1 = Z1^2
-    FieldElement z1z1 = z1 * z1;
+    BigInt z1z1 = mont_mul_cios(z1, z1);
     
     // U2 = X2*Z1Z1
-    FieldElement u2 = x2 * z1z1;
+    BigInt u2 = mont_mul_cios(x2, z1z1);
     
     // S2 = Y2*Z1*Z1Z1
-    FieldElement temp_s2 = y2 * z1;
-    FieldElement s2 = temp_s2 * z1z1;
+    BigInt temp_s2 = mont_mul_cios(y2, z1);
+    BigInt s2 = mont_mul_cios(temp_s2, z1z1);
     
     // H = U2-X1
-    FieldElement h = u2 - x1;
+    BigInt h = ff_sub(u2, x1);
     
     // HH = H^2
-    FieldElement hh = h * h;
+    BigInt hh = mont_mul_cios(h, h);
     
     // I = 4*HH
-    FieldElement i = hh + hh; // *2
-    i = i + i;  // *4
+    BigInt i = ff_add(hh, hh); // *2
+    i = ff_add(i, i);          // *4
     
     // J = H*I
-    FieldElement j = h * i;
+    BigInt j = mont_mul_cios(h, i);
     
     // r = 2*(S2-Y1)
-    FieldElement s2_minus_y1 = s2 - y1;
-    FieldElement r = s2_minus_y1 + s2_minus_y1;
+    BigInt s2_minus_y1 = ff_sub(s2, y1);
+    BigInt r = ff_add(s2_minus_y1, s2_minus_y1);
     
     // V = X1*I
-    FieldElement v = x1 * i;
+    BigInt v = mont_mul_cios(x1, i);
     
     // X3 = r^2-J-2*V
-    FieldElement r2 = r * r;
-    FieldElement v2 = v + v;
-    FieldElement jv2 = j + v2;
-    FieldElement x3 = r2 - jv2;
+    BigInt r2 = mont_mul_cios(r, r);
+    BigInt v2 = ff_add(v, v);
+    BigInt jv2 = ff_add(j, v2);
+    BigInt x3 = ff_sub(r2, jv2);
     
     // Y3 = r*(V-X3)-2*Y1*J
-    FieldElement v_minus_x3 = v - x3;
-    FieldElement r_vmx3 = r * v_minus_x3;
-    FieldElement y1j = y1 * j;
-    FieldElement y1j2 = y1j + y1j;
-    FieldElement y3 = r_vmx3 - y1j2;
+    BigInt v_minus_x3 = ff_sub(v, x3);
+    BigInt r_vmx3 = mont_mul_cios(r, v_minus_x3);
+    BigInt y1j = mont_mul_cios(y1, j);
+    BigInt y1j2 = ff_add(y1j, y1j);
+    BigInt y3 = ff_sub(r_vmx3, y1j2);
     
     // Z3 = (Z1+H)^2-Z1Z1-HH
-    FieldElement z1_plus_h = z1 + h;
-    FieldElement z1_plus_h_squared = z1_plus_h * z1_plus_h;
-    FieldElement temp = z1_plus_h_squared - z1z1;
-    FieldElement z3 = temp - hh;
+    BigInt z1_plus_h = ff_add(z1, h);
+    BigInt z1_plus_h_squared = mont_mul_cios(z1_plus_h, z1_plus_h);
+    BigInt temp = ff_sub(z1_plus_h_squared, z1z1);
+    BigInt z3 = ff_sub(temp, hh);
     
-    return Jacobian{ .x = x3, .y = y3, .z = z3 };
+    Jacobian result;
+    result.x = x3;
+    result.y = y3;
+    result.z = z3;
+    return result;
 }
 
-Jacobian jacobian_scalar_mul(Jacobian point, uint scalar) {
+Jacobian jacobian_scalar_mul(
+    Jacobian pt,
+    uint scalar
+) {
     // Handle special cases first
-    if (scalar == 0 || is_bigint_zero(point.z.value)) return get_bn254_zero_mont();
-    if (scalar == 1) return point;
+    if (scalar == 0 || is_bigint_zero(pt.z)) {
+        return get_bn254_zero_mont();
+    }
+    if (scalar == 1) {
+        return pt;
+    }
 
     Jacobian result = get_bn254_zero_mont();
-    Jacobian temp = point;
+    Jacobian temp = pt;
     uint s = scalar;
 
     while (s > 0) {
@@ -163,17 +182,22 @@ Jacobian jacobian_scalar_mul(Jacobian point, uint scalar) {
         temp = jacobian_dbl_2009_l(temp);
         s = s >> 1;
     }
+    
     return result;
 }
 
-Jacobian jacobian_neg(Jacobian a) {
-    if (is_jacobian_zero(a)) return a;
+Jacobian jacobian_neg(Jacobian pt) {
+    if (is_jacobian_zero(pt)) { return pt; }
 
     // Negate Y (mod p): newY = p - Y
-    FieldElement p = FieldElement{ *get_p() };
-    FieldElement negY = p - a.y;
+    BigInt p = MODULUS;
+    BigInt negY = ff_sub(p, pt.y);
 
-    return Jacobian{ .x = a.x, .y = negY, .z = a.z };
+    Jacobian result;
+    result.x = pt.x;
+    result.y = negY;
+    result.z = pt.z;
+    return result;
 }
 
 // Override operators in Jacobian

--- a/mopro-msm/src/msm/metal_msm/shader/curve/jacobian.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/curve/jacobian.metal
@@ -8,7 +8,7 @@ using namespace metal;
 #include "../mont_backend/mont.metal"
 #include "./utils.metal"
 
-Jacobian jacobian_dbl_2009_l(Jacobian pt) {
+inline Jacobian jacobian_dbl_2009_l(Jacobian pt) {
     BigInt x = pt.x;
     BigInt y = pt.y;
     BigInt z = pt.z;
@@ -42,7 +42,7 @@ Jacobian jacobian_dbl_2009_l(Jacobian pt) {
     return result;
 }
 
-Jacobian jacobian_add_2007_bl(Jacobian a, Jacobian b) {
+inline Jacobian jacobian_add_2007_bl(Jacobian a, Jacobian b) {
     if (is_jacobian_zero(a)) return b;
     if (is_jacobian_zero(b)) return a;
     if (a == b) return jacobian_dbl_2009_l(a);
@@ -96,7 +96,7 @@ Jacobian jacobian_add_2007_bl(Jacobian a, Jacobian b) {
 
 // Notice that this algo only takes standard form instead of Montgomery form
 // http://www.hyperelliptic.org/EFD/g1p/auto-shortw-jacobian-0.html#addition-madd-2007-bl
-Jacobian jacobian_madd_2007_bl(Jacobian a, Affine b) {
+inline Jacobian jacobian_madd_2007_bl(Jacobian a, Affine b) {
     BigInt x1 = a.x;
     BigInt y1 = a.y;
     BigInt z1 = a.z;
@@ -159,7 +159,7 @@ Jacobian jacobian_madd_2007_bl(Jacobian a, Affine b) {
     return result;
 }
 
-Jacobian jacobian_scalar_mul(
+inline Jacobian jacobian_scalar_mul(
     Jacobian pt,
     uint scalar
 ) {
@@ -186,7 +186,7 @@ Jacobian jacobian_scalar_mul(
     return result;
 }
 
-Jacobian jacobian_neg(Jacobian pt) {
+inline Jacobian jacobian_neg(Jacobian pt) {
     if (is_jacobian_zero(pt)) { return pt; }
 
     // Negate Y (mod p): newY = p - Y

--- a/mopro-msm/src/msm/metal_msm/shader/curve/jacobian_add_2007_bl.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/curve/jacobian_add_2007_bl.metal
@@ -17,18 +17,18 @@ kernel void run(
     device BigInt* result_zr [[ buffer(8) ]],
     uint gid [[ thread_position_in_grid ]]
 ) {
-    FieldElement x1 = FieldElement{ *a_xr };
-    FieldElement y1 = FieldElement{ *a_yr };
-    FieldElement z1 = FieldElement{ *a_zr };
-    FieldElement x2 = FieldElement{ *b_xr };
-    FieldElement y2 = FieldElement{ *b_yr };
-    FieldElement z2 = FieldElement{ *b_zr };
+    BigInt x1 = *a_xr;
+    BigInt y1 = *a_yr;
+    BigInt z1 = *a_zr;
+    BigInt x2 = *b_xr;
+    BigInt y2 = *b_yr;
+    BigInt z2 = *b_zr;
 
-    Jacobian a = Jacobian{ .x = x1, .y = y1, .z = z1 };
-    Jacobian b = Jacobian{ .x = x2, .y = y2, .z = z2 };
+    Jacobian a; a.x = x1; a.y = y1; a.z = z1;
+    Jacobian b; b.x = x2; b.y = y2; b.z = z2;
 
-    Jacobian res = a + b;
-    *result_xr = res.x.value;
-    *result_yr = res.y.value;
-    *result_zr = res.z.value;
+    Jacobian res = jacobian_add_2007_bl(a, b);
+    *result_xr = res.x;
+    *result_yr = res.y;
+    *result_zr = res.z;
 }

--- a/mopro-msm/src/msm/metal_msm/shader/curve/jacobian_dbl_2009_l.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/curve/jacobian_dbl_2009_l.metal
@@ -14,14 +14,14 @@ kernel void run(
     device BigInt* result_zr [[ buffer(5) ]],
     uint gid [[ thread_position_in_grid ]]
 ) {
-    FieldElement x1 = FieldElement{ *a_xr };
-    FieldElement y1 = FieldElement{ *a_yr };
-    FieldElement z1 = FieldElement{ *a_zr };
+    BigInt x1 = *a_xr;
+    BigInt y1 = *a_yr;
+    BigInt z1 = *a_zr;
 
-    Jacobian a = Jacobian{ .x = x1, .y = y1, .z = z1 };
+    Jacobian a; a.x = x1; a.y = y1; a.z = z1;
 
     Jacobian res = jacobian_dbl_2009_l(a);
-    *result_xr = res.x.value;
-    *result_yr = res.y.value;
-    *result_zr = res.z.value;
+    *result_xr = res.x;
+    *result_yr = res.y;
+    *result_zr = res.z;
 }

--- a/mopro-msm/src/msm/metal_msm/shader/curve/jacobian_madd_2007_bl.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/curve/jacobian_madd_2007_bl.metal
@@ -16,17 +16,17 @@ kernel void run(
     device BigInt* result_zr [[ buffer(7) ]],
     uint gid [[ thread_position_in_grid ]]
 ) {
-    FieldElement x1 = FieldElement{ *a_xr };
-    FieldElement y1 = FieldElement{ *a_yr };
-    FieldElement z1 = FieldElement{ *a_zr };
-    FieldElement x2 = FieldElement{ *b_xr };
-    FieldElement y2 = FieldElement{ *b_yr };
+    BigInt x1 = *a_xr;
+    BigInt y1 = *a_yr;
+    BigInt z1 = *a_zr;
+    BigInt x2 = *b_xr;
+    BigInt y2 = *b_yr;
 
-    Jacobian a = Jacobian{ .x = x1, .y = y1, .z = z1 };
-    Affine b = Affine{ .x = x2, .y = y2 };
+    Jacobian a; a.x = x1; a.y = y1; a.z = z1;
+    Affine b; b.x = x2; b.y = y2;
 
-    Jacobian res = a + b;
-    *result_xr = res.x.value;
-    *result_yr = res.y.value;
-    *result_zr = res.z.value;
+    Jacobian res = jacobian_madd_2007_bl(a, b);
+    *result_xr = res.x;
+    *result_yr = res.y;
+    *result_zr = res.z;
 }

--- a/mopro-msm/src/msm/metal_msm/shader/curve/jacobian_neg.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/curve/jacobian_neg.metal
@@ -1,5 +1,3 @@
-// source: https://github.com/geometryxyz/msl-secp256k1
-
 using namespace metal;
 #include <metal_stdlib>
 #include <metal_math>
@@ -14,14 +12,14 @@ kernel void run(
     device BigInt* result_zr [[ buffer(5) ]],
     uint gid [[ thread_position_in_grid ]]
 ) {
-    FieldElement x1 = FieldElement{ *a_xr };
-    FieldElement y1 = FieldElement{ *a_yr };
-    FieldElement z1 = FieldElement{ *a_zr };
+    BigInt x1 = *a_xr;
+    BigInt y1 = *a_yr;
+    BigInt z1 = *a_zr;
 
-    Jacobian a = Jacobian{ .x = x1, .y = y1, .z = z1 };
+    Jacobian a; a.x = x1; a.y = y1; a.z = z1;
 
-    Jacobian res = -a;
-    *result_xr = res.x.value;
-    *result_yr = res.y.value;
-    *result_zr = res.z.value;
+    Jacobian res = jacobian_neg(a);
+    *result_xr = res.x;
+    *result_yr = res.y;
+    *result_zr = res.z;
 }

--- a/mopro-msm/src/msm/metal_msm/shader/curve/utils.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/curve/utils.metal
@@ -6,11 +6,11 @@ using namespace metal;
 #include "../bigint/bigint.metal"
 #include "../misc/get_constant.metal"
 
-bool is_jacobian_zero(Jacobian a) {
+inline bool is_jacobian_zero(Jacobian a) {
     return is_bigint_zero(a.z);
 }
 
-bool jacobian_eq(Jacobian lhs, Jacobian rhs) {
+inline bool jacobian_eq(Jacobian lhs, Jacobian rhs) {
     for (uint i = 0; i < NUM_LIMBS; i++) {
         if (lhs.x.limbs[i] != rhs.x.limbs[i]) return false;
         else if (lhs.y.limbs[i] != rhs.y.limbs[i]) return false;

--- a/mopro-msm/src/msm/metal_msm/shader/curve/utils.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/curve/utils.metal
@@ -7,14 +7,14 @@ using namespace metal;
 #include "../misc/get_constant.metal"
 
 bool is_jacobian_zero(Jacobian a) {
-    return is_bigint_zero(a.z.value);
+    return is_bigint_zero(a.z);
 }
 
 bool jacobian_eq(Jacobian lhs, Jacobian rhs) {
     for (uint i = 0; i < NUM_LIMBS; i++) {
-        if (lhs.x.value.limbs[i] != rhs.x.value.limbs[i]) return false;
-        else if (lhs.y.value.limbs[i] != rhs.y.value.limbs[i]) return false;
-        else if (lhs.z.value.limbs[i] != rhs.z.value.limbs[i]) return false;
+        if (lhs.x.limbs[i] != rhs.x.limbs[i]) return false;
+        else if (lhs.y.limbs[i] != rhs.y.limbs[i]) return false;
+        else if (lhs.z.limbs[i] != rhs.z.limbs[i]) return false;
     }
     return true;
 }

--- a/mopro-msm/src/msm/metal_msm/shader/cuzk/barrett_reduction.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/cuzk/barrett_reduction.metal
@@ -106,7 +106,7 @@ BigInt barrett_reduce(BigIntExtraWide a) {
     return ff_reduce(r);
 }
 
-BigInt field_mul(BigIntWide a, BigIntWide b) {
+inline BigInt field_mul(BigIntWide a, BigIntWide b) {
     BigIntExtraWide xy = mul(a, b);
     return barrett_reduce(xy);
 }

--- a/mopro-msm/src/msm/metal_msm/shader/cuzk/barrett_reduction.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/cuzk/barrett_reduction.metal
@@ -75,17 +75,18 @@ BigInt get_higher_with_slack(BigIntExtraWide a) {
     return out;
 }
 
-FieldElement barrett_reduce(BigIntExtraWide a) {
+BigInt barrett_reduce(BigIntExtraWide a) {
     for (uint i = 0; i < NUM_LIMBS; i++) {
         LOG_DEBUG_DUPL("res.limbs[%u] = %u", i, a.limbs[i]);
     }
 
+    BigInt p = MODULUS;
     BigInt mu = get_mu();
 
     BigInt a_hi = get_higher_with_slack(a);
     BigIntExtraWide l = mul(bigint_to_wide(a_hi), bigint_to_wide(mu));
     BigInt l_hi = get_higher_with_slack(l);
-    BigIntExtraWide lp = mul(bigint_to_wide(l_hi), get_p_wide());
+    BigIntExtraWide lp = mul(bigint_to_wide(l_hi), bigint_to_wide(p));
 
     // Subtract lp from original a
     BigIntResultExtraWide sub_result = sub_512(a, lp);
@@ -97,14 +98,15 @@ FieldElement barrett_reduce(BigIntExtraWide a) {
         r_wide = add_512(r_wide, p_wide).value;
     }
 
-    FieldElement res = { bigint_zero() };
+    BigInt r = bigint_zero();
     for (uint i = 0; i < NUM_LIMBS; i++) {
-        res.value.limbs[i] = r_wide.limbs[i];
+        r.limbs[i] = r_wide.limbs[i];
     }
-    return ff_reduce(res);
+
+    return ff_reduce(r);
 }
 
-FieldElement field_mul(BigIntWide a, BigIntWide b) {
+BigInt field_mul(BigIntWide a, BigIntWide b) {
     BigIntExtraWide xy = mul(a, b);
     return barrett_reduce(xy);
 }

--- a/mopro-msm/src/msm/metal_msm/shader/cuzk/convert_point_coords_and_decompose_scalars.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/cuzk/convert_point_coords_and_decompose_scalars.metal
@@ -9,8 +9,8 @@ kernel void convert_point_coords_and_decompose_scalars(
     device const uint* coords           [[buffer(0)]],
     device const uint* scalars          [[buffer(1)]],
     constant uint& input_size           [[buffer(2)]],
-    device FieldElement* point_x        [[buffer(3)]],
-    device FieldElement* point_y        [[buffer(4)]],
+    device BigInt* point_x        [[buffer(3)]],
+    device BigInt* point_y        [[buffer(4)]],
     device uint* chunks                 [[buffer(5)]],
     uint3 gid                           [[thread_position_in_grid]]
 ) {
@@ -61,8 +61,8 @@ kernel void convert_point_coords_and_decompose_scalars(
 
     // Convert x,y to Montgomery form: X = x * R mod p, Y = y * R mod p.
     BigIntWide r = get_r();
-    FieldElement x_mont = field_mul(bigint_to_wide(x_bigint), r);
-    FieldElement y_mont = field_mul(bigint_to_wide(y_bigint), r);
+    BigInt x_mont = field_mul(bigint_to_wide(x_bigint), r);
+    BigInt y_mont = field_mul(bigint_to_wide(y_bigint), r);
 
     // Store them in point_x, point_y
     point_x[id] = x_mont;

--- a/mopro-msm/src/msm/metal_msm/shader/cuzk/extract_word_from_bytes_le.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/cuzk/extract_word_from_bytes_le.metal
@@ -4,7 +4,7 @@ using namespace metal;
 #include <metal_stdlib>
 #include <metal_math>
 
-uint32_t extract_word_from_bytes_le(
+inline uint32_t extract_word_from_bytes_le(
     const thread uint32_t* input,
     uint32_t word_idx,
     uint32_t chunk_size

--- a/mopro-msm/src/msm/metal_msm/shader/cuzk/kernel_barrett_reduction.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/cuzk/kernel_barrett_reduction.metal
@@ -19,6 +19,6 @@ kernel void run(
     device BigInt* res [[ buffer(1) ]],
     uint gid [[ thread_position_in_grid ]]
 ) {
-    *res = barrett_reduce(*a).value;
+    *res = barrett_reduce(*a);
     LOG_DEBUG("pointer: %p", res);
 }

--- a/mopro-msm/src/msm/metal_msm/shader/cuzk/kernel_field_mul.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/cuzk/kernel_field_mul.metal
@@ -9,5 +9,5 @@ kernel void run(
     device BigInt* res [[ buffer(2) ]],
     uint gid [[ thread_position_in_grid ]]
 ) {
-    *res = field_mul(*a, *b).value;
+    *res = field_mul(*a, *b);
 }

--- a/mopro-msm/src/msm/metal_msm/shader/cuzk/pbpr.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/cuzk/pbpr.metal
@@ -4,15 +4,15 @@ using namespace metal;
 #include "../misc/get_constant.metal"
 
 kernel void parallel_bpr(
-    constant FieldElement* buckets_x         [[ buffer(0) ]],
-    constant FieldElement* buckets_y         [[ buffer(1) ]],
-    constant FieldElement* buckets_z         [[ buffer(2) ]],
-    device FieldElement* m_x                 [[ buffer(3) ]],
-    device FieldElement* m_y                 [[ buffer(4) ]],
-    device FieldElement* m_z                 [[ buffer(5) ]],
-    device FieldElement* s_x                 [[ buffer(6) ]],
-    device FieldElement* s_y                 [[ buffer(7) ]],
-    device FieldElement* s_z                 [[ buffer(8) ]],
+    constant BigInt* buckets_x         [[ buffer(0) ]],
+    constant BigInt* buckets_y         [[ buffer(1) ]],
+    constant BigInt* buckets_z         [[ buffer(2) ]],
+    device BigInt* m_x                 [[ buffer(3) ]],
+    device BigInt* m_y                 [[ buffer(4) ]],
+    device BigInt* m_z                 [[ buffer(5) ]],
+    device BigInt* s_x                 [[ buffer(6) ]],
+    device BigInt* s_y                 [[ buffer(7) ]],
+    device BigInt* s_z                 [[ buffer(8) ]],
     constant uint32_t& grid_width      [[ buffer(9) ]],
     constant uint32_t& total_threads   [[ buffer(10) ]],
     constant uint32_t& r               [[ buffer(11) ]],
@@ -28,60 +28,60 @@ kernel void parallel_bpr(
     for (uint32_t l = 1; l <= r; l++) {
         
         Jacobian m_shared = {
-            { m_x[gid].value },
-            { m_y[gid].value },
-            { m_z[gid].value }
+            m_x[gid],
+            m_y[gid],
+            m_z[gid]
         };
 
         Jacobian s_shared = {
-            { s_x[gid].value },
-            { s_y[gid].value },
-            { s_z[gid].value }
+            s_x[gid],
+            s_y[gid],
+            s_z[gid]
         };
 
         Jacobian bucket_val;
 
         if (l != 1) {
-            bucket_val.x.value = buckets_x[(gid + 1) * r - l].value;
-            bucket_val.y.value = buckets_y[(gid + 1) * r - l].value;
-            bucket_val.z.value = buckets_z[(gid + 1) * r - l].value;
+            bucket_val.x = buckets_x[(gid + 1) * r - l];
+            bucket_val.y = buckets_y[(gid + 1) * r - l];
+            bucket_val.z = buckets_z[(gid + 1) * r - l];
             
             m_shared = m_shared + bucket_val;
             s_shared = s_shared + m_shared;
         } else {
-            bucket_val.x.value = buckets_x[(gid + 1) * r - 1].value;
-            bucket_val.y.value = buckets_y[(gid + 1) * r - 1].value;
-            bucket_val.z.value = buckets_z[(gid + 1) * r - 1].value;
+            bucket_val.x = buckets_x[(gid + 1) * r - 1];
+            bucket_val.y = buckets_y[(gid + 1) * r - 1];
+            bucket_val.z = buckets_z[(gid + 1) * r - 1];
             
             m_shared = bucket_val;
             s_shared = m_shared;
         }
         
-        m_x[gid].value = m_shared.x.value;
-        m_y[gid].value = m_shared.y.value;
-        m_z[gid].value = m_shared.z.value;
+        m_x[gid] = m_shared.x;
+        m_y[gid] = m_shared.y;
+        m_z[gid] = m_shared.z;
         
-        s_x[gid].value = s_shared.x.value;
-        s_y[gid].value = s_shared.y.value;
-        s_z[gid].value = s_shared.z.value;
+        s_x[gid] = s_shared.x;
+        s_y[gid] = s_shared.y;
+        s_z[gid] = s_shared.z;
     }
 
     Jacobian final_s = {
-        { s_x[gid].value },
-        { s_y[gid].value },
-        { s_z[gid].value }
+        s_x[gid],
+        s_y[gid],
+        s_z[gid]
     };
 
     Jacobian m = {
-        { m_x[gid].value },
-        { m_y[gid].value },
-        { m_z[gid].value }
+        m_x[gid],
+        m_y[gid],
+        m_z[gid]
     };
 
     uint32_t scalar = gid * r;
     final_s = final_s + jacobian_scalar_mul(m, scalar);
     
-    s_x[gid].value = final_s.x.value;
-    s_y[gid].value = final_s.y.value;
-    s_z[gid].value = final_s.z.value;
+    s_x[gid] = final_s.x;
+    s_y[gid] = final_s.y;
+    s_z[gid] = final_s.z;
 }

--- a/mopro-msm/src/msm/metal_msm/shader/cuzk/smvp.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/cuzk/smvp.metal
@@ -17,11 +17,11 @@ using namespace metal;
 kernel void smvp(
     device const uint*          row_ptr         [[ buffer(0) ]],
     device const uint*          val_idx         [[ buffer(1) ]],
-    device const FieldElement*  new_point_x     [[ buffer(2) ]],
-    device const FieldElement*  new_point_y     [[ buffer(3) ]],
-    device FieldElement*        bucket_x        [[ buffer(4) ]],
-    device FieldElement*        bucket_y        [[ buffer(5) ]],
-    device FieldElement*        bucket_z        [[ buffer(6) ]],
+    device const BigInt*        new_point_x     [[ buffer(2) ]],
+    device const BigInt*        new_point_y     [[ buffer(3) ]],
+    device BigInt*              bucket_x        [[ buffer(4) ]],
+    device BigInt*              bucket_y        [[ buffer(5) ]],
+    device BigInt*              bucket_z        [[ buffer(6) ]],
     constant uint4&             params          [[ buffer(7) ]],
     uint3                       gid             [[thread_position_in_grid]],
     uint3                       tid             [[thread_position_in_threadgroup]]
@@ -78,7 +78,7 @@ kernel void smvp(
             sum = sum + b;
 
             // Debug for correct input points
-            LOG_DEBUG("new_point_x[%u].value.limbs[0]: %u", idx, new_point_x[idx].value.limbs[0]);
+            LOG_DEBUG("new_point_x[%u].limbs[0]: %u", idx, new_point_x[idx].limbs[0]);
         }
 
         // In short Weierstrass, negation = flip sign of Y mod p: jacobian_neg.
@@ -118,7 +118,7 @@ kernel void smvp(
         // Debug for correct sum
         if (id == 0) {
             for (uint i = 0; i < NUM_LIMBS; i++) {
-                LOG_DEBUG("sum[%u].x.value.limbs[%u]: %u", id, i, sum.x.value.limbs[i]);
+                LOG_DEBUG("sum[%u].x.limbs[%u]: %u", id, i, sum.x.limbs[i]);
             }
         }
     }

--- a/mopro-msm/src/msm/metal_msm/shader/field/ff.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/field/ff.metal
@@ -6,30 +6,27 @@ using namespace metal;
 #include <metal_math>
 #include "../bigint/bigint.metal"
 
-BigInt ff_reduce(BigInt a) {
+inline BigInt ff_reduce(BigInt a) {
     BigInt p = MODULUS;
     BigIntResult res = bigint_sub(a, p);
     if (res.carry == 1) return a;
     return res.value;
 }
 
-BigInt ff_add(BigInt a, BigInt b) {
-    BigIntResult res = bigint_add_unsafe(a, b);
-    return ff_reduce(res.value);
+inline BigInt ff_add(BigInt a, BigInt b) {
+    return ff_reduce(bigint_add_unsafe(a, b).value);
 }
 
-BigInt ff_sub(BigInt a, BigInt b) {
+inline BigInt ff_sub(BigInt a, BigInt b) {
     bool a_gte_b = bigint_gte(a, b);
 
     if (a_gte_b) {
-        BigIntResult res = bigint_sub(a, b);
-        return res.value;
+        return bigint_sub(a, b).value;
     }
     else {
         // p - (b - a)
         BigInt p = MODULUS;
         BigIntResult diff = bigint_sub(b, a);
-        BigIntResult res = bigint_sub(p, diff.value);
-        return res.value;
+        return bigint_sub(p, diff.value).value;
     }
 }

--- a/mopro-msm/src/msm/metal_msm/shader/field/ff.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/field/ff.metal
@@ -6,46 +6,30 @@ using namespace metal;
 #include <metal_math>
 #include "../bigint/bigint.metal"
 
-/// Reduce if the value is greater than the modulus
-FieldElement ff_reduce(FieldElement a) {
-    BigIntResult sub_res = bigint_sub(a.value, *get_p());
-    if (sub_res.carry == 1) return a;
-    return FieldElement{ sub_res.value };
+BigInt ff_reduce(BigInt a) {
+    BigInt p = MODULUS;
+    BigIntResult res = bigint_sub(a, p);
+    if (res.carry == 1) return a;
+    return res.value;
 }
 
-/// Reduce once if the value is greater than the modulus
-FieldElement ff_conditional_reduce(FieldElement a) {
-    if (a.value >= *get_p()) {
-        a.value = a.value - *get_p();
-    }
-    return a;
+BigInt ff_add(BigInt a, BigInt b) {
+    BigIntResult res = bigint_add_unsafe(a, b);
+    return ff_reduce(res.value);
 }
 
-FieldElement ff_add(FieldElement a, FieldElement b) {
-    FieldElement res;
-    res.value = a.value + b.value;
-    return ff_reduce(res);
-}
+BigInt ff_sub(BigInt a, BigInt b) {
+    bool a_gte_b = bigint_gte(a, b);
 
-FieldElement ff_sub(FieldElement a, FieldElement b) {
-    bool a_gte_b = bigint_gte(a.value, b.value);
-    BigInt sub_res;
     if (a_gte_b) {
-        sub_res = a.value - b.value;
+        BigIntResult res = bigint_sub(a, b);
+        return res.value;
     }
     else {
         // p - (b - a)
-        BigInt diff = b.value - a.value;
-        sub_res = *get_p() - diff;
+        BigInt p = MODULUS;
+        BigIntResult diff = bigint_sub(b, a);
+        BigIntResult res = bigint_sub(p, diff.value);
+        return res.value;
     }
-    return FieldElement{ sub_res };
-}
-
-// Overload Operators
-constexpr FieldElement operator+(const FieldElement lhs, const FieldElement rhs) {
-    return ff_add(lhs, rhs);
-}
-
-constexpr FieldElement operator-(const FieldElement lhs, const FieldElement rhs) {
-    return ff_sub(lhs, rhs);
 }

--- a/mopro-msm/src/msm/metal_msm/shader/field/ff_add.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/field/ff_add.metal
@@ -11,9 +11,5 @@ kernel void run(
     device BigInt* res [[ buffer(2) ]],
     uint gid [[ thread_position_in_grid ]]
 ) {
-    // wrap into FieldElement
-    FieldElement a_field = { *a };
-    FieldElement b_field = { *b };
-    FieldElement res_field = a_field + b_field;
-    *res = res_field.value;
+    *res = ff_add(*a, *b);
 }

--- a/mopro-msm/src/msm/metal_msm/shader/field/ff_reduce.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/field/ff_reduce.metal
@@ -10,8 +10,5 @@ kernel void run(
     device BigInt* res [[ buffer(1) ]],
     uint gid [[ thread_position_in_grid ]]
 ) {
-    // wrap into FieldElement
-    FieldElement a_field = { *a };
-    FieldElement res_field = ff_reduce(a_field);
-    *res = res_field.value;
+    *res = ff_reduce(*a);
 }

--- a/mopro-msm/src/msm/metal_msm/shader/field/ff_sub.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/field/ff_sub.metal
@@ -11,9 +11,5 @@ kernel void run(
     device BigInt* res [[ buffer(2) ]],
     uint gid [[ thread_position_in_grid ]]
 ) {
-    // wrap into FieldElement
-    FieldElement a_field = { *a };
-    FieldElement b_field = { *b };
-    FieldElement res_field = a_field - b_field;
-    *res = res_field.value;
+    *res = ff_sub(*a, *b);
 }

--- a/mopro-msm/src/msm/metal_msm/shader/misc/get_constant.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/misc/get_constant.metal
@@ -25,8 +25,7 @@ using namespace metal;
                  INIT_LIMB(16), INIT_LIMB(17), INIT_LIMB(18), INIT_LIMB(19)
 
 // Since modulus is constantly used, we initialize it here
-// and return its ptr when needed
-constant BigInt modulus = {
+constant BigInt MODULUS = {
 #if (NUM_LIMBS == 16)
     LIMBS_16
 #elif (NUM_LIMBS == 17)
@@ -60,11 +59,6 @@ BigIntWide get_r() {
         r.limbs[i] = MONT_RADIX[i];
     }
     return r;
-}
-
-/// Returns a reference to the modulus
-constant BigInt* get_p() {
-    return &modulus;
 }
 
 BigIntWide get_p_wide() {
@@ -110,9 +104,9 @@ BigIntExtraWide bigint_zero_extra_wide() {
 Jacobian get_bn254_zero() {
     Jacobian zero;
     for (uint i = 0; i < NUM_LIMBS; i++) {
-        zero.x.value.limbs[i] = BN254_ZERO_X[i];
-        zero.y.value.limbs[i] = BN254_ZERO_Y[i];
-        zero.z.value.limbs[i] = BN254_ZERO_Z[i];
+        zero.x.limbs[i] = BN254_ZERO_X[i];
+        zero.y.limbs[i] = BN254_ZERO_Y[i];
+        zero.z.limbs[i] = BN254_ZERO_Z[i];
     }
     return zero;
 }
@@ -120,9 +114,9 @@ Jacobian get_bn254_zero() {
 Jacobian get_bn254_one() {
     Jacobian one;
     for (uint i = 0; i < NUM_LIMBS; i++) {
-        one.x.value.limbs[i] = BN254_ONE_X[i];
-        one.y.value.limbs[i] = BN254_ONE_Y[i];
-        one.z.value.limbs[i] = BN254_ONE_Z[i];
+        one.x.limbs[i] = BN254_ONE_X[i];
+        one.y.limbs[i] = BN254_ONE_Y[i];
+        one.z.limbs[i] = BN254_ONE_Z[i];
     }
     return one;
 }
@@ -130,9 +124,9 @@ Jacobian get_bn254_one() {
 Jacobian get_bn254_zero_mont() {
     Jacobian zero;
     for (uint i = 0; i < NUM_LIMBS; i++) {
-        zero.x.value.limbs[i] = BN254_ZERO_XR[i];
-        zero.y.value.limbs[i] = BN254_ZERO_YR[i];
-        zero.z.value.limbs[i] = BN254_ZERO_ZR[i];
+        zero.x.limbs[i] = BN254_ZERO_XR[i];
+        zero.y.limbs[i] = BN254_ZERO_YR[i];
+        zero.z.limbs[i] = BN254_ZERO_ZR[i];
     }
     return zero;
 }
@@ -140,9 +134,9 @@ Jacobian get_bn254_zero_mont() {
 Jacobian get_bn254_one_mont() {
     Jacobian one;
     for (uint i = 0; i < NUM_LIMBS; i++) {
-        one.x.value.limbs[i] = BN254_ONE_XR[i];
-        one.y.value.limbs[i] = BN254_ONE_YR[i];
-        one.z.value.limbs[i] = BN254_ONE_ZR[i];
+        one.x.limbs[i] = BN254_ONE_XR[i];
+        one.y.limbs[i] = BN254_ONE_YR[i];
+        one.z.limbs[i] = BN254_ONE_ZR[i];
     }
     return one;
 }

--- a/mopro-msm/src/msm/metal_msm/shader/misc/test_get_constant.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/misc/test_get_constant.metal
@@ -15,7 +15,7 @@ kernel void test_get_r(device BigIntWide* result) {
 }
 
 kernel void test_get_p(device BigInt* result) {
-    *result = *get_p();
+    *result = MODULUS;
 }
 
 kernel void test_get_p_wide(device BigIntWide* result) {
@@ -24,28 +24,28 @@ kernel void test_get_p_wide(device BigIntWide* result) {
 
 kernel void test_get_bn254_zero(device BigInt* result_x, device BigInt* result_y, device BigInt* result_z) {
     Jacobian result = get_bn254_zero();
-    *result_x = result.x.value;
-    *result_y = result.y.value;
-    *result_z = result.z.value;
+    *result_x = result.x;
+    *result_y = result.y;
+    *result_z = result.z;
 }
 
 kernel void test_get_bn254_one(device BigInt* result_x, device BigInt* result_y, device BigInt* result_z) {
     Jacobian result = get_bn254_one();
-    *result_x = result.x.value;
-    *result_y = result.y.value;
-    *result_z = result.z.value;
+    *result_x = result.x;
+    *result_y = result.y;
+    *result_z = result.z;
 }
 
 kernel void test_get_bn254_zero_mont(device BigInt* result_x, device BigInt* result_y, device BigInt* result_z) {
     Jacobian result = get_bn254_zero_mont();
-    *result_x = result.x.value;
-    *result_y = result.y.value;
-    *result_z = result.z.value;
+    *result_x = result.x;
+    *result_y = result.y;
+    *result_z = result.z;
 }
 
 kernel void test_get_bn254_one_mont(device BigInt* result_x, device BigInt* result_y, device BigInt* result_z) {
     Jacobian result = get_bn254_one_mont();
-    *result_x = result.x.value;
-    *result_y = result.y.value;
-    *result_z = result.z.value;
+    *result_x = result.x;
+    *result_y = result.y;
+    *result_z = result.z;
 }

--- a/mopro-msm/src/msm/metal_msm/shader/misc/types.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/misc/types.metal
@@ -5,15 +5,15 @@ using namespace metal;
 #include "../constants.metal"
 
 struct BigInt {
-    array<uint32_t, NUM_LIMBS> limbs;
+    array<uint, NUM_LIMBS> limbs;
 };
 
 struct BigIntWide {
-    array<uint32_t, NUM_LIMBS_WIDE> limbs;
+    array<uint, NUM_LIMBS_WIDE> limbs;
 };
 
 struct BigIntExtraWide {
-    array<uint32_t, NUM_LIMBS_EXTRA_WIDE> limbs;
+    array<uint, NUM_LIMBS_EXTRA_WIDE> limbs;
 };
 
 struct BigIntResult {
@@ -31,18 +31,13 @@ struct BigIntResultExtraWide {
     bool carry;
 };
 
-// wrapper around BigInt to avoid having to pass modulus around
-struct FieldElement {
-    BigInt value;
-};
-
 struct Jacobian {
-    FieldElement x;
-    FieldElement y;
-    FieldElement z;
+    BigInt x;
+    BigInt y;
+    BigInt z;
 };
 
 struct Affine {
-    FieldElement x;
-    FieldElement y;
+    BigInt x;
+    BigInt y;
 };

--- a/mopro-msm/src/msm/metal_msm/shader/mont_backend/mont.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/mont_backend/mont.metal
@@ -92,7 +92,7 @@ BigInt mont_mul_modified(BigInt x, BigInt y) {
 /// The CIOS method for Montgomery multiplication from Tolga Acar's thesis:
 /// High-Speed Algorithms & Architectures For Number-Theoretic Cryptosystems
 /// https://www.proquest.com/openview/1018972f191afe55443658b28041c118/1
-BigInt mont_mul_cios(BigInt x, BigInt y) {
+inline BigInt mont_mul_cios(BigInt x, BigInt y) {
     BigInt p = MODULUS;
 
     BigInt result;

--- a/mopro-msm/src/msm/metal_msm/shader/mont_backend/mont_mul_cios.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/mont_backend/mont_mul_cios.metal
@@ -11,8 +11,5 @@ kernel void run(
     device BigInt* result [[ buffer(2) ]],
     uint gid [[ thread_position_in_grid ]]
 ) {
-    FieldElement lhs_field = { *lhs };
-    FieldElement rhs_field = { *rhs };
-    FieldElement res_field = mont_mul_cios(lhs_field, rhs_field);
-    *result = res_field.value;
+    *result = mont_mul_cios(*lhs, *rhs);
 }

--- a/mopro-msm/src/msm/metal_msm/shader/mont_backend/mont_mul_cios_benchmarks.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/mont_backend/mont_mul_cios_benchmarks.metal
@@ -10,14 +10,13 @@ kernel void run(
     device BigInt* result [[ buffer(3) ]],
     uint gid [[ thread_position_in_grid ]]
 ) {
-    FieldElement lhs_field = { *lhs };
-    FieldElement rhs_field = { *rhs };
+    BigInt a = *lhs;
+    BigInt b = *rhs;
     array<uint, 1> cost_arr = *cost;
 
-    // calculate lhs^3 * rhs
-    FieldElement c = mont_mul_cios(lhs_field, lhs_field);
+    BigInt c = mont_mul_cios(a, a);
     for (uint i = 1; i < cost_arr[0]; i ++) {
-        c = mont_mul_cios(c, lhs_field);
+        c = mont_mul_cios(c, a);
     }
-    *result = mont_mul_cios(c, rhs_field).value;
+    *result = mont_mul_cios(c, b);
 }

--- a/mopro-msm/src/msm/metal_msm/shader/mont_backend/mont_mul_modified.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/mont_backend/mont_mul_modified.metal
@@ -11,8 +11,5 @@ kernel void run(
     device BigInt* result [[ buffer(2) ]],
     uint gid [[ thread_position_in_grid ]]
 ) {
-    FieldElement lhs_field = { *lhs };
-    FieldElement rhs_field = { *rhs };
-    FieldElement res_field = mont_mul_modified(lhs_field, rhs_field);
-    *result = res_field.value;
+    *result = mont_mul_modified(*lhs, *rhs);
 }

--- a/mopro-msm/src/msm/metal_msm/shader/mont_backend/mont_mul_modified_benchmarks.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/mont_backend/mont_mul_modified_benchmarks.metal
@@ -10,14 +10,13 @@ kernel void run(
     device BigInt* result [[ buffer(3) ]],
     uint gid [[ thread_position_in_grid ]]
 ) {
-    FieldElement lhs_field = { *lhs };
-    FieldElement rhs_field = { *rhs };
+    BigInt a = *lhs;
+    BigInt b = *rhs;
     array<uint, 1> cost_arr = *cost;
 
-    // calculate lhs^3 * rhs
-    FieldElement c = mont_mul_modified(lhs_field, lhs_field);
+    BigInt c = mont_mul_modified(a, a);
     for (uint i = 1; i < cost_arr[0]; i ++) {
-        c = mont_mul_modified(c, lhs_field);
+        c = mont_mul_modified(c, a);
     }
-    *result = mont_mul_modified(c, rhs_field).value;
+    *result = mont_mul_modified(c, b);
 }

--- a/mopro-msm/src/msm/metal_msm/shader/mont_backend/mont_mul_optimised.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/mont_backend/mont_mul_optimised.metal
@@ -11,8 +11,5 @@ kernel void run(
     device BigInt* result [[ buffer(2) ]],
     uint gid [[ thread_position_in_grid ]]
 ) {
-    FieldElement lhs_field = { *lhs };
-    FieldElement rhs_field = { *rhs };
-    FieldElement res_field = mont_mul_optimised(lhs_field, rhs_field);
-    *result = res_field.value;
+    *result = mont_mul_optimised(*lhs, *rhs);
 }

--- a/mopro-msm/src/msm/metal_msm/shader/mont_backend/mont_mul_optimised_benchmarks.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/mont_backend/mont_mul_optimised_benchmarks.metal
@@ -10,14 +10,13 @@ kernel void run(
     device BigInt* result [[ buffer(3) ]],
     uint gid [[ thread_position_in_grid ]]
 ) {
-    FieldElement lhs_field = { *lhs };
-    FieldElement rhs_field = { *rhs };
+    BigInt a = *lhs;
+    BigInt b = *rhs;
     array<uint, 1> cost_arr = *cost;
 
-    // calculate lhs^3 * rhs
-    FieldElement c = mont_mul_optimised(lhs_field, lhs_field);
+    BigInt c = mont_mul_optimised(a, a);
     for (uint i = 1; i < cost_arr[0]; i ++) {
-        c = mont_mul_optimised(c, lhs_field);
+        c = mont_mul_optimised(c, a);
     }
-    *result = mont_mul_optimised(c, rhs_field).value;
+    *result = mont_mul_optimised(c, b);
 }


### PR DESCRIPTION
- Closes issue: #60

## Summary
This PR reverts the use of `FieldElement` (introduced in commit f6daf7a7458b12b8ac437530807ab6e3b51f3ebb) back to `BigInt`. This change significantly reduces load/store instructions and register pressure, especially in performance-critical tight loops.

Additionally, `inline` attributes were added to frequently invoked functions, further decreasing function call overhead and improving overall performance.

## Montgomery Multiplication Benchmarks
Benchmarks were conducted on a system with:
- Apple M3 chip
- 24 GB unified memory
- macOS 15
- Metal 32023.404

### Benchmark Command
```
cargo test --package mopro-msm --lib -- msm::metal_msm::tests --ignored --nocapture
```

### Benchmark Results

#### Before Optimization
```
=== benchmarking mont_mul_modified ===
- 13-bit limbs: 251ms
- 15-bit limbs: 260ms

=== benchmarking mont_mul_optimised ===
- 13-bit limbs: 239ms

=== benchmarking mont_mul_cios ===
- 13-bit limbs: 827ms
- 15-bit limbs: 625ms
- 16-bit limbs: 541ms
```

#### After Optimization
```
=== benchmarking mont_mul_modified ===
- 13-bit limbs: 189ms (~25% improvement)
- 15-bit limbs: 198ms (~24% improvement)

=== benchmarking mont_mul_optimised ===
- 13-bit limbs: 195ms (~18% improvement)

=== benchmarking mont_mul_cios ===
- 13-bit limbs: 430ms (~48% improvement)
- 15-bit limbs: 334ms (~46% improvement)
- 16-bit limbs: 185ms (~66% improvement)
```

This PR significantly improves performance across various limb sizes for Montgomery multiplication.

