### PR TITLE
fix(metal): Correct Phase 3 of cuzk/transpose

### DIFF
--- a/mopro-msm/src/msm/metal_msm/shader/cuzk/transpose.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/cuzk/transpose.metal
@@ -3,15 +3,14 @@ using namespace metal;
 
 kernel void transpose(
     device const uint* all_csr_col_idx       [[buffer(0)]],
-    constant uint2& params                   [[buffer(1)]],
-    device atomic_uint* all_csc_col_ptr      [[buffer(2)]],
-    device uint* all_csc_val_idxs            [[buffer(3)]],
-    device atomic_uint* all_curr             [[buffer(4)]],
+    device atomic_uint* all_csc_col_ptr      [[buffer(1)]],
+    device uint* all_csc_val_idxs            [[buffer(2)]],
+    device uint* all_curr                    [[buffer(3)]],
+    constant uint2& params                   [[buffer(4)]],
     uint gid [[thread_position_in_grid]]
 ) {
-    // Subtask index (equivalent to thread ID)
     const uint subtask_idx = gid;
-    
+
     const uint n = params.x;    // Number of columns
     const uint input_size = params.y;   // Input size
     
@@ -21,48 +20,46 @@ kernel void transpose(
     const uint curr_offset = subtask_idx * n;
     
     // Phase 1: Count non-zero elements in each column
-    for (uint j = 0; j < input_size; j++) {
-        const uint col = all_csr_col_idx[cci_offset + j];
+    for (uint j = 0u; j < input_size; j++) {
         atomic_fetch_add_explicit(
-            &all_csc_col_ptr[ccp_offset + col + 1u], 
+            &all_csc_col_ptr[ccp_offset + all_csr_col_idx[cci_offset + j] + 1u], 
             1u, 
             memory_order_relaxed
         );
     }
     
     // Phase 2: Prefix sum for column pointers
-    for (uint i = 1; i < n + 1u; i++) {
-        const uint prev_count = atomic_load_explicit(
+    for (uint i = 1u; i < n + 1u; i++) {
+        const uint incremental_sum = atomic_load_explicit(
             &all_csc_col_ptr[ccp_offset + i - 1u], 
             memory_order_relaxed
         );
         atomic_fetch_add_explicit(
             &all_csc_col_ptr[ccp_offset + i], 
-            prev_count, 
+            incremental_sum, 
             memory_order_relaxed
         );
     }
     
     // Phase 3: Rearrange elements into CSC format
+    /// "Traverse the nonzero elements again and move them to their final
+    /// positions determined by the column offsets in csc_col_ptr and their
+    /// current relative positions in curr." (Wang et al, 2016).
     uint val = 0u;
     for (uint j = 0; j < input_size; j++) {
         const uint col = all_csr_col_idx[cci_offset + j];
         
         // Get current position for this column
-        const uint loc = atomic_load_explicit(
+        uint loc = atomic_load_explicit(
             &all_csc_col_ptr[ccp_offset + col], 
             memory_order_relaxed
         );
-        
-        // Calculate final position and update current counter
-        const uint curr_pos = atomic_fetch_add_explicit(
-            (device atomic_uint*)&all_curr[curr_offset + col],  // Cast to atomic_uint pointer
-            1u, 
-            memory_order_relaxed
-        );
+
+        loc += all_curr[curr_offset + col];
+        all_curr[curr_offset + col]++;
         
         // Store the value index in CSC format
-        all_csc_val_idxs[cci_offset + loc + curr_pos] = val;
+        all_csc_val_idxs[cci_offset + loc] = val;
         val++;
     }
 }

--- a/mopro-msm/src/msm/metal_msm/tests/cuzk/transpose.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/cuzk/transpose.rs
@@ -49,8 +49,14 @@ fn test_sparse_matrix_transposition() {
 
         helper.execute_shader(
             &config,
-            &[&all_csr_col_idx_buf, &params_buf],
-            &[&all_csc_col_ptr_buf, &all_csc_val_idxs_buf, &all_curr_buf],
+            &[
+                &all_csr_col_idx_buf,
+                &all_csc_col_ptr_buf,
+                &all_csc_val_idxs_buf,
+                &all_curr_buf,
+                &params_buf,
+            ],
+            &[],
             &thread_group_count,
             &thread_group_size,
         );
@@ -85,6 +91,552 @@ fn test_sparse_matrix_transposition() {
         }
         helper.drop_all_buffers();
     }
+}
+
+#[test]
+#[serial_test::serial]
+fn test_transpose_single_element() {
+    let config = MetalConfig {
+        log_limb_size: 16,
+        num_limbs: 16,
+        shader_file: "cuzk/transpose.metal".to_string(),
+        kernel_name: "transpose".to_string(),
+    };
+
+    let mut helper = MetalHelper::new();
+
+    // Test with single element in single column
+    let n = 3u32;
+    let input_size = 1u32;
+    let num_subtasks = 1;
+
+    let all_csr_col_idx = vec![1u32]; // Single element in column 1
+    let (expected_col_ptr, expected_val_idxs) = compute_expected_csc(&all_csr_col_idx, n);
+
+    // Create buffers
+    let all_csr_col_idx_buf = helper.create_input_buffer(&all_csr_col_idx);
+    let all_csc_col_ptr_buf = helper.create_output_buffer(num_subtasks * (n as usize + 1));
+    let all_csc_val_idxs_buf = helper.create_output_buffer(num_subtasks * input_size as usize);
+    let all_curr_buf = helper.create_output_buffer(num_subtasks * n as usize);
+    let params_buf = helper.create_input_buffer(&vec![n, input_size]);
+
+    // Execute shader
+    let thread_group_count = helper.create_thread_group_size(num_subtasks as u64, 1, 1);
+    let thread_group_size = helper.create_thread_group_size(1, 1, 1);
+
+    helper.execute_shader(
+        &config,
+        &[
+            &all_csr_col_idx_buf,
+            &all_csc_col_ptr_buf,
+            &all_csc_val_idxs_buf,
+            &all_curr_buf,
+            &params_buf,
+        ],
+        &[],
+        &thread_group_count,
+        &thread_group_size,
+    );
+
+    // Read and validate results
+    let csc_col_ptr = helper.read_results(&all_csc_col_ptr_buf, n as usize + 1);
+    let csc_val_idxs = helper.read_results(&all_csc_val_idxs_buf, input_size as usize);
+
+    assert_eq!(
+        csc_col_ptr, expected_col_ptr,
+        "Single element column pointers mismatch"
+    );
+    assert_eq!(
+        csc_val_idxs, expected_val_idxs,
+        "Single element value indices mismatch"
+    );
+
+    helper.drop_all_buffers();
+}
+
+#[test]
+#[serial_test::serial]
+fn test_transpose_all_same_column() {
+    let config = MetalConfig {
+        log_limb_size: 16,
+        num_limbs: 16,
+        shader_file: "cuzk/transpose.metal".to_string(),
+        kernel_name: "transpose".to_string(),
+    };
+
+    let mut helper = MetalHelper::new();
+
+    // Test with all elements in the same column
+    let n = 4u32;
+    let input_size = 5u32;
+    let num_subtasks = 1;
+
+    let all_csr_col_idx = vec![2u32; input_size as usize]; // All elements in column 2
+    let (expected_col_ptr, expected_val_idxs) = compute_expected_csc(&all_csr_col_idx, n);
+
+    // Create buffers
+    let all_csr_col_idx_buf = helper.create_input_buffer(&all_csr_col_idx);
+    let all_csc_col_ptr_buf = helper.create_output_buffer(num_subtasks * (n as usize + 1));
+    let all_csc_val_idxs_buf = helper.create_output_buffer(num_subtasks * input_size as usize);
+    let all_curr_buf = helper.create_output_buffer(num_subtasks * n as usize);
+    let params_buf = helper.create_input_buffer(&vec![n, input_size]);
+
+    // Execute shader
+    let thread_group_count = helper.create_thread_group_size(num_subtasks as u64, 1, 1);
+    let thread_group_size = helper.create_thread_group_size(1, 1, 1);
+
+    helper.execute_shader(
+        &config,
+        &[
+            &all_csr_col_idx_buf,
+            &all_csc_col_ptr_buf,
+            &all_csc_val_idxs_buf,
+            &all_curr_buf,
+            &params_buf,
+        ],
+        &[],
+        &thread_group_count,
+        &thread_group_size,
+    );
+
+    // Read and validate results
+    let csc_col_ptr = helper.read_results(&all_csc_col_ptr_buf, n as usize + 1);
+    let csc_val_idxs = helper.read_results(&all_csc_val_idxs_buf, input_size as usize);
+
+    assert_eq!(
+        csc_col_ptr, expected_col_ptr,
+        "Same column pointers mismatch"
+    );
+    assert_eq!(
+        csc_val_idxs, expected_val_idxs,
+        "Same column value indices mismatch"
+    );
+
+    helper.drop_all_buffers();
+}
+
+#[test]
+#[serial_test::serial]
+fn test_transpose_sequential_columns() {
+    let config = MetalConfig {
+        log_limb_size: 16,
+        num_limbs: 16,
+        shader_file: "cuzk/transpose.metal".to_string(),
+        kernel_name: "transpose".to_string(),
+    };
+
+    let mut helper = MetalHelper::new();
+
+    // Test with elements in sequential columns (0, 1, 2, 3, ...)
+    let n = 5u32;
+    let input_size = 5u32;
+    let num_subtasks = 1;
+
+    let all_csr_col_idx: Vec<u32> = (0..input_size).collect(); // [0, 1, 2, 3, 4]
+    let (expected_col_ptr, expected_val_idxs) = compute_expected_csc(&all_csr_col_idx, n);
+
+    // Create buffers
+    let all_csr_col_idx_buf = helper.create_input_buffer(&all_csr_col_idx);
+    let all_csc_col_ptr_buf = helper.create_output_buffer(num_subtasks * (n as usize + 1));
+    let all_csc_val_idxs_buf = helper.create_output_buffer(num_subtasks * input_size as usize);
+    let all_curr_buf = helper.create_output_buffer(num_subtasks * n as usize);
+    let params_buf = helper.create_input_buffer(&vec![n, input_size]);
+
+    // Execute shader
+    let thread_group_count = helper.create_thread_group_size(num_subtasks as u64, 1, 1);
+    let thread_group_size = helper.create_thread_group_size(1, 1, 1);
+
+    helper.execute_shader(
+        &config,
+        &[
+            &all_csr_col_idx_buf,
+            &all_csc_col_ptr_buf,
+            &all_csc_val_idxs_buf,
+            &all_curr_buf,
+            &params_buf,
+        ],
+        &[],
+        &thread_group_count,
+        &thread_group_size,
+    );
+
+    // Read and validate results
+    let csc_col_ptr = helper.read_results(&all_csc_col_ptr_buf, n as usize + 1);
+    let csc_val_idxs = helper.read_results(&all_csc_val_idxs_buf, input_size as usize);
+
+    assert_eq!(
+        csc_col_ptr, expected_col_ptr,
+        "Sequential column pointers mismatch"
+    );
+    assert_eq!(
+        csc_val_idxs, expected_val_idxs,
+        "Sequential column value indices mismatch"
+    );
+
+    helper.drop_all_buffers();
+}
+
+#[test]
+#[serial_test::serial]
+fn test_transpose_reverse_order() {
+    let config = MetalConfig {
+        log_limb_size: 16,
+        num_limbs: 16,
+        shader_file: "cuzk/transpose.metal".to_string(),
+        kernel_name: "transpose".to_string(),
+    };
+
+    let mut helper = MetalHelper::new();
+
+    // Test with elements in reverse order (n-1, n-2, ..., 1, 0)
+    let n = 4u32;
+    let input_size = 4u32;
+    let num_subtasks = 1;
+
+    let all_csr_col_idx: Vec<u32> = (0..input_size).rev().collect(); // [3, 2, 1, 0]
+    let (expected_col_ptr, expected_val_idxs) = compute_expected_csc(&all_csr_col_idx, n);
+
+    // Create buffers
+    let all_csr_col_idx_buf = helper.create_input_buffer(&all_csr_col_idx);
+    let all_csc_col_ptr_buf = helper.create_output_buffer(num_subtasks * (n as usize + 1));
+    let all_csc_val_idxs_buf = helper.create_output_buffer(num_subtasks * input_size as usize);
+    let all_curr_buf = helper.create_output_buffer(num_subtasks * n as usize);
+    let params_buf = helper.create_input_buffer(&vec![n, input_size]);
+
+    // Execute shader
+    let thread_group_count = helper.create_thread_group_size(num_subtasks as u64, 1, 1);
+    let thread_group_size = helper.create_thread_group_size(1, 1, 1);
+
+    helper.execute_shader(
+        &config,
+        &[
+            &all_csr_col_idx_buf,
+            &all_csc_col_ptr_buf,
+            &all_csc_val_idxs_buf,
+            &all_curr_buf,
+            &params_buf,
+        ],
+        &[],
+        &thread_group_count,
+        &thread_group_size,
+    );
+
+    // Read and validate results
+    let csc_col_ptr = helper.read_results(&all_csc_col_ptr_buf, n as usize + 1);
+    let csc_val_idxs = helper.read_results(&all_csc_val_idxs_buf, input_size as usize);
+
+    assert_eq!(
+        csc_col_ptr, expected_col_ptr,
+        "Reverse order column pointers mismatch"
+    );
+    assert_eq!(
+        csc_val_idxs, expected_val_idxs,
+        "Reverse order value indices mismatch"
+    );
+
+    helper.drop_all_buffers();
+}
+
+#[test]
+#[serial_test::serial]
+fn test_transpose_empty_columns() {
+    let config = MetalConfig {
+        log_limb_size: 16,
+        num_limbs: 16,
+        shader_file: "cuzk/transpose.metal".to_string(),
+        kernel_name: "transpose".to_string(),
+    };
+
+    let mut helper = MetalHelper::new();
+
+    // Test with some empty columns (only use columns 0 and 3, leaving 1 and 2 empty)
+    let n = 5u32;
+    let input_size = 6u32;
+    let num_subtasks = 1;
+
+    let all_csr_col_idx = vec![0u32, 0u32, 3u32, 3u32, 0u32, 4u32]; // Columns 1 and 2 are empty
+    let (expected_col_ptr, expected_val_idxs) = compute_expected_csc(&all_csr_col_idx, n);
+
+    // Create buffers
+    let all_csr_col_idx_buf = helper.create_input_buffer(&all_csr_col_idx);
+    let all_csc_col_ptr_buf = helper.create_output_buffer(num_subtasks * (n as usize + 1));
+    let all_csc_val_idxs_buf = helper.create_output_buffer(num_subtasks * input_size as usize);
+    let all_curr_buf = helper.create_output_buffer(num_subtasks * n as usize);
+    let params_buf = helper.create_input_buffer(&vec![n, input_size]);
+
+    // Execute shader
+    let thread_group_count = helper.create_thread_group_size(num_subtasks as u64, 1, 1);
+    let thread_group_size = helper.create_thread_group_size(1, 1, 1);
+
+    helper.execute_shader(
+        &config,
+        &[
+            &all_csr_col_idx_buf,
+            &all_csc_col_ptr_buf,
+            &all_csc_val_idxs_buf,
+            &all_curr_buf,
+            &params_buf,
+        ],
+        &[],
+        &thread_group_count,
+        &thread_group_size,
+    );
+
+    // Read and validate results
+    let csc_col_ptr = helper.read_results(&all_csc_col_ptr_buf, n as usize + 1);
+    let csc_val_idxs = helper.read_results(&all_csc_val_idxs_buf, input_size as usize);
+
+    assert_eq!(
+        csc_col_ptr, expected_col_ptr,
+        "Empty columns pointers mismatch"
+    );
+    assert_eq!(
+        csc_val_idxs, expected_val_idxs,
+        "Empty columns value indices mismatch"
+    );
+
+    helper.drop_all_buffers();
+}
+
+#[test]
+#[serial_test::serial]
+fn test_transpose_multiple_subtasks_edge_cases() {
+    let config = MetalConfig {
+        log_limb_size: 16,
+        num_limbs: 16,
+        shader_file: "cuzk/transpose.metal".to_string(),
+        kernel_name: "transpose".to_string(),
+    };
+
+    let mut helper = MetalHelper::new();
+
+    // Test with multiple subtasks having different patterns
+    let n = 3u32;
+    let input_size = 4u32;
+    let num_subtasks = 3;
+
+    let mut all_csr_col_idx = Vec::new();
+    let mut expected_results = Vec::new();
+
+    // Subtask 0: All elements in column 0
+    let cols0 = vec![0u32; input_size as usize];
+    let (expected_col_ptr0, expected_val_idxs0) = compute_expected_csc(&cols0, n);
+    expected_results.push((expected_col_ptr0, expected_val_idxs0));
+    all_csr_col_idx.extend_from_slice(&cols0);
+
+    // Subtask 1: Sequential pattern
+    let cols1: Vec<u32> = vec![0, 1, 2, 1];
+    let (expected_col_ptr1, expected_val_idxs1) = compute_expected_csc(&cols1, n);
+    expected_results.push((expected_col_ptr1, expected_val_idxs1));
+    all_csr_col_idx.extend_from_slice(&cols1);
+
+    // Subtask 2: Reverse pattern
+    let cols2: Vec<u32> = vec![2, 2, 1, 0];
+    let (expected_col_ptr2, expected_val_idxs2) = compute_expected_csc(&cols2, n);
+    expected_results.push((expected_col_ptr2, expected_val_idxs2));
+    all_csr_col_idx.extend_from_slice(&cols2);
+
+    // Create buffers
+    let all_csr_col_idx_buf = helper.create_input_buffer(&all_csr_col_idx);
+    let all_csc_col_ptr_buf = helper.create_output_buffer(num_subtasks * (n as usize + 1));
+    let all_csc_val_idxs_buf = helper.create_output_buffer(num_subtasks * input_size as usize);
+    let all_curr_buf = helper.create_output_buffer(num_subtasks * n as usize);
+    let params_buf = helper.create_input_buffer(&vec![n, input_size]);
+
+    // Execute shader
+    let thread_group_count = helper.create_thread_group_size(num_subtasks as u64, 1, 1);
+    let thread_group_size = helper.create_thread_group_size(1, 1, 1);
+
+    helper.execute_shader(
+        &config,
+        &[
+            &all_csr_col_idx_buf,
+            &all_csc_col_ptr_buf,
+            &all_csc_val_idxs_buf,
+            &all_curr_buf,
+            &params_buf,
+        ],
+        &[],
+        &thread_group_count,
+        &thread_group_size,
+    );
+
+    // Read results
+    let csc_col_ptr = helper.read_results(&all_csc_col_ptr_buf, num_subtasks * (n as usize + 1));
+    let csc_val_idxs =
+        helper.read_results(&all_csc_val_idxs_buf, num_subtasks * input_size as usize);
+
+    // Validate each subtask
+    for subtask in 0..num_subtasks {
+        let offset = subtask * (n as usize + 1);
+        let expected_col_ptr = &expected_results[subtask].0;
+        let actual_col_ptr = &csc_col_ptr[offset..offset + (n as usize + 1)];
+
+        assert_eq!(
+            actual_col_ptr, expected_col_ptr,
+            "Subtask {}: Column pointers mismatch\nExpected: {:?}\nActual: {:?}",
+            subtask, expected_col_ptr, actual_col_ptr
+        );
+
+        let val_offset = subtask * input_size as usize;
+        let expected_vals = &expected_results[subtask].1;
+        let actual_vals = &csc_val_idxs[val_offset..val_offset + input_size as usize];
+
+        assert_eq!(
+            actual_vals, expected_vals,
+            "Subtask {}: Value indices mismatch\nExpected: {:?}\nActual: {:?}",
+            subtask, expected_vals, actual_vals
+        );
+    }
+
+    helper.drop_all_buffers();
+}
+
+#[test]
+#[serial_test::serial]
+fn test_transpose_boundary_columns() {
+    let config = MetalConfig {
+        log_limb_size: 16,
+        num_limbs: 16,
+        shader_file: "cuzk/transpose.metal".to_string(),
+        kernel_name: "transpose".to_string(),
+    };
+
+    let mut helper = MetalHelper::new();
+
+    // Test with elements only in first and last columns
+    let n = 5u32;
+    let input_size = 6u32;
+    let num_subtasks = 1;
+
+    let all_csr_col_idx = vec![0u32, 4u32, 0u32, 4u32, 0u32, 4u32]; // Only columns 0 and 4
+    let (expected_col_ptr, expected_val_idxs) = compute_expected_csc(&all_csr_col_idx, n);
+
+    // Create buffers
+    let all_csr_col_idx_buf = helper.create_input_buffer(&all_csr_col_idx);
+    let all_csc_col_ptr_buf = helper.create_output_buffer(num_subtasks * (n as usize + 1));
+    let all_csc_val_idxs_buf = helper.create_output_buffer(num_subtasks * input_size as usize);
+    let all_curr_buf = helper.create_output_buffer(num_subtasks * n as usize);
+    let params_buf = helper.create_input_buffer(&vec![n, input_size]);
+
+    // Execute shader
+    let thread_group_count = helper.create_thread_group_size(num_subtasks as u64, 1, 1);
+    let thread_group_size = helper.create_thread_group_size(1, 1, 1);
+
+    helper.execute_shader(
+        &config,
+        &[
+            &all_csr_col_idx_buf,
+            &all_csc_col_ptr_buf,
+            &all_csc_val_idxs_buf,
+            &all_curr_buf,
+            &params_buf,
+        ],
+        &[],
+        &thread_group_count,
+        &thread_group_size,
+    );
+
+    // Read and validate results
+    let csc_col_ptr = helper.read_results(&all_csc_col_ptr_buf, n as usize + 1);
+    let csc_val_idxs = helper.read_results(&all_csc_val_idxs_buf, input_size as usize);
+
+    assert_eq!(
+        csc_col_ptr, expected_col_ptr,
+        "Boundary columns pointers mismatch"
+    );
+    assert_eq!(
+        csc_val_idxs, expected_val_idxs,
+        "Boundary columns value indices mismatch"
+    );
+
+    helper.drop_all_buffers();
+}
+
+#[test]
+#[serial_test::serial]
+fn test_transpose_large_scale() {
+    let config = MetalConfig {
+        log_limb_size: 16,
+        num_limbs: 16,
+        shader_file: "cuzk/transpose.metal".to_string(),
+        kernel_name: "transpose".to_string(),
+    };
+
+    let mut helper = MetalHelper::new();
+
+    // Test with larger scale to stress test the shader
+    let n = 100u32;
+    let input_size = 1000u32;
+    let num_subtasks = 8;
+
+    let mut all_csr_col_idx = Vec::new();
+    let mut expected_results = Vec::new();
+    let mut rng = rand::thread_rng();
+
+    for _ in 0..num_subtasks {
+        let cols = (0..input_size)
+            .map(|_| rng.gen_range(0..n))
+            .collect::<Vec<u32>>();
+        let (expected_col_ptr, expected_val_idxs) = compute_expected_csc(&cols, n);
+        expected_results.push((expected_col_ptr, expected_val_idxs));
+        all_csr_col_idx.extend_from_slice(&cols);
+    }
+
+    // Create buffers
+    let all_csr_col_idx_buf = helper.create_input_buffer(&all_csr_col_idx);
+    let all_csc_col_ptr_buf = helper.create_output_buffer(num_subtasks * (n as usize + 1));
+    let all_csc_val_idxs_buf = helper.create_output_buffer(num_subtasks * input_size as usize);
+    let all_curr_buf = helper.create_output_buffer(num_subtasks * n as usize);
+    let params_buf = helper.create_input_buffer(&vec![n, input_size]);
+
+    // Execute shader
+    let thread_group_count = helper.create_thread_group_size(num_subtasks as u64, 1, 1);
+    let thread_group_size = helper.create_thread_group_size(1, 1, 1);
+
+    helper.execute_shader(
+        &config,
+        &[
+            &all_csr_col_idx_buf,
+            &all_csc_col_ptr_buf,
+            &all_csc_val_idxs_buf,
+            &all_curr_buf,
+            &params_buf,
+        ],
+        &[],
+        &thread_group_count,
+        &thread_group_size,
+    );
+
+    // Read results
+    let csc_col_ptr = helper.read_results(&all_csc_col_ptr_buf, num_subtasks * (n as usize + 1));
+    let csc_val_idxs =
+        helper.read_results(&all_csc_val_idxs_buf, num_subtasks * input_size as usize);
+
+    // Validate each subtask
+    for subtask in 0..num_subtasks {
+        let offset = subtask * (n as usize + 1);
+        let expected_col_ptr = &expected_results[subtask].0;
+        let actual_col_ptr = &csc_col_ptr[offset..offset + (n as usize + 1)];
+
+        assert_eq!(
+            actual_col_ptr, expected_col_ptr,
+            "Large scale subtask {}: Column pointers mismatch",
+            subtask
+        );
+
+        let val_offset = subtask * input_size as usize;
+        let expected_vals = &expected_results[subtask].1;
+        let actual_vals = &csc_val_idxs[val_offset..val_offset + input_size as usize];
+
+        assert_eq!(
+            actual_vals, expected_vals,
+            "Large scale subtask {}: Value indices mismatch",
+            subtask
+        );
+    }
+
+    helper.drop_all_buffers();
 }
 
 fn compute_expected_csc(csr_cols: &[u32], n: u32) -> (Vec<u32>, Vec<u32>) {


### PR DESCRIPTION
## What’s fixed
Phase 3 of our Metal shader’s transpose algorithm was implemented incorrectly. This patch rewrites that section to match the serial-transpose algorithm in Wang et al., ["Parallel Transposition of Sparse Data Structures"](https://synergy.cs.vt.edu/pubs/papers/wang-transposition-ics16.pdf), ICS 2016.

## Fixes
1. **Align with reference implementation**

   * Mirrors the WGSL reference (lines 66-73) in the Z-Prize repo. (https://github.com/z-prize/2023-entries/blob/6cc68aeb63071d90817aeff4b55b34444fae42a8/prize-2-msm-wasm/webgpu-only/tal-derei-koh-wei-jie/src/submission/implementation/wgsl/cuzk/transpose.wgsl#L66-L73)
   ```wgsl
    var val = 0u;
    for (var j = 0u; j < input_size; j++) {
        var loc = atomicLoad(&all_csc_col_ptr[ccp_offset + all_csr_col_idx[cci_offset + j]]);
        loc += all_curr[curr_offset + all_csr_col_idx[cci_offset + j]];
        all_curr[curr_offset + all_csr_col_idx[cci_offset + j]]++;
        all_csc_val_idxs[cci_offset + loc] = val;
        val++;
    }
   ```
2. **Replace faulty code**

   * Removes the wrong code in `transpose.metal`.
   https://github.com/zkmopro/gpu-acceleration/blob/7e717b1956b975d04bc3a031e27b40b549f4378c/mopro-msm/src/msm/metal_msm/shader/cuzk/transpose.metal#L57-L66

   * Adds the correct MSL logic and syntax.
   https://github.com/zkmopro/gpu-acceleration/blob/0d90f9033f13456242ff98b79f78e98d4add0834/mopro-msm/src/msm/metal_msm/shader/cuzk/transpose.metal#L50-L63

## result
The Metal path now produces correct transpose results, fully consistent with the paper and the WGSL version