### PR TITLE
Test/gpu pipeline e2e

### DIFF
--- a/mopro-msm/src/msm/metal_msm/host/shader.rs
+++ b/mopro-msm/src/msm/metal_msm/host/shader.rs
@@ -12,310 +12,309 @@
  * xcrun -sdk macosx metallib <path.ir> -o <path.metallib>
  */
 
- use crate::msm::metal_msm::utils::barrett_params::calc_barrett_mu;
- use crate::msm::metal_msm::utils::limbs_conversion::GenericLimbConversion;
- use crate::msm::metal_msm::utils::mont_params::calc_mont_radix;
- use ark_bn254::{Fq as BaseField, G1Projective as G};
- use ark_ec::Group;
- use ark_ff::{BigInt, PrimeField, Zero};
- use num_bigint::BigUint;
- use std::fs;
- use std::path::PathBuf;
- use std::process::Command;
- use std::string::String;
- 
- macro_rules! write_constant_array {
-     ($data:expr, $name:expr, $values:expr, $size:expr) => {
-         $data += format!("constant uint32_t {}[{}] = {{\n", $name, $size).as_str();
-         $data += &$values
-             .iter()
-             .map(|v| format!("    {}", v))
-             .collect::<Vec<_>>()
-             .join(",\n");
-         $data += "\n};\n";
-     };
- }
- 
- pub fn compile_metal(path_from_cargo_manifest_dir: &str, input_filename: &str) -> String {
-     let input_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-         .join(path_from_cargo_manifest_dir)
-         .join(input_filename);
-     let c = input_path.clone().into_os_string().into_string().unwrap();
- 
-     let lib = input_path.clone().into_os_string().into_string().unwrap();
-     let lib = format!("{}.lib", lib);
- 
-     let exe = if cfg!(target_os = "ios") {
-         Command::new("xcrun")
-             .args([
-                 "-sdk",
-                 "iphoneos",
-                 "metal",
-                 "-std=metal3.2",
-                 "-target",
-                 "air64-apple-ios18.0",
-                 "-fmetal-enable-logging",
-                 "-o",
-                 lib.as_str(),
-                 c.as_str(),
-             ])
-             .output()
-             .expect("failed to compile")
-     } else if cfg!(target_os = "macos") {
-         let macos_version = std::process::Command::new("sw_vers")
-             .args(["-productVersion"])
-             .output()
-             .ok()
-             .and_then(|output| String::from_utf8(output.stdout).ok())
-             .and_then(|version| {
-                 version
-                     .trim()
-                     .split('.')
-                     .next()
-                     .and_then(|major| major.parse::<u32>().ok())
-             })
-             .unwrap_or(0);
- 
-         let mut args = vec!["-sdk", "macosx", "metal"];
- 
-         // Only specify Metal 3.2 for metal logging if macOS version is 15.0 or higher
-         if macos_version >= 15 {
-             args.extend([
-                 "-std=metal3.2",
-                 "-target",
-                 "air64-apple-macos15.0",
-                 "-fmetal-enable-logging",
-             ]);
-         }
- 
-         args.extend(["-o", lib.as_str(), c.as_str()]);
- 
-         Command::new("xcrun")
-             .args(args)
-             .output()
-             .expect("failed to compile")
-     } else {
-         panic!("Unsupported architecture");
-     };
- 
-     if exe.stderr.len() != 0 {
-         panic!("{}", String::from_utf8(exe.stderr).unwrap());
-     }
- 
-     lib
- }
- 
- pub fn write_constants(
-     filepath: &str,
-     num_limbs: usize,
-     log_limb_size: u32,
-     n0: u32,
-     nsafe: usize,
- ) {
-     let two_pow_word_size = 2u32.pow(log_limb_size);
-     let mask = two_pow_word_size - 1u32;
-     let slack = num_limbs as u32 * log_limb_size - BaseField::MODULUS_BIT_SIZE;
-     let num_limbs_wide = num_limbs + 1;
-     let num_limbs_extra_wide = num_limbs * 2;
- 
-     // MSM instance params
-     let input_size = BaseField::MODULUS_BIT_SIZE / 32;
-     let chunk_size = 16;
-     let num_columns = 2u32.pow(chunk_size);
-     let num_rows = (input_size as f32 / num_columns as f32).ceil() as u32;
-     let num_subtasks = (256 as f32 / chunk_size as f32).ceil() as u32;
- 
-     let mut c_workgroup_size = 64;
-     let mut c_num_x_workgroups = 128;
-     let mut c_num_y_workgroups = input_size / c_workgroup_size / c_num_x_workgroups;
-     let c_num_z_workgroups = 1;
- 
-     if input_size <= 256 {
-         c_workgroup_size = input_size;
-         c_num_x_workgroups = 1;
-         c_num_y_workgroups = 1;
-     } else if input_size > 256 && input_size <= 32768 {
-         c_workgroup_size = 64;
-         c_num_x_workgroups = 4;
-         c_num_y_workgroups = input_size / c_workgroup_size / c_num_x_workgroups;
-     } else if input_size > 32768 && input_size <= 65536 {
-         c_workgroup_size = 256;
-         c_num_x_workgroups = 8;
-         c_num_y_workgroups = input_size / c_workgroup_size / c_num_x_workgroups;
-     } else if input_size > 65536 && input_size <= 131072 {
-         c_workgroup_size = 256;
-         c_num_x_workgroups = 8;
-         c_num_y_workgroups = input_size / c_workgroup_size / c_num_x_workgroups;
-     } else if input_size > 131072 && input_size <= 262144 {
-         c_workgroup_size = 256;
-         c_num_x_workgroups = 32;
-         c_num_y_workgroups = input_size / c_workgroup_size / c_num_x_workgroups;
-     } else if input_size > 262144 && input_size <= 524288 {
-         c_workgroup_size = 256;
-         c_num_x_workgroups = 32;
-         c_num_y_workgroups = input_size / c_workgroup_size / c_num_x_workgroups;
-     } else if input_size > 524288 && input_size <= 1048576 {
-         c_workgroup_size = 256;
-         c_num_x_workgroups = 32;
-         c_num_y_workgroups = input_size / c_workgroup_size / c_num_x_workgroups;
-     }
- 
-     let basefield_modulus = BaseField::MODULUS.to_limbs(num_limbs, log_limb_size);
-     let r = calc_mont_radix(num_limbs, log_limb_size);
-     let p: BigUint = BaseField::MODULUS.try_into().unwrap();
-     let mu_in_ark: BigInt<4> = calc_barrett_mu(&p).try_into().unwrap();
-     let mont_radix_limbs: Vec<u32> = {
-         let mont_radix_limbs: BigInt<6> = r.clone().try_into().unwrap();
-         mont_radix_limbs.to_limbs(num_limbs_wide, log_limb_size) // num_limbs_wide because mont_radix is 257 bits
-     };
-     let (bn254_zero, bn254_one) = {
-         let bn254_zero = G::zero();
-         let bn254_one = G::generator();
-         (bn254_zero, bn254_one)
-     };
- 
-     let mut data = "// THIS FILE IS AUTOGENERATED BY shader.rs\n".to_owned();
-     data += "#pragma once\n";
-     data += format!("#define NUM_LIMBS {}\n", num_limbs).as_str();
-     data += format!("#define NUM_LIMBS_WIDE {}\n", num_limbs_wide).as_str();
-     data += format!("#define NUM_LIMBS_EXTRA_WIDE {}\n", num_limbs_extra_wide).as_str();
-     data += format!("#define LOG_LIMB_SIZE {}\n", log_limb_size).as_str();
-     data += format!("#define TWO_POW_WORD_SIZE {}\n", two_pow_word_size).as_str();
-     data += format!("#define MASK {}\n", mask).as_str();
-     data += format!("#define N0 {}\n", n0).as_str();
-     data += format!("#define NSAFE {}\n", nsafe).as_str();
-     data += format!("#define SLACK {}\n", slack).as_str();
-     data += format!("#define CHUNK_SIZE {}\n", chunk_size).as_str();
-     data += format!("#define NUM_COLUMNS {}\n", num_columns).as_str();
-     data += format!("#define NUM_ROWS {}\n", num_rows).as_str();
-     data += format!("#define NUM_SUBTASKS {}\n", num_subtasks).as_str();
-     data += format!("#define WORKGROUP_SIZE {}\n", c_workgroup_size).as_str();
-     data += format!("#define NUM_X_WORKGROUPS {}\n", c_num_x_workgroups).as_str();
-     data += format!("#define NUM_Y_WORKGROUPS {}\n", c_num_y_workgroups).as_str();
-     data += format!("#define NUM_Z_WORKGROUPS {}\n", c_num_z_workgroups).as_str();
- 
-     let mu_limbs = mu_in_ark.to_limbs(num_limbs, log_limb_size);
-     write_constant_array!(data, "BARRETT_MU", mu_limbs, "NUM_LIMBS");
- 
-     write_constant_array!(
-         data,
-         "BN254_BASEFIELD_MODULUS",
-         basefield_modulus,
-         "NUM_LIMBS"
-     );
-     write_constant_array!(data, "MONT_RADIX", mont_radix_limbs, "NUM_LIMBS_WIDE");
- 
-     let bn254_zero_limbs = |c: &ark_ff::BigInt<4>| c.to_limbs(num_limbs, log_limb_size);
-     write_constant_array!(
-         data,
-         "BN254_ZERO_X",
-         bn254_zero_limbs(&bn254_zero.x.into()),
-         "NUM_LIMBS"
-     );
-     write_constant_array!(
-         data,
-         "BN254_ZERO_Y",
-         bn254_zero_limbs(&bn254_zero.y.into()),
-         "NUM_LIMBS"
-     );
-     write_constant_array!(
-         data,
-         "BN254_ZERO_Z",
-         bn254_zero_limbs(&bn254_zero.z.into()),
-         "NUM_LIMBS"
-     );
- 
-     let bn254_one_limbs = |c: &ark_ff::BigInt<4>| c.to_limbs(num_limbs, log_limb_size);
-     write_constant_array!(
-         data,
-         "BN254_ONE_X",
-         bn254_one_limbs(&bn254_one.x.into()),
-         "NUM_LIMBS"
-     );
-     write_constant_array!(
-         data,
-         "BN254_ONE_Y",
-         bn254_one_limbs(&bn254_one.y.into()),
-         "NUM_LIMBS"
-     );
-     write_constant_array!(
-         data,
-         "BN254_ONE_Z",
-         bn254_one_limbs(&bn254_one.z.into()),
-         "NUM_LIMBS"
-     );
- 
-     let p: BigUint = BaseField::MODULUS.try_into().unwrap();
-     let (bn254_zero_xr_limbs, bn254_zero_yr_limbs, bn254_zero_zr_limbs) = {
-         let bn254_zero_x: BigUint = bn254_zero.x.into();
-         let bn254_zero_y: BigUint = bn254_zero.y.into();
-         let bn254_zero_z: BigUint = bn254_zero.z.into();
-         let bn254_zero_xr = (bn254_zero_x * &r) % &p;
-         let bn254_zero_yr = (bn254_zero_y * &r) % &p;
-         let bn254_zero_zr = (bn254_zero_z * &r) % &p;
-         (
-             ark_ff::BigInt::<4>::try_from(bn254_zero_xr)
-                 .unwrap()
-                 .to_limbs(num_limbs, log_limb_size),
-             ark_ff::BigInt::<4>::try_from(bn254_zero_yr)
-                 .unwrap()
-                 .to_limbs(num_limbs, log_limb_size),
-             ark_ff::BigInt::<4>::try_from(bn254_zero_zr)
-                 .unwrap()
-                 .to_limbs(num_limbs, log_limb_size),
-         )
-     };
-     write_constant_array!(data, "BN254_ZERO_XR", bn254_zero_xr_limbs, "NUM_LIMBS");
-     write_constant_array!(data, "BN254_ZERO_YR", bn254_zero_yr_limbs, "NUM_LIMBS");
-     write_constant_array!(data, "BN254_ZERO_ZR", bn254_zero_zr_limbs, "NUM_LIMBS");
- 
-     let (bn254_one_xr_limbs, bn254_one_yr_limbs, bn254_one_zr_limbs) = {
-         let bn254_one_x: BigUint = bn254_one.x.into();
-         let bn254_one_y: BigUint = bn254_one.y.into();
-         let bn254_one_z: BigUint = bn254_one.z.into();
-         let bn254_one_xr = (bn254_one_x * &r) % &p;
-         let bn254_one_yr = (bn254_one_y * &r) % &p;
-         let bn254_one_zr = (bn254_one_z * &r) % &p;
-         (
-             ark_ff::BigInt::<4>::try_from(bn254_one_xr)
-                 .unwrap()
-                 .to_limbs(num_limbs, log_limb_size),
-             ark_ff::BigInt::<4>::try_from(bn254_one_yr)
-                 .unwrap()
-                 .to_limbs(num_limbs, log_limb_size),
-             ark_ff::BigInt::<4>::try_from(bn254_one_zr)
-                 .unwrap()
-                 .to_limbs(num_limbs, log_limb_size),
-         )
-     };
-     write_constant_array!(data, "BN254_ONE_XR", bn254_one_xr_limbs, "NUM_LIMBS");
-     write_constant_array!(data, "BN254_ONE_YR", bn254_one_yr_limbs, "NUM_LIMBS");
-     write_constant_array!(data, "BN254_ONE_ZR", bn254_one_zr_limbs, "NUM_LIMBS");
- 
-     let output_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-         .join(filepath)
-         .join("constants.metal");
-     fs::write(output_path, data).expect("Unable to write constants file");
- }
- 
- #[cfg(test)]
- pub mod tests {
-     use super::*;
- 
-     #[test]
-     #[serial_test::serial]
-     pub fn test_compile() {
-         let lib_filepath = compile_metal(
-             "../mopro-msm/src/msm/metal_msm/shader",
-             "bigint/bigint_add_unsafe.metal",
-         );
-         println!("{}", lib_filepath);
-     }
- 
-     #[test]
-     #[serial_test::serial]
-     pub fn test_write_constants() {
-         write_constants("../mopro-msm/src/msm/metal_msm/shader", 16, 16, 25481, 1);
-     }
- }
- 
+use crate::msm::metal_msm::utils::barrett_params::calc_barrett_mu;
+use crate::msm::metal_msm::utils::limbs_conversion::GenericLimbConversion;
+use crate::msm::metal_msm::utils::mont_params::calc_mont_radix;
+use ark_bn254::{Fq as BaseField, G1Projective as G};
+use ark_ec::Group;
+use ark_ff::{BigInt, PrimeField, Zero};
+use num_bigint::BigUint;
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+use std::string::String;
+
+macro_rules! write_constant_array {
+    ($data:expr, $name:expr, $values:expr, $size:expr) => {
+        $data += format!("constant uint32_t {}[{}] = {{\n", $name, $size).as_str();
+        $data += &$values
+            .iter()
+            .map(|v| format!("    {}", v))
+            .collect::<Vec<_>>()
+            .join(",\n");
+        $data += "\n};\n";
+    };
+}
+
+pub fn compile_metal(path_from_cargo_manifest_dir: &str, input_filename: &str) -> String {
+    let input_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join(path_from_cargo_manifest_dir)
+        .join(input_filename);
+    let c = input_path.clone().into_os_string().into_string().unwrap();
+
+    let lib = input_path.clone().into_os_string().into_string().unwrap();
+    let lib = format!("{}.lib", lib);
+
+    let exe = if cfg!(target_os = "ios") {
+        Command::new("xcrun")
+            .args([
+                "-sdk",
+                "iphoneos",
+                "metal",
+                "-std=metal3.2",
+                "-target",
+                "air64-apple-ios18.0",
+                "-fmetal-enable-logging",
+                "-o",
+                lib.as_str(),
+                c.as_str(),
+            ])
+            .output()
+            .expect("failed to compile")
+    } else if cfg!(target_os = "macos") {
+        let macos_version = std::process::Command::new("sw_vers")
+            .args(["-productVersion"])
+            .output()
+            .ok()
+            .and_then(|output| String::from_utf8(output.stdout).ok())
+            .and_then(|version| {
+                version
+                    .trim()
+                    .split('.')
+                    .next()
+                    .and_then(|major| major.parse::<u32>().ok())
+            })
+            .unwrap_or(0);
+
+        let mut args = vec!["-sdk", "macosx", "metal"];
+
+        // Only specify Metal 3.2 for metal logging if macOS version is 15.0 or higher
+        if macos_version >= 15 {
+            args.extend([
+                "-std=metal3.2",
+                "-target",
+                "air64-apple-macos15.0",
+                "-fmetal-enable-logging",
+            ]);
+        }
+
+        args.extend(["-o", lib.as_str(), c.as_str()]);
+
+        Command::new("xcrun")
+            .args(args)
+            .output()
+            .expect("failed to compile")
+    } else {
+        panic!("Unsupported architecture");
+    };
+
+    if exe.stderr.len() != 0 {
+        panic!("{}", String::from_utf8(exe.stderr).unwrap());
+    }
+
+    lib
+}
+
+pub fn write_constants(
+    filepath: &str,
+    num_limbs: usize,
+    log_limb_size: u32,
+    n0: u32,
+    nsafe: usize,
+) {
+    let two_pow_word_size = 2u32.pow(log_limb_size);
+    let mask = two_pow_word_size - 1u32;
+    let slack = num_limbs as u32 * log_limb_size - BaseField::MODULUS_BIT_SIZE;
+    let num_limbs_wide = num_limbs + 1;
+    let num_limbs_extra_wide = num_limbs * 2;
+
+    // MSM instance params
+    let input_size = BaseField::MODULUS_BIT_SIZE / 32;
+    let chunk_size = 16;
+    let num_columns = 2u32.pow(chunk_size);
+    let num_rows = (input_size as f32 / num_columns as f32).ceil() as u32;
+    let num_subtasks = (256 as f32 / chunk_size as f32).ceil() as u32;
+
+    let mut c_workgroup_size = 64;
+    let mut c_num_x_workgroups = 128;
+    let mut c_num_y_workgroups = input_size / c_workgroup_size / c_num_x_workgroups;
+    let c_num_z_workgroups = 1;
+
+    if input_size <= 256 {
+        c_workgroup_size = input_size;
+        c_num_x_workgroups = 1;
+        c_num_y_workgroups = 1;
+    } else if input_size > 256 && input_size <= 32768 {
+        c_workgroup_size = 64;
+        c_num_x_workgroups = 4;
+        c_num_y_workgroups = input_size / c_workgroup_size / c_num_x_workgroups;
+    } else if input_size > 32768 && input_size <= 65536 {
+        c_workgroup_size = 256;
+        c_num_x_workgroups = 8;
+        c_num_y_workgroups = input_size / c_workgroup_size / c_num_x_workgroups;
+    } else if input_size > 65536 && input_size <= 131072 {
+        c_workgroup_size = 256;
+        c_num_x_workgroups = 8;
+        c_num_y_workgroups = input_size / c_workgroup_size / c_num_x_workgroups;
+    } else if input_size > 131072 && input_size <= 262144 {
+        c_workgroup_size = 256;
+        c_num_x_workgroups = 32;
+        c_num_y_workgroups = input_size / c_workgroup_size / c_num_x_workgroups;
+    } else if input_size > 262144 && input_size <= 524288 {
+        c_workgroup_size = 256;
+        c_num_x_workgroups = 32;
+        c_num_y_workgroups = input_size / c_workgroup_size / c_num_x_workgroups;
+    } else if input_size > 524288 && input_size <= 1048576 {
+        c_workgroup_size = 256;
+        c_num_x_workgroups = 32;
+        c_num_y_workgroups = input_size / c_workgroup_size / c_num_x_workgroups;
+    }
+
+    let basefield_modulus = BaseField::MODULUS.to_limbs(num_limbs, log_limb_size);
+    let r = calc_mont_radix(num_limbs, log_limb_size);
+    let p: BigUint = BaseField::MODULUS.try_into().unwrap();
+    let mu_in_ark: BigInt<4> = calc_barrett_mu(&p).try_into().unwrap();
+    let mont_radix_limbs: Vec<u32> = {
+        let mont_radix_limbs: BigInt<6> = r.clone().try_into().unwrap();
+        mont_radix_limbs.to_limbs(num_limbs_wide, log_limb_size) // num_limbs_wide because mont_radix is 257 bits
+    };
+    let (bn254_zero, bn254_one) = {
+        let bn254_zero = G::zero();
+        let bn254_one = G::generator();
+        (bn254_zero, bn254_one)
+    };
+
+    let mut data = "// THIS FILE IS AUTOGENERATED BY shader.rs\n".to_owned();
+    data += "#pragma once\n";
+    data += format!("#define NUM_LIMBS {}\n", num_limbs).as_str();
+    data += format!("#define NUM_LIMBS_WIDE {}\n", num_limbs_wide).as_str();
+    data += format!("#define NUM_LIMBS_EXTRA_WIDE {}\n", num_limbs_extra_wide).as_str();
+    data += format!("#define LOG_LIMB_SIZE {}\n", log_limb_size).as_str();
+    data += format!("#define TWO_POW_WORD_SIZE {}\n", two_pow_word_size).as_str();
+    data += format!("#define MASK {}\n", mask).as_str();
+    data += format!("#define N0 {}\n", n0).as_str();
+    data += format!("#define NSAFE {}\n", nsafe).as_str();
+    data += format!("#define SLACK {}\n", slack).as_str();
+    data += format!("#define CHUNK_SIZE {}\n", chunk_size).as_str();
+    data += format!("#define NUM_COLUMNS {}\n", num_columns).as_str();
+    data += format!("#define NUM_ROWS {}\n", num_rows).as_str();
+    data += format!("#define NUM_SUBTASKS {}\n", num_subtasks).as_str();
+    data += format!("#define WORKGROUP_SIZE {}\n", c_workgroup_size).as_str();
+    data += format!("#define NUM_X_WORKGROUPS {}\n", c_num_x_workgroups).as_str();
+    data += format!("#define NUM_Y_WORKGROUPS {}\n", c_num_y_workgroups).as_str();
+    data += format!("#define NUM_Z_WORKGROUPS {}\n", c_num_z_workgroups).as_str();
+
+    let mu_limbs = mu_in_ark.to_limbs(num_limbs, log_limb_size);
+    write_constant_array!(data, "BARRETT_MU", mu_limbs, "NUM_LIMBS");
+
+    write_constant_array!(
+        data,
+        "BN254_BASEFIELD_MODULUS",
+        basefield_modulus,
+        "NUM_LIMBS"
+    );
+    write_constant_array!(data, "MONT_RADIX", mont_radix_limbs, "NUM_LIMBS_WIDE");
+
+    let bn254_zero_limbs = |c: &ark_ff::BigInt<4>| c.to_limbs(num_limbs, log_limb_size);
+    write_constant_array!(
+        data,
+        "BN254_ZERO_X",
+        bn254_zero_limbs(&bn254_zero.x.into()),
+        "NUM_LIMBS"
+    );
+    write_constant_array!(
+        data,
+        "BN254_ZERO_Y",
+        bn254_zero_limbs(&bn254_zero.y.into()),
+        "NUM_LIMBS"
+    );
+    write_constant_array!(
+        data,
+        "BN254_ZERO_Z",
+        bn254_zero_limbs(&bn254_zero.z.into()),
+        "NUM_LIMBS"
+    );
+
+    let bn254_one_limbs = |c: &ark_ff::BigInt<4>| c.to_limbs(num_limbs, log_limb_size);
+    write_constant_array!(
+        data,
+        "BN254_ONE_X",
+        bn254_one_limbs(&bn254_one.x.into()),
+        "NUM_LIMBS"
+    );
+    write_constant_array!(
+        data,
+        "BN254_ONE_Y",
+        bn254_one_limbs(&bn254_one.y.into()),
+        "NUM_LIMBS"
+    );
+    write_constant_array!(
+        data,
+        "BN254_ONE_Z",
+        bn254_one_limbs(&bn254_one.z.into()),
+        "NUM_LIMBS"
+    );
+
+    let p: BigUint = BaseField::MODULUS.try_into().unwrap();
+    let (bn254_zero_xr_limbs, bn254_zero_yr_limbs, bn254_zero_zr_limbs) = {
+        let bn254_zero_x: BigUint = bn254_zero.x.into();
+        let bn254_zero_y: BigUint = bn254_zero.y.into();
+        let bn254_zero_z: BigUint = bn254_zero.z.into();
+        let bn254_zero_xr = (bn254_zero_x * &r) % &p;
+        let bn254_zero_yr = (bn254_zero_y * &r) % &p;
+        let bn254_zero_zr = (bn254_zero_z * &r) % &p;
+        (
+            ark_ff::BigInt::<4>::try_from(bn254_zero_xr)
+                .unwrap()
+                .to_limbs(num_limbs, log_limb_size),
+            ark_ff::BigInt::<4>::try_from(bn254_zero_yr)
+                .unwrap()
+                .to_limbs(num_limbs, log_limb_size),
+            ark_ff::BigInt::<4>::try_from(bn254_zero_zr)
+                .unwrap()
+                .to_limbs(num_limbs, log_limb_size),
+        )
+    };
+    write_constant_array!(data, "BN254_ZERO_XR", bn254_zero_xr_limbs, "NUM_LIMBS");
+    write_constant_array!(data, "BN254_ZERO_YR", bn254_zero_yr_limbs, "NUM_LIMBS");
+    write_constant_array!(data, "BN254_ZERO_ZR", bn254_zero_zr_limbs, "NUM_LIMBS");
+
+    let (bn254_one_xr_limbs, bn254_one_yr_limbs, bn254_one_zr_limbs) = {
+        let bn254_one_x: BigUint = bn254_one.x.into();
+        let bn254_one_y: BigUint = bn254_one.y.into();
+        let bn254_one_z: BigUint = bn254_one.z.into();
+        let bn254_one_xr = (bn254_one_x * &r) % &p;
+        let bn254_one_yr = (bn254_one_y * &r) % &p;
+        let bn254_one_zr = (bn254_one_z * &r) % &p;
+        (
+            ark_ff::BigInt::<4>::try_from(bn254_one_xr)
+                .unwrap()
+                .to_limbs(num_limbs, log_limb_size),
+            ark_ff::BigInt::<4>::try_from(bn254_one_yr)
+                .unwrap()
+                .to_limbs(num_limbs, log_limb_size),
+            ark_ff::BigInt::<4>::try_from(bn254_one_zr)
+                .unwrap()
+                .to_limbs(num_limbs, log_limb_size),
+        )
+    };
+    write_constant_array!(data, "BN254_ONE_XR", bn254_one_xr_limbs, "NUM_LIMBS");
+    write_constant_array!(data, "BN254_ONE_YR", bn254_one_yr_limbs, "NUM_LIMBS");
+    write_constant_array!(data, "BN254_ONE_ZR", bn254_one_zr_limbs, "NUM_LIMBS");
+
+    let output_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join(filepath)
+        .join("constants.metal");
+    fs::write(output_path, data).expect("Unable to write constants file");
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+
+    #[test]
+    #[serial_test::serial]
+    pub fn test_compile() {
+        let lib_filepath = compile_metal(
+            "../mopro-msm/src/msm/metal_msm/shader",
+            "bigint/bigint_add_unsafe.metal",
+        );
+        println!("{}", lib_filepath);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    pub fn test_write_constants() {
+        write_constants("../mopro-msm/src/msm/metal_msm/shader", 16, 16, 25481, 1);
+    }
+}

--- a/mopro-msm/src/msm/metal_msm/host/shader.rs
+++ b/mopro-msm/src/msm/metal_msm/host/shader.rs
@@ -12,309 +12,310 @@
  * xcrun -sdk macosx metallib <path.ir> -o <path.metallib>
  */
 
-use crate::msm::metal_msm::utils::barrett_params::calc_barrett_mu;
-use crate::msm::metal_msm::utils::limbs_conversion::GenericLimbConversion;
-use crate::msm::metal_msm::utils::mont_params::calc_mont_radix;
-use ark_bn254::{Fq as BaseField, G1Projective as G};
-use ark_ec::Group;
-use ark_ff::{BigInt, PrimeField, Zero};
-use num_bigint::BigUint;
-use std::fs;
-use std::path::PathBuf;
-use std::process::Command;
-use std::string::String;
-
-macro_rules! write_constant_array {
-    ($data:expr, $name:expr, $values:expr, $size:expr) => {
-        $data += format!("constant uint32_t {}[{}] = {{\n", $name, $size).as_str();
-        $data += &$values
-            .iter()
-            .map(|v| format!("    {}", v))
-            .collect::<Vec<_>>()
-            .join(",\n");
-        $data += "\n};\n";
-    };
-}
-
-pub fn compile_metal(path_from_cargo_manifest_dir: &str, input_filename: &str) -> String {
-    let input_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join(path_from_cargo_manifest_dir)
-        .join(input_filename);
-    let c = input_path.clone().into_os_string().into_string().unwrap();
-
-    let lib = input_path.clone().into_os_string().into_string().unwrap();
-    let lib = format!("{}.lib", lib);
-
-    let exe = if cfg!(target_os = "ios") {
-        Command::new("xcrun")
-            .args([
-                "-sdk",
-                "iphoneos",
-                "metal",
-                "-std=metal3.2",
-                "-target",
-                "air64-apple-ios18.0",
-                "-fmetal-enable-logging",
-                "-o",
-                lib.as_str(),
-                c.as_str(),
-            ])
-            .output()
-            .expect("failed to compile")
-    } else if cfg!(target_os = "macos") {
-        let macos_version = std::process::Command::new("sw_vers")
-            .args(["-productVersion"])
-            .output()
-            .ok()
-            .and_then(|output| String::from_utf8(output.stdout).ok())
-            .and_then(|version| {
-                version
-                    .trim()
-                    .split('.')
-                    .next()
-                    .and_then(|major| major.parse::<u32>().ok())
-            })
-            .unwrap_or(0);
-
-        let mut args = vec!["-sdk", "macosx", "metal"];
-
-        // Only specify Metal 3.2 for metal logging if macOS version is 15.0 or higher
-        if macos_version >= 15 {
-            args.extend([
-                "-std=metal3.2",
-                "-target",
-                "air64-apple-macos15.0",
-                "-fmetal-enable-logging",
-            ]);
-        }
-
-        args.extend(["-o", lib.as_str(), c.as_str()]);
-
-        Command::new("xcrun")
-            .args(args)
-            .output()
-            .expect("failed to compile")
-    } else {
-        panic!("Unsupported architecture");
-    };
-
-    if exe.stderr.len() != 0 {
-        panic!("{}", String::from_utf8(exe.stderr).unwrap());
-    }
-
-    lib
-}
-
-pub fn write_constants(
-    filepath: &str,
-    num_limbs: usize,
-    log_limb_size: u32,
-    n0: u32,
-    nsafe: usize,
-) {
-    let two_pow_word_size = 2u32.pow(log_limb_size);
-    let mask = two_pow_word_size - 1u32;
-    let slack = num_limbs as u32 * log_limb_size - BaseField::MODULUS_BIT_SIZE;
-    let num_limbs_wide = num_limbs + 1;
-    let num_limbs_extra_wide = num_limbs * 2;
-
-    // MSM instance params
-    let input_size = BaseField::MODULUS_BIT_SIZE / 32;
-    let chunk_size = if input_size >= 65536 { 16 } else { 4 };
-    let num_columns = 2u32.pow(chunk_size);
-    let num_rows = (input_size as f32 / num_columns as f32).ceil() as u32;
-    let num_subtasks = (256 as f32 / chunk_size as f32).ceil() as u32;
-
-    let mut c_workgroup_size = 64;
-    let mut c_num_x_workgroups = 128;
-    let mut c_num_y_workgroups = input_size / c_workgroup_size / c_num_x_workgroups;
-    let c_num_z_workgroups = 1;
-
-    if input_size <= 256 {
-        c_workgroup_size = input_size;
-        c_num_x_workgroups = 1;
-        c_num_y_workgroups = 1;
-    } else if input_size > 256 && input_size <= 32768 {
-        c_workgroup_size = 64;
-        c_num_x_workgroups = 4;
-        c_num_y_workgroups = input_size / c_workgroup_size / c_num_x_workgroups;
-    } else if input_size > 32768 && input_size <= 65536 {
-        c_workgroup_size = 256;
-        c_num_x_workgroups = 8;
-        c_num_y_workgroups = input_size / c_workgroup_size / c_num_x_workgroups;
-    } else if input_size > 65536 && input_size <= 131072 {
-        c_workgroup_size = 256;
-        c_num_x_workgroups = 8;
-        c_num_y_workgroups = input_size / c_workgroup_size / c_num_x_workgroups;
-    } else if input_size > 131072 && input_size <= 262144 {
-        c_workgroup_size = 256;
-        c_num_x_workgroups = 32;
-        c_num_y_workgroups = input_size / c_workgroup_size / c_num_x_workgroups;
-    } else if input_size > 262144 && input_size <= 524288 {
-        c_workgroup_size = 256;
-        c_num_x_workgroups = 32;
-        c_num_y_workgroups = input_size / c_workgroup_size / c_num_x_workgroups;
-    } else if input_size > 524288 && input_size <= 1048576 {
-        c_workgroup_size = 256;
-        c_num_x_workgroups = 32;
-        c_num_y_workgroups = input_size / c_workgroup_size / c_num_x_workgroups;
-    }
-
-    let basefield_modulus = BaseField::MODULUS.to_limbs(num_limbs, log_limb_size);
-    let r = calc_mont_radix(num_limbs, log_limb_size);
-    let p: BigUint = BaseField::MODULUS.try_into().unwrap();
-    let mu_in_ark: BigInt<4> = calc_barrett_mu(&p).try_into().unwrap();
-    let mont_radix_limbs: Vec<u32> = {
-        let mont_radix_limbs: BigInt<6> = r.clone().try_into().unwrap();
-        mont_radix_limbs.to_limbs(num_limbs_wide, log_limb_size) // num_limbs_wide because mont_radix is 257 bits
-    };
-    let (bn254_zero, bn254_one) = {
-        let bn254_zero = G::zero();
-        let bn254_one = G::generator();
-        (bn254_zero, bn254_one)
-    };
-
-    let mut data = "// THIS FILE IS AUTOGENERATED BY shader.rs\n".to_owned();
-    data += "#pragma once\n";
-    data += format!("#define NUM_LIMBS {}\n", num_limbs).as_str();
-    data += format!("#define NUM_LIMBS_WIDE {}\n", num_limbs_wide).as_str();
-    data += format!("#define NUM_LIMBS_EXTRA_WIDE {}\n", num_limbs_extra_wide).as_str();
-    data += format!("#define LOG_LIMB_SIZE {}\n", log_limb_size).as_str();
-    data += format!("#define TWO_POW_WORD_SIZE {}\n", two_pow_word_size).as_str();
-    data += format!("#define MASK {}\n", mask).as_str();
-    data += format!("#define N0 {}\n", n0).as_str();
-    data += format!("#define NSAFE {}\n", nsafe).as_str();
-    data += format!("#define SLACK {}\n", slack).as_str();
-    data += format!("#define CHUNK_SIZE {}\n", chunk_size).as_str();
-    data += format!("#define NUM_COLUMNS {}\n", num_columns).as_str();
-    data += format!("#define NUM_ROWS {}\n", num_rows).as_str();
-    data += format!("#define NUM_SUBTASKS {}\n", num_subtasks).as_str();
-    data += format!("#define WORKGROUP_SIZE {}\n", c_workgroup_size).as_str();
-    data += format!("#define NUM_X_WORKGROUPS {}\n", c_num_x_workgroups).as_str();
-    data += format!("#define NUM_Y_WORKGROUPS {}\n", c_num_y_workgroups).as_str();
-    data += format!("#define NUM_Z_WORKGROUPS {}\n", c_num_z_workgroups).as_str();
-
-    let mu_limbs = mu_in_ark.to_limbs(num_limbs, log_limb_size);
-    write_constant_array!(data, "BARRETT_MU", mu_limbs, "NUM_LIMBS");
-
-    write_constant_array!(
-        data,
-        "BN254_BASEFIELD_MODULUS",
-        basefield_modulus,
-        "NUM_LIMBS"
-    );
-    write_constant_array!(data, "MONT_RADIX", mont_radix_limbs, "NUM_LIMBS_WIDE");
-
-    let bn254_zero_limbs = |c: &ark_ff::BigInt<4>| c.to_limbs(num_limbs, log_limb_size);
-    write_constant_array!(
-        data,
-        "BN254_ZERO_X",
-        bn254_zero_limbs(&bn254_zero.x.into()),
-        "NUM_LIMBS"
-    );
-    write_constant_array!(
-        data,
-        "BN254_ZERO_Y",
-        bn254_zero_limbs(&bn254_zero.y.into()),
-        "NUM_LIMBS"
-    );
-    write_constant_array!(
-        data,
-        "BN254_ZERO_Z",
-        bn254_zero_limbs(&bn254_zero.z.into()),
-        "NUM_LIMBS"
-    );
-
-    let bn254_one_limbs = |c: &ark_ff::BigInt<4>| c.to_limbs(num_limbs, log_limb_size);
-    write_constant_array!(
-        data,
-        "BN254_ONE_X",
-        bn254_one_limbs(&bn254_one.x.into()),
-        "NUM_LIMBS"
-    );
-    write_constant_array!(
-        data,
-        "BN254_ONE_Y",
-        bn254_one_limbs(&bn254_one.y.into()),
-        "NUM_LIMBS"
-    );
-    write_constant_array!(
-        data,
-        "BN254_ONE_Z",
-        bn254_one_limbs(&bn254_one.z.into()),
-        "NUM_LIMBS"
-    );
-
-    let p: BigUint = BaseField::MODULUS.try_into().unwrap();
-    let (bn254_zero_xr_limbs, bn254_zero_yr_limbs, bn254_zero_zr_limbs) = {
-        let bn254_zero_x: BigUint = bn254_zero.x.into();
-        let bn254_zero_y: BigUint = bn254_zero.y.into();
-        let bn254_zero_z: BigUint = bn254_zero.z.into();
-        let bn254_zero_xr = (bn254_zero_x * &r) % &p;
-        let bn254_zero_yr = (bn254_zero_y * &r) % &p;
-        let bn254_zero_zr = (bn254_zero_z * &r) % &p;
-        (
-            ark_ff::BigInt::<4>::try_from(bn254_zero_xr)
-                .unwrap()
-                .to_limbs(num_limbs, log_limb_size),
-            ark_ff::BigInt::<4>::try_from(bn254_zero_yr)
-                .unwrap()
-                .to_limbs(num_limbs, log_limb_size),
-            ark_ff::BigInt::<4>::try_from(bn254_zero_zr)
-                .unwrap()
-                .to_limbs(num_limbs, log_limb_size),
-        )
-    };
-    write_constant_array!(data, "BN254_ZERO_XR", bn254_zero_xr_limbs, "NUM_LIMBS");
-    write_constant_array!(data, "BN254_ZERO_YR", bn254_zero_yr_limbs, "NUM_LIMBS");
-    write_constant_array!(data, "BN254_ZERO_ZR", bn254_zero_zr_limbs, "NUM_LIMBS");
-
-    let (bn254_one_xr_limbs, bn254_one_yr_limbs, bn254_one_zr_limbs) = {
-        let bn254_one_x: BigUint = bn254_one.x.into();
-        let bn254_one_y: BigUint = bn254_one.y.into();
-        let bn254_one_z: BigUint = bn254_one.z.into();
-        let bn254_one_xr = (bn254_one_x * &r) % &p;
-        let bn254_one_yr = (bn254_one_y * &r) % &p;
-        let bn254_one_zr = (bn254_one_z * &r) % &p;
-        (
-            ark_ff::BigInt::<4>::try_from(bn254_one_xr)
-                .unwrap()
-                .to_limbs(num_limbs, log_limb_size),
-            ark_ff::BigInt::<4>::try_from(bn254_one_yr)
-                .unwrap()
-                .to_limbs(num_limbs, log_limb_size),
-            ark_ff::BigInt::<4>::try_from(bn254_one_zr)
-                .unwrap()
-                .to_limbs(num_limbs, log_limb_size),
-        )
-    };
-    write_constant_array!(data, "BN254_ONE_XR", bn254_one_xr_limbs, "NUM_LIMBS");
-    write_constant_array!(data, "BN254_ONE_YR", bn254_one_yr_limbs, "NUM_LIMBS");
-    write_constant_array!(data, "BN254_ONE_ZR", bn254_one_zr_limbs, "NUM_LIMBS");
-
-    let output_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join(filepath)
-        .join("constants.metal");
-    fs::write(output_path, data).expect("Unable to write constants file");
-}
-
-#[cfg(test)]
-pub mod tests {
-    use super::*;
-
-    #[test]
-    #[serial_test::serial]
-    pub fn test_compile() {
-        let lib_filepath = compile_metal(
-            "../mopro-msm/src/msm/metal_msm/shader",
-            "bigint/bigint_add_unsafe.metal",
-        );
-        println!("{}", lib_filepath);
-    }
-
-    #[test]
-    #[serial_test::serial]
-    pub fn test_write_constants() {
-        write_constants("../mopro-msm/src/msm/metal_msm/shader", 16, 16, 25481, 1);
-    }
-}
+ use crate::msm::metal_msm::utils::barrett_params::calc_barrett_mu;
+ use crate::msm::metal_msm::utils::limbs_conversion::GenericLimbConversion;
+ use crate::msm::metal_msm::utils::mont_params::calc_mont_radix;
+ use ark_bn254::{Fq as BaseField, G1Projective as G};
+ use ark_ec::Group;
+ use ark_ff::{BigInt, PrimeField, Zero};
+ use num_bigint::BigUint;
+ use std::fs;
+ use std::path::PathBuf;
+ use std::process::Command;
+ use std::string::String;
+ 
+ macro_rules! write_constant_array {
+     ($data:expr, $name:expr, $values:expr, $size:expr) => {
+         $data += format!("constant uint32_t {}[{}] = {{\n", $name, $size).as_str();
+         $data += &$values
+             .iter()
+             .map(|v| format!("    {}", v))
+             .collect::<Vec<_>>()
+             .join(",\n");
+         $data += "\n};\n";
+     };
+ }
+ 
+ pub fn compile_metal(path_from_cargo_manifest_dir: &str, input_filename: &str) -> String {
+     let input_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+         .join(path_from_cargo_manifest_dir)
+         .join(input_filename);
+     let c = input_path.clone().into_os_string().into_string().unwrap();
+ 
+     let lib = input_path.clone().into_os_string().into_string().unwrap();
+     let lib = format!("{}.lib", lib);
+ 
+     let exe = if cfg!(target_os = "ios") {
+         Command::new("xcrun")
+             .args([
+                 "-sdk",
+                 "iphoneos",
+                 "metal",
+                 "-std=metal3.2",
+                 "-target",
+                 "air64-apple-ios18.0",
+                 "-fmetal-enable-logging",
+                 "-o",
+                 lib.as_str(),
+                 c.as_str(),
+             ])
+             .output()
+             .expect("failed to compile")
+     } else if cfg!(target_os = "macos") {
+         let macos_version = std::process::Command::new("sw_vers")
+             .args(["-productVersion"])
+             .output()
+             .ok()
+             .and_then(|output| String::from_utf8(output.stdout).ok())
+             .and_then(|version| {
+                 version
+                     .trim()
+                     .split('.')
+                     .next()
+                     .and_then(|major| major.parse::<u32>().ok())
+             })
+             .unwrap_or(0);
+ 
+         let mut args = vec!["-sdk", "macosx", "metal"];
+ 
+         // Only specify Metal 3.2 for metal logging if macOS version is 15.0 or higher
+         if macos_version >= 15 {
+             args.extend([
+                 "-std=metal3.2",
+                 "-target",
+                 "air64-apple-macos15.0",
+                 "-fmetal-enable-logging",
+             ]);
+         }
+ 
+         args.extend(["-o", lib.as_str(), c.as_str()]);
+ 
+         Command::new("xcrun")
+             .args(args)
+             .output()
+             .expect("failed to compile")
+     } else {
+         panic!("Unsupported architecture");
+     };
+ 
+     if exe.stderr.len() != 0 {
+         panic!("{}", String::from_utf8(exe.stderr).unwrap());
+     }
+ 
+     lib
+ }
+ 
+ pub fn write_constants(
+     filepath: &str,
+     num_limbs: usize,
+     log_limb_size: u32,
+     n0: u32,
+     nsafe: usize,
+ ) {
+     let two_pow_word_size = 2u32.pow(log_limb_size);
+     let mask = two_pow_word_size - 1u32;
+     let slack = num_limbs as u32 * log_limb_size - BaseField::MODULUS_BIT_SIZE;
+     let num_limbs_wide = num_limbs + 1;
+     let num_limbs_extra_wide = num_limbs * 2;
+ 
+     // MSM instance params
+     let input_size = BaseField::MODULUS_BIT_SIZE / 32;
+     let chunk_size = 16;
+     let num_columns = 2u32.pow(chunk_size);
+     let num_rows = (input_size as f32 / num_columns as f32).ceil() as u32;
+     let num_subtasks = (256 as f32 / chunk_size as f32).ceil() as u32;
+ 
+     let mut c_workgroup_size = 64;
+     let mut c_num_x_workgroups = 128;
+     let mut c_num_y_workgroups = input_size / c_workgroup_size / c_num_x_workgroups;
+     let c_num_z_workgroups = 1;
+ 
+     if input_size <= 256 {
+         c_workgroup_size = input_size;
+         c_num_x_workgroups = 1;
+         c_num_y_workgroups = 1;
+     } else if input_size > 256 && input_size <= 32768 {
+         c_workgroup_size = 64;
+         c_num_x_workgroups = 4;
+         c_num_y_workgroups = input_size / c_workgroup_size / c_num_x_workgroups;
+     } else if input_size > 32768 && input_size <= 65536 {
+         c_workgroup_size = 256;
+         c_num_x_workgroups = 8;
+         c_num_y_workgroups = input_size / c_workgroup_size / c_num_x_workgroups;
+     } else if input_size > 65536 && input_size <= 131072 {
+         c_workgroup_size = 256;
+         c_num_x_workgroups = 8;
+         c_num_y_workgroups = input_size / c_workgroup_size / c_num_x_workgroups;
+     } else if input_size > 131072 && input_size <= 262144 {
+         c_workgroup_size = 256;
+         c_num_x_workgroups = 32;
+         c_num_y_workgroups = input_size / c_workgroup_size / c_num_x_workgroups;
+     } else if input_size > 262144 && input_size <= 524288 {
+         c_workgroup_size = 256;
+         c_num_x_workgroups = 32;
+         c_num_y_workgroups = input_size / c_workgroup_size / c_num_x_workgroups;
+     } else if input_size > 524288 && input_size <= 1048576 {
+         c_workgroup_size = 256;
+         c_num_x_workgroups = 32;
+         c_num_y_workgroups = input_size / c_workgroup_size / c_num_x_workgroups;
+     }
+ 
+     let basefield_modulus = BaseField::MODULUS.to_limbs(num_limbs, log_limb_size);
+     let r = calc_mont_radix(num_limbs, log_limb_size);
+     let p: BigUint = BaseField::MODULUS.try_into().unwrap();
+     let mu_in_ark: BigInt<4> = calc_barrett_mu(&p).try_into().unwrap();
+     let mont_radix_limbs: Vec<u32> = {
+         let mont_radix_limbs: BigInt<6> = r.clone().try_into().unwrap();
+         mont_radix_limbs.to_limbs(num_limbs_wide, log_limb_size) // num_limbs_wide because mont_radix is 257 bits
+     };
+     let (bn254_zero, bn254_one) = {
+         let bn254_zero = G::zero();
+         let bn254_one = G::generator();
+         (bn254_zero, bn254_one)
+     };
+ 
+     let mut data = "// THIS FILE IS AUTOGENERATED BY shader.rs\n".to_owned();
+     data += "#pragma once\n";
+     data += format!("#define NUM_LIMBS {}\n", num_limbs).as_str();
+     data += format!("#define NUM_LIMBS_WIDE {}\n", num_limbs_wide).as_str();
+     data += format!("#define NUM_LIMBS_EXTRA_WIDE {}\n", num_limbs_extra_wide).as_str();
+     data += format!("#define LOG_LIMB_SIZE {}\n", log_limb_size).as_str();
+     data += format!("#define TWO_POW_WORD_SIZE {}\n", two_pow_word_size).as_str();
+     data += format!("#define MASK {}\n", mask).as_str();
+     data += format!("#define N0 {}\n", n0).as_str();
+     data += format!("#define NSAFE {}\n", nsafe).as_str();
+     data += format!("#define SLACK {}\n", slack).as_str();
+     data += format!("#define CHUNK_SIZE {}\n", chunk_size).as_str();
+     data += format!("#define NUM_COLUMNS {}\n", num_columns).as_str();
+     data += format!("#define NUM_ROWS {}\n", num_rows).as_str();
+     data += format!("#define NUM_SUBTASKS {}\n", num_subtasks).as_str();
+     data += format!("#define WORKGROUP_SIZE {}\n", c_workgroup_size).as_str();
+     data += format!("#define NUM_X_WORKGROUPS {}\n", c_num_x_workgroups).as_str();
+     data += format!("#define NUM_Y_WORKGROUPS {}\n", c_num_y_workgroups).as_str();
+     data += format!("#define NUM_Z_WORKGROUPS {}\n", c_num_z_workgroups).as_str();
+ 
+     let mu_limbs = mu_in_ark.to_limbs(num_limbs, log_limb_size);
+     write_constant_array!(data, "BARRETT_MU", mu_limbs, "NUM_LIMBS");
+ 
+     write_constant_array!(
+         data,
+         "BN254_BASEFIELD_MODULUS",
+         basefield_modulus,
+         "NUM_LIMBS"
+     );
+     write_constant_array!(data, "MONT_RADIX", mont_radix_limbs, "NUM_LIMBS_WIDE");
+ 
+     let bn254_zero_limbs = |c: &ark_ff::BigInt<4>| c.to_limbs(num_limbs, log_limb_size);
+     write_constant_array!(
+         data,
+         "BN254_ZERO_X",
+         bn254_zero_limbs(&bn254_zero.x.into()),
+         "NUM_LIMBS"
+     );
+     write_constant_array!(
+         data,
+         "BN254_ZERO_Y",
+         bn254_zero_limbs(&bn254_zero.y.into()),
+         "NUM_LIMBS"
+     );
+     write_constant_array!(
+         data,
+         "BN254_ZERO_Z",
+         bn254_zero_limbs(&bn254_zero.z.into()),
+         "NUM_LIMBS"
+     );
+ 
+     let bn254_one_limbs = |c: &ark_ff::BigInt<4>| c.to_limbs(num_limbs, log_limb_size);
+     write_constant_array!(
+         data,
+         "BN254_ONE_X",
+         bn254_one_limbs(&bn254_one.x.into()),
+         "NUM_LIMBS"
+     );
+     write_constant_array!(
+         data,
+         "BN254_ONE_Y",
+         bn254_one_limbs(&bn254_one.y.into()),
+         "NUM_LIMBS"
+     );
+     write_constant_array!(
+         data,
+         "BN254_ONE_Z",
+         bn254_one_limbs(&bn254_one.z.into()),
+         "NUM_LIMBS"
+     );
+ 
+     let p: BigUint = BaseField::MODULUS.try_into().unwrap();
+     let (bn254_zero_xr_limbs, bn254_zero_yr_limbs, bn254_zero_zr_limbs) = {
+         let bn254_zero_x: BigUint = bn254_zero.x.into();
+         let bn254_zero_y: BigUint = bn254_zero.y.into();
+         let bn254_zero_z: BigUint = bn254_zero.z.into();
+         let bn254_zero_xr = (bn254_zero_x * &r) % &p;
+         let bn254_zero_yr = (bn254_zero_y * &r) % &p;
+         let bn254_zero_zr = (bn254_zero_z * &r) % &p;
+         (
+             ark_ff::BigInt::<4>::try_from(bn254_zero_xr)
+                 .unwrap()
+                 .to_limbs(num_limbs, log_limb_size),
+             ark_ff::BigInt::<4>::try_from(bn254_zero_yr)
+                 .unwrap()
+                 .to_limbs(num_limbs, log_limb_size),
+             ark_ff::BigInt::<4>::try_from(bn254_zero_zr)
+                 .unwrap()
+                 .to_limbs(num_limbs, log_limb_size),
+         )
+     };
+     write_constant_array!(data, "BN254_ZERO_XR", bn254_zero_xr_limbs, "NUM_LIMBS");
+     write_constant_array!(data, "BN254_ZERO_YR", bn254_zero_yr_limbs, "NUM_LIMBS");
+     write_constant_array!(data, "BN254_ZERO_ZR", bn254_zero_zr_limbs, "NUM_LIMBS");
+ 
+     let (bn254_one_xr_limbs, bn254_one_yr_limbs, bn254_one_zr_limbs) = {
+         let bn254_one_x: BigUint = bn254_one.x.into();
+         let bn254_one_y: BigUint = bn254_one.y.into();
+         let bn254_one_z: BigUint = bn254_one.z.into();
+         let bn254_one_xr = (bn254_one_x * &r) % &p;
+         let bn254_one_yr = (bn254_one_y * &r) % &p;
+         let bn254_one_zr = (bn254_one_z * &r) % &p;
+         (
+             ark_ff::BigInt::<4>::try_from(bn254_one_xr)
+                 .unwrap()
+                 .to_limbs(num_limbs, log_limb_size),
+             ark_ff::BigInt::<4>::try_from(bn254_one_yr)
+                 .unwrap()
+                 .to_limbs(num_limbs, log_limb_size),
+             ark_ff::BigInt::<4>::try_from(bn254_one_zr)
+                 .unwrap()
+                 .to_limbs(num_limbs, log_limb_size),
+         )
+     };
+     write_constant_array!(data, "BN254_ONE_XR", bn254_one_xr_limbs, "NUM_LIMBS");
+     write_constant_array!(data, "BN254_ONE_YR", bn254_one_yr_limbs, "NUM_LIMBS");
+     write_constant_array!(data, "BN254_ONE_ZR", bn254_one_zr_limbs, "NUM_LIMBS");
+ 
+     let output_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+         .join(filepath)
+         .join("constants.metal");
+     fs::write(output_path, data).expect("Unable to write constants file");
+ }
+ 
+ #[cfg(test)]
+ pub mod tests {
+     use super::*;
+ 
+     #[test]
+     #[serial_test::serial]
+     pub fn test_compile() {
+         let lib_filepath = compile_metal(
+             "../mopro-msm/src/msm/metal_msm/shader",
+             "bigint/bigint_add_unsafe.metal",
+         );
+         println!("{}", lib_filepath);
+     }
+ 
+     #[test]
+     #[serial_test::serial]
+     pub fn test_write_constants() {
+         write_constants("../mopro-msm/src/msm/metal_msm/shader", 16, 16, 25481, 1);
+     }
+ }
+ 

--- a/mopro-msm/src/msm/metal_msm/shader/cuzk/barrett_reduction.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/cuzk/barrett_reduction.metal
@@ -1,21 +1,17 @@
 #pragma once
 
-using namespace metal;
 #include <metal_stdlib>
 #include <metal_math>
 #include "../field/ff.metal"
+using namespace metal;
 
 #if defined(__METAL_VERSION__) && (__METAL_VERSION__ >= 320)
     #include <metal_logging>
-    // Create our real logger.
     constant os_log logger(/*subsystem=*/"barret_reduction", /*category=*/"metal");
-    // Define the log macro to forward to logger_kernel.log_info.
     #define LOG_DEBUG_DUPL(...) logger.log_debug(__VA_ARGS__)
 #else
-    // For older Metal versions, define a dummy macro that does nothing.
     #define LOG_DEBUG_DUPL(...) ((void)0)
 #endif
-
 
 BigIntExtraWide mul(BigIntWide a, BigIntWide b) {
     BigIntExtraWide res = bigint_zero_extra_wide();
@@ -46,7 +42,8 @@ BigIntResultExtraWide sub_512(BigIntExtraWide a, BigIntExtraWide b) {
         if (a.limbs[i] < (b.limbs[i] + res.carry)) {
             res.value.limbs[i] += (MASK + 1);
             res.carry = 1;
-        } else {
+        }
+        else {
             res.carry = 0;
         }
     }

--- a/mopro-msm/src/msm/metal_msm/shader/cuzk/extract_word_from_bytes_le.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/cuzk/extract_word_from_bytes_le.metal
@@ -1,8 +1,8 @@
 #pragma once
 
-using namespace metal;
 #include <metal_stdlib>
 #include <metal_math>
+using namespace metal;
 
 inline uint32_t extract_word_from_bytes_le(
     const thread uint32_t* input,
@@ -22,7 +22,8 @@ inline uint32_t extract_word_from_bytes_le(
     }
     if (start_byte_idx == end_byte_idx) {
         word = (input[start_byte_idx] & mask) >> end_byte_offset;
-    } else {
+    }
+    else {
         word = (input[start_byte_idx] & mask) << (16 - end_byte_offset);
         word += input[end_byte_idx] >> end_byte_offset;
     }

--- a/mopro-msm/src/msm/metal_msm/shader/cuzk/kernel_barrett_reduction.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/cuzk/kernel_barrett_reduction.metal
@@ -1,23 +1,20 @@
-using namespace metal;
 #include <metal_stdlib>
 #include <metal_math>
 #include "barrett_reduction.metal"
+using namespace metal;
 
 #if defined(__METAL_VERSION__) && (__METAL_VERSION__ >= 320)
     #include <metal_logging>
-    // Create our real logger.
     constant os_log logger_kernel(/*subsystem=*/"ketnel_barret_reduction", /*category=*/"metal");
-    // Define the log macro to forward to logger_kernel.log_debug.
     #define LOG_DEBUG(...) logger_kernel.log_debug(__VA_ARGS__)
 #else
-    // For older Metal versions, define a dummy macro that does nothing.
     #define LOG_DEBUG(...) ((void)0)
 #endif
 
 kernel void run(
-    device BigIntExtraWide* a [[ buffer(0) ]],
-    device BigInt* res [[ buffer(1) ]],
-    uint gid [[ thread_position_in_grid ]]
+    device BigIntExtraWide* a   [[ buffer(0) ]],
+    device BigInt* res          [[ buffer(1) ]],
+    uint gid                    [[ thread_position_in_grid ]]
 ) {
     *res = barrett_reduce(*a);
     LOG_DEBUG("pointer: %p", res);

--- a/mopro-msm/src/msm/metal_msm/shader/cuzk/kernel_field_mul.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/cuzk/kernel_field_mul.metal
@@ -1,13 +1,13 @@
-using namespace metal;
 #include <metal_stdlib>
 #include <metal_math>
 #include "barrett_reduction.metal"
+using namespace metal;
 
 kernel void run(
-    device BigIntWide* a [[ buffer(0) ]],
-    device BigIntWide* b [[ buffer(1) ]],
-    device BigInt* res [[ buffer(2) ]],
-    uint gid [[ thread_position_in_grid ]]
+    device BigIntWide* a    [[ buffer(0) ]],
+    device BigIntWide* b    [[ buffer(1) ]],
+    device BigInt* res      [[ buffer(2) ]],
+    uint gid                [[ thread_position_in_grid ]]
 ) {
     *res = field_mul(*a, *b);
 }

--- a/mopro-msm/src/msm/metal_msm/shader/cuzk/transpose.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/cuzk/transpose.metal
@@ -1,13 +1,17 @@
+// Serial transpose algo adapted from Wang et al, 2016, "Parallel
+// Transposition of Sparse Data Structures".
+// https://synergy.cs.vt.edu/pubs/papers/wang-transposition-ics16.pdf
+
 #include <metal_stdlib>
 using namespace metal;
 
 kernel void transpose(
-    device const uint* all_csr_col_idx       [[buffer(0)]],
-    device atomic_uint* all_csc_col_ptr      [[buffer(1)]],
-    device uint* all_csc_val_idxs            [[buffer(2)]],
-    device uint* all_curr                    [[buffer(3)]],
-    constant uint2& params                   [[buffer(4)]],
-    uint gid [[thread_position_in_grid]]
+    device const uint* all_csr_col_idx      [[buffer(0)]],
+    device atomic_uint* all_csc_col_ptr     [[buffer(1)]],
+    device uint* all_csc_val_idxs           [[buffer(2)]],
+    device uint* all_curr                   [[buffer(3)]],
+    constant uint2& params                  [[buffer(4)]],
+    uint gid                                [[thread_position_in_grid]]
 ) {
     const uint subtask_idx = gid;
 

--- a/mopro-msm/src/msm/metal_msm/tests/cuzk/convert_point_coords_and_decompose_scalars.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/cuzk/convert_point_coords_and_decompose_scalars.rs
@@ -99,11 +99,7 @@ fn test_scalar_decomposition() {
     // Setup test config
     let log_limb_size = 16;
     let num_limbs = 16;
-    let chunk_size = if BaseField::MODULUS_BIT_SIZE / 32 >= 65536 {
-        16
-    } else {
-        4
-    };
+    let chunk_size = 16;
     let num_subtasks = (256f32 / chunk_size as f32).ceil() as usize;
     let num_columns = 1 << chunk_size; // 2^chunk_size
 

--- a/mopro-msm/src/msm/metal_msm/tests/cuzk/e2e.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/cuzk/e2e.rs
@@ -1,0 +1,660 @@
+use crate::msm::metal_msm::cuzk_cpu_reproduction::*;
+use crate::msm::metal_msm::utils::limbs_conversion::GenericLimbConversion;
+use crate::msm::metal_msm::utils::metal_wrapper::*;
+use crate::msm::metal_msm::utils::mont_reduction::raw_reduction;
+use ark_bn254::{Fq as BaseField, Fr as ScalarField, G1Affine as Affine, G1Projective as G};
+use ark_ec::VariableBaseMSM;
+use ark_ff::{BigInt, PrimeField};
+use ark_std::Zero;
+use std::error::Error;
+
+
+pub fn metal_e2e_msm(bases: &[Affine], scalars: &[ScalarField]) -> Result<G, Box<dyn Error>> {
+    let input_size = bases.len();
+    let chunk_size = 16;
+    let num_subtasks = 256 / chunk_size;
+    let num_columns = 1 << chunk_size; // 2^chunk_size
+
+    let msm_config = MetalConfig {
+        log_limb_size: 16,
+        num_limbs: 16,
+        shader_file: "".to_string(),
+        kernel_name: "".to_string(),
+    };
+    let msm_constants = get_or_calc_constants(msm_config.num_limbs, msm_config.log_limb_size);
+
+    //-------------------------------------------------------
+    // Pack input points + scalars => 16-bit halfwords
+    //-------------------------------------------------------
+    let (coords, scals) = pack_affine_and_scalars(bases, scalars, &msm_config);
+
+    //-------------------------------------------------------
+    // 1) Convert & Decompose (GPU)
+    //    => point_x, point_y, scalar_chunks
+    //-------------------------------------------------------
+    // Per your writeup, we want to launch `input_size` threads total in 1D.
+    // E.g. each thread handles exactly 1 (point, scalar).
+    let mut helper1 = MetalHelper::new();
+    let conv_decomp_config = MetalConfig {
+        log_limb_size: msm_config.log_limb_size,
+        num_limbs: msm_config.num_limbs,
+        // The Metal or .metal file that has your coordinate+scalar decomposition kernel:
+        shader_file: "cuzk/convert_point_coords_and_decompose_scalars.metal".to_string(),
+        kernel_name: "convert_point_coords_and_decompose_scalars".to_string(), // or whatever entry point you use
+    };
+
+    println!("\n--- Stage 1: Convert & Decompose (GPU) ---");
+    println!("Input coords len: {}", coords.len());
+    println!("Input scals len: {}", scals.len());
+    println!("Input input_size: {}", input_size);
+    println!("Input num_subtasks: {}", num_subtasks);
+    println!("Input chunk_size: {}", chunk_size);
+
+    let (gpu_point_x, gpu_point_y, gpu_scalar_chunks) = convert_decompose_gpu(
+        &mut helper1,
+        &conv_decomp_config,
+        &coords,
+        &scals,
+        input_size,
+        num_subtasks,
+    );
+    println!("Output gpu_point_x len: {}", gpu_point_x.len());
+    println!("Output gpu_point_y len: {}", gpu_point_y.len());
+    println!("Output gpu_scalar_chunks len: {}", gpu_scalar_chunks.len());
+
+    helper1.drop_all_buffers();
+
+    //-------------------------------------------------------
+    // 2) Transpose (GPU)
+    //    => csc_col_ptr, csc_val_idxs
+    //-------------------------------------------------------
+    // Launch `num_subtasks` threads total (1D). Each subtask does its own transpose.
+    let mut helper2 = MetalHelper::new();
+    let transpose_config = MetalConfig {
+        log_limb_size: msm_config.log_limb_size,
+        num_limbs: msm_config.num_limbs,
+        shader_file: "cuzk/transpose.metal".to_string(),
+        kernel_name: "transpose".to_string(), // or your actual entry point
+    };
+
+    println!("\n--- Stage 2: Transpose (GPU) ---");
+    println!("Input gpu_scalar_chunks len: {}", gpu_scalar_chunks.len());
+    println!("Input num_subtasks: {}", num_subtasks);
+    println!("Input input_size: {}", input_size);
+    println!("Input num_columns: {}", num_columns);
+
+    let (gpu_csc_col_ptr, gpu_csc_val_idxs) = transpose_gpu(
+        &mut helper2,
+        &transpose_config,
+        &gpu_scalar_chunks,
+        num_subtasks,
+        input_size,
+        num_columns,
+    );
+    println!("Output gpu_csc_col_ptr len: {}", gpu_csc_col_ptr.len());
+    println!("Output gpu_csc_val_idxs len: {}", gpu_csc_val_idxs.len());
+
+    helper2.drop_all_buffers();
+
+    //-------------------------------------------------------
+    // 3) SMVP (GPU)
+    //    => bucket_x, bucket_y, bucket_z
+    //-------------------------------------------------------
+    // Launch `(input_size/2)*num_subtasks` threads in total (which is half_columns * num_subtasks).
+    // Or if you prefer, you can do (num_subtasks, half_columns, 1) as 3D dispatch.
+    // Each thread does "two passes" (positive + negative).
+    let mut helper3 = MetalHelper::new();
+    let smvp_config = MetalConfig {
+        log_limb_size: msm_config.log_limb_size,
+        num_limbs: msm_config.num_limbs,
+        shader_file: "cuzk/smvp.metal".to_string(),
+        kernel_name: "smvp".to_string(),
+    };
+
+    println!("\n--- Stage 3: SMVP (GPU) ---");
+    println!("Input gpu_csc_col_ptr len: {}", gpu_csc_col_ptr.len());
+    println!("Input gpu_csc_val_idxs len: {}", gpu_csc_val_idxs.len());
+    println!("Input gpu_point_x len: {}", gpu_point_x.len());
+    println!("Input gpu_point_y len: {}", gpu_point_y.len());
+    println!("Input input_size: {}", input_size);
+    println!("Input num_subtasks: {}", num_subtasks);
+    println!("Input num_columns: {}", num_columns);
+
+    let (gpu_bucket_x, gpu_bucket_y, gpu_bucket_z) = smvp_gpu(
+        &mut helper3,
+        &smvp_config,
+        &gpu_csc_col_ptr,
+        &gpu_csc_val_idxs,
+        &gpu_point_x,
+        &gpu_point_y,
+        input_size,
+        num_subtasks,
+        num_columns,
+    );
+    println!("Output gpu_bucket_x len: {}", gpu_bucket_x.len());
+    println!("Output gpu_bucket_y len: {}", gpu_bucket_y.len());
+    println!("Output gpu_bucket_z len: {}", gpu_bucket_z.len());
+
+    helper3.drop_all_buffers();
+
+    //-------------------------------------------------------
+    // 4) Parallel Bucket Reduction (PBPR) (GPU)
+    //    => g_points_x, g_points_y, g_points_z
+    //-------------------------------------------------------
+    // Launch `256*num_subtasks` threads total, in two stages (like submission.ts).
+    // Each stage processes `num_subtasks_per_bpr` at a time.
+    // Typically 256 threads per subtask.
+    let mut helper4 = MetalHelper::new();
+    let pbpr_stage1_config = MetalConfig {
+        log_limb_size: msm_config.log_limb_size,
+        num_limbs: msm_config.num_limbs,
+        shader_file: "cuzk/pbpr.metal".to_string(),
+        kernel_name: "bpr_stage_1".to_string(),
+    };
+    let pbpr_stage2_config = MetalConfig {
+        log_limb_size: msm_config.log_limb_size,
+        num_limbs: msm_config.num_limbs,
+        shader_file: "cuzk/pbpr.metal".to_string(),
+        kernel_name: "bpr_stage_2".to_string(),
+    };
+
+    println!("\n--- Stage 4: PBPR (GPU) ---");
+    println!("Input gpu_bucket_x len: {}", gpu_bucket_x.len());
+    println!("Input gpu_bucket_y len: {}", gpu_bucket_y.len());
+    println!("Input gpu_bucket_z len: {}", gpu_bucket_z.len());
+    println!("Input num_subtasks: {}", num_subtasks);
+    println!("Input num_columns: {}", num_columns);
+
+    let (gpu_g_points_x, gpu_g_points_y, gpu_g_points_z) = pbpr_gpu(
+        &mut helper4,
+        &pbpr_stage1_config,
+        &pbpr_stage2_config,
+        &gpu_bucket_x,
+        &gpu_bucket_y,
+        &gpu_bucket_z,
+        num_subtasks,
+        num_columns,
+    );
+    println!("Output gpu_g_points_x len: {}", gpu_g_points_x.len());
+    println!("Output gpu_g_points_y len: {}", gpu_g_points_y.len());
+    println!("Output gpu_g_points_z len: {}", gpu_g_points_z.len());
+
+    helper4.drop_all_buffers();
+
+    // At this point, we have `g_points_x, g_points_y, g_points_z` representing the "bucket-sum"
+    // partial results for each subtask. We'll decode them to BN254 projective points in CPU.
+
+    println!("\n--- Stage 4.5: PBPR Final Reduction (CPU) ---");
+    let pbpr_workgroup_size: usize = 256; // Match b_workgroup_size from GPU
+    let mut gpu_points = Vec::with_capacity(num_subtasks);
+
+    println!("Input num_subtasks: {}", num_subtasks);
+    println!("Input pbpr_workgroup_size: {}", pbpr_workgroup_size);
+
+    for i in 0..num_subtasks {
+        let mut accumulated_point_for_subtask_i = G::zero();
+        for j in 0..pbpr_workgroup_size {
+            let flat_idx = i * pbpr_workgroup_size + j;
+            let limb_start_idx = flat_idx * msm_config.num_limbs;
+            let limb_end_idx = (flat_idx + 1) * msm_config.num_limbs;
+
+            let xr_limbs_u32 = &gpu_g_points_x[limb_start_idx..limb_end_idx];
+            let yr_limbs_u32 = &gpu_g_points_y[limb_start_idx..limb_end_idx];
+            let zr_limbs_u32 = &gpu_g_points_z[limb_start_idx..limb_end_idx];
+
+            // Convert u32 limbs to BigInt<4> for raw_reduction
+            let xr_bigint_mont = BigInt::<4>::from_limbs(&xr_limbs_u32, msm_config.log_limb_size);
+            let yr_bigint_mont = BigInt::<4>::from_limbs(&yr_limbs_u32, msm_config.log_limb_size);
+            let zr_bigint_mont = BigInt::<4>::from_limbs(&zr_limbs_u32, msm_config.log_limb_size);
+
+            let xr_bigint_std = raw_reduction(xr_bigint_mont.clone());
+            let yr_bigint_std = raw_reduction(yr_bigint_mont.clone());
+            let zr_bigint_std = raw_reduction(zr_bigint_mont.clone());
+
+            let result_xr =
+                BaseField::from_bigint(xr_bigint_std).unwrap_or_else(|| BaseField::zero());
+            let result_yr =
+                BaseField::from_bigint(yr_bigint_std).unwrap_or_else(|| BaseField::zero());
+            let result_zr =
+                BaseField::from_bigint(zr_bigint_std).unwrap_or_else(|| BaseField::zero());
+
+            let partial_g_point = G::new(result_xr, result_yr, result_zr); // use the unchecked version once we have the correct implementation
+                                                                           // let partial_g_point = G::new_unchecked(result_xr, result_yr, result_zr);
+            accumulated_point_for_subtask_i += partial_g_point;
+        }
+        gpu_points.push(accumulated_point_for_subtask_i);
+    }
+
+    println!("\n--- Stage 5: Horner's Method (CPU) ---");
+    println!("Input decoded gpu_points len: {}", gpu_points.len());
+    println!("Input chunk_size: {}", chunk_size);
+
+    //-------------------------------------------------------
+    // 5) Horner's Method (CPU)
+    //    => final GPU-based MSM result
+    //-------------------------------------------------------
+    let m = ScalarField::from(1u64 << chunk_size);
+    let mut result = gpu_points[gpu_points.len() - 1];
+    if gpu_points.len() > 1 {
+        for i in (0..gpu_points.len() - 1).rev() {
+            result *= m;
+            result += gpu_points[i];
+        }
+    }
+
+    Ok(result)
+}
+
+//-------------------------------------------------------------------------------------
+// GPU Stage 1: Convert & Decompose
+//   total threads => `input_size` (1D dispatch)
+//-------------------------------------------------------------------------------------
+fn convert_decompose_gpu(
+    helper: &mut MetalHelper,
+    config: &MetalConfig,
+    coords: &Vec<u32>,  // packed X & Y halfwords
+    scalars: &Vec<u32>, // packed scalar halfwords
+    input_size: usize,
+    num_subtasks: usize,
+) -> (Vec<u32>, Vec<u32>, Vec<u32>) {
+    // Create input buffers
+    let coords_buf = helper.create_input_buffer(coords);
+    let scalars_buf = helper.create_input_buffer(scalars);
+
+    // Output buffers: point_x, point_y, scalar_chunks
+    //   - Each X or Y is stored as num_limbs "fullwords"; your kernel may want them in halfwords
+    //   - Each scalar_chunk is `input_size * num_subtasks` length (u32).
+    let out_point_x = helper.create_output_buffer(input_size * config.num_limbs);
+    let out_point_y = helper.create_output_buffer(input_size * config.num_limbs);
+    let out_scalar_chunks = helper.create_output_buffer(input_size * num_subtasks);
+
+    let input_size_buf = helper.create_input_buffer(&vec![input_size as u32]);
+
+    // Compute how many total threads, which is `input_size`. We can do 1D:
+    let thread_count = helper.create_thread_group_size(input_size as u64, 1, 1);
+    let threads_per_group = helper.create_thread_group_size(1, 1, 1);
+
+    // Dispatch
+    helper.execute_shader(
+        config,
+        &[
+            &coords_buf,     // buffer(0)
+            &scalars_buf,    // buffer(1)
+            &input_size_buf, // buffer(2)
+        ],
+        &[
+            &out_point_x,       // buffer(X)
+            &out_point_y,       // buffer(Y)
+            &out_scalar_chunks, // buffer(chunks)
+        ],
+        &thread_count,
+        &threads_per_group,
+    );
+
+    // Read back
+    let gpu_point_x = helper.read_results(&out_point_x, input_size * config.num_limbs);
+    let gpu_point_y = helper.read_results(&out_point_y, input_size * config.num_limbs);
+    let gpu_scalar_chunks = helper.read_results(&out_scalar_chunks, input_size * num_subtasks);
+
+    (gpu_point_x, gpu_point_y, gpu_scalar_chunks)
+}
+
+//-------------------------------------------------------------------------------------
+// GPU Stage 2: Transpose (CSR -> CSC) for each subtask
+//   total threads => num_subtasks
+//-------------------------------------------------------------------------------------
+fn transpose_gpu(
+    helper: &mut MetalHelper,
+    config: &MetalConfig,
+    scalar_chunks: &Vec<u32>,
+    num_subtasks: usize,
+    input_size: usize,
+    num_columns: u32,
+) -> (Vec<u32>, Vec<u32>) {
+    let in_chunks_buf = helper.create_input_buffer(scalar_chunks);
+
+    let out_csc_col_ptr =
+        helper.create_output_buffer(num_subtasks * ((num_columns + 1) as usize) * 4);
+    let out_csc_val_idxs = helper.create_output_buffer(scalar_chunks.len());
+    let out_curr = helper.create_output_buffer(num_subtasks * (num_columns as usize) * 4);
+
+    let params = vec![
+        num_columns,       // params.x  → n ( #columns per sparse matrix )
+        input_size as u32, // params.y  → input_size ( #rows )
+    ];
+    let params_buf = helper.create_input_buffer(&params);
+
+    // 1D dispatch => #threads = num_subtasks
+    let thread_count = helper.create_thread_group_size(num_subtasks as u64, 1, 1);
+    let threads_per_group = helper.create_thread_group_size(1, 1, 1);
+
+    helper.execute_shader(
+        config,
+        &[
+            &in_chunks_buf,    // buffer(0)
+            &out_csc_col_ptr,  // buffer(1)
+            &out_csc_val_idxs, // buffer(2)
+            &out_curr,         // buffer(3)
+            &params_buf,       // buffer(4)
+        ],
+        &[],
+        &thread_count,
+        &threads_per_group,
+    );
+
+    // Read results
+    let gpu_csc_col_ptr = helper.read_results(
+        &out_csc_col_ptr,
+        num_subtasks * ((num_columns + 1) as usize) * 4,
+    );
+    let gpu_csc_val_idxs = helper.read_results(&out_csc_val_idxs, scalar_chunks.len());
+
+    (gpu_csc_col_ptr, gpu_csc_val_idxs)
+}
+
+//-------------------------------------------------------------------------------------
+// GPU Stage 3: SMVP
+//   total threads => half_columns * num_subtasks
+//
+// This accumulates each "positive/negative bucket."  Our typical kernel does
+// a loop (j=0..1) for each thread to handle ± buckets, then merges them in place.
+//-------------------------------------------------------------------------------------
+fn smvp_gpu(
+    helper: &mut MetalHelper,
+    config: &MetalConfig,
+    gpu_csc_col_ptr: &Vec<u32>,
+    gpu_csc_val_idxs: &Vec<u32>,
+    gpu_point_x: &Vec<u32>,
+    gpu_point_y: &Vec<u32>,
+    input_size: usize,
+    num_subtasks: usize,
+    num_columns: u32,
+) -> (Vec<u32>, Vec<u32>, Vec<u32>) {
+    let half_columns = num_columns / 2;
+
+    let mut s_workgroup_size = 256u32;
+    let mut s_num_x_workgroups = 64u32;
+    let mut s_num_y_workgroups = half_columns / s_workgroup_size / s_num_x_workgroups;
+    let mut s_num_z_workgroups = num_subtasks as u32;
+
+    if half_columns < 32768 {
+        s_workgroup_size = 32;
+        s_num_x_workgroups = 1;
+        s_num_y_workgroups = half_columns / s_workgroup_size / s_num_x_workgroups;
+    }
+
+    if num_columns < 256 {
+        s_workgroup_size = 1;
+        s_num_x_workgroups = half_columns;
+        s_num_y_workgroups = 1;
+        s_num_z_workgroups = 1;
+    }
+
+    // This is a dynamic variable that determines the number of CSR
+    // matrices processed per invocation of the shader. A safe default is 1.
+    let num_subtask_chunk_size = 4u32;
+
+    let bucket_sum_coord_bytelength =
+        (num_columns / 2) as usize * config.num_limbs as usize * 4 * num_subtasks as usize;
+
+    // Input buffers
+    let row_ptr_buf = helper.create_input_buffer(gpu_csc_col_ptr);
+    let val_idx_buf = helper.create_input_buffer(gpu_csc_val_idxs);
+    let point_x_buf = helper.create_input_buffer(gpu_point_x);
+    let point_y_buf = helper.create_input_buffer(gpu_point_y);
+
+    // Output "bucket" buffers - create once and reuse
+    let bucket_x_buf = helper.create_output_buffer(bucket_sum_coord_bytelength);
+    let bucket_y_buf = helper.create_output_buffer(bucket_sum_coord_bytelength);
+    let bucket_z_buf = helper.create_output_buffer(bucket_sum_coord_bytelength);
+
+    // Debug print the workgroup configuration
+    println!("SMVP Debug Info:");
+    println!("  half_columns: {}", half_columns);
+    println!("  num_subtasks: {}", num_subtasks);
+    println!("  s_workgroup_size: {}", s_workgroup_size);
+    println!("  s_num_x_workgroups: {}", s_num_x_workgroups);
+    println!("  s_num_y_workgroups: {}", s_num_y_workgroups);
+    println!("  s_num_z_workgroups: {}", s_num_z_workgroups);
+    println!("  num_subtask_chunk_size: {}", num_subtask_chunk_size);
+
+    // Loop through subtask chunks like in the reference
+    for offset in (0..num_subtasks as u32).step_by(num_subtask_chunk_size as usize) {
+        // Uniform params => [input_size, num_y_workgroups, num_z_workgroups, offset]
+        let params = vec![
+            input_size as u32,
+            s_num_y_workgroups,
+            s_num_z_workgroups,
+            offset,
+        ];
+        let params_buf = helper.create_input_buffer(&params);
+
+        let adjusted_s_num_x_workgroups = if num_columns < 256 {
+            s_num_x_workgroups
+        } else if num_subtasks as u32 >= num_subtask_chunk_size {
+            std::cmp::max(
+                1,
+                s_num_x_workgroups / (num_subtasks as u32 / num_subtask_chunk_size),
+            )
+        } else {
+            s_num_x_workgroups
+        };
+
+        println!("SMVP Execution Debug:");
+        println!("  offset: {}", offset);
+        println!(
+            "  adjusted_s_num_x_workgroups: {}",
+            adjusted_s_num_x_workgroups
+        );
+        println!(
+            "  thread_group_count: ({}, {}, {})",
+            adjusted_s_num_x_workgroups, s_num_y_workgroups, s_num_z_workgroups
+        );
+        println!("  threads_per_group: ({}, 1, 1)", s_workgroup_size);
+
+        let thread_group_count = helper.create_thread_group_size(
+            adjusted_s_num_x_workgroups as u64,
+            s_num_y_workgroups as u64,
+            s_num_z_workgroups as u64,
+        );
+        let threads_per_group = helper.create_thread_group_size(s_workgroup_size as u64, 1, 1);
+
+        println!("executing smvp_gpu, offset: {}", offset);
+        helper.execute_shader(
+            config,
+            &[
+                &row_ptr_buf,
+                &val_idx_buf,
+                &point_x_buf,
+                &point_y_buf,
+                &bucket_x_buf,
+                &bucket_y_buf,
+                &bucket_z_buf,
+                &params_buf,
+            ],
+            &[],
+            &thread_group_count,
+            &threads_per_group,
+        );
+    }
+
+    let out_x = helper.read_results(&bucket_x_buf, bucket_sum_coord_bytelength);
+    let out_y = helper.read_results(&bucket_y_buf, bucket_sum_coord_bytelength);
+    let out_z = helper.read_results(&bucket_z_buf, bucket_sum_coord_bytelength);
+
+    (out_x, out_y, out_z)
+}
+
+//-------------------------------------------------------------------------------------
+// GPU Stage 4: Parallel Bucket Reduction (PBPR)
+//   total threads => 256 * num_subtasks
+//   done in 2 sub-stages
+//-------------------------------------------------------------------------------------
+fn pbpr_gpu(
+    helper: &mut MetalHelper,
+    stage1_config: &MetalConfig,
+    stage2_config: &MetalConfig,
+    bucket_x: &Vec<u32>,
+    bucket_y: &Vec<u32>,
+    bucket_z: &Vec<u32>,
+    num_subtasks: usize,
+    num_columns: u32,
+) -> (Vec<u32>, Vec<u32>, Vec<u32>) {
+    let num_subtasks_per_bpr_1 = 16;
+
+    let b_num_x_workgroups = num_subtasks_per_bpr_1;
+    let b_num_y_workgroups = 1;
+    let b_num_z_workgroups = 1;
+    let b_workgroup_size = 256;
+
+    let bucket_sum_x_buf = helper.create_input_buffer(bucket_x);
+    let bucket_sum_y_buf = helper.create_input_buffer(bucket_y);
+    let bucket_sum_z_buf = helper.create_input_buffer(bucket_z);
+
+    // Buffers that store the bucket points reduction (BPR) output.
+    let g_points_coord_bytelength =
+        (num_subtasks * b_workgroup_size * stage1_config.num_limbs) as usize * 4;
+
+    let g_points_x_buf = helper.create_output_buffer(g_points_coord_bytelength);
+    let g_points_y_buf = helper.create_output_buffer(g_points_coord_bytelength);
+    let g_points_z_buf = helper.create_output_buffer(g_points_coord_bytelength);
+
+    // Stage 1
+    for subtask_chunk_idx in (0..num_subtasks).step_by(num_subtasks_per_bpr_1 as usize) {
+        println!("subtask_chunk_idx: {}", subtask_chunk_idx);
+        let params = vec![
+            subtask_chunk_idx as u32,
+            num_columns,
+            num_subtasks_per_bpr_1,
+        ];
+        let params_buf = helper.create_input_buffer(&params);
+        let workgroup_size_buf = helper.create_input_buffer(&vec![b_workgroup_size as u32]);
+
+        let stage1_group_count = helper.create_thread_group_size(
+            b_num_x_workgroups as u64,
+            b_num_y_workgroups as u64,
+            b_num_z_workgroups as u64,
+        );
+        let stage1_group_size = helper.create_thread_group_size(b_workgroup_size as u64, 1, 1);
+
+        println!("executing stage1_config");
+        helper.execute_shader(
+            stage1_config,
+            &[
+                &bucket_sum_x_buf,
+                &bucket_sum_y_buf,
+                &bucket_sum_z_buf,
+                &g_points_x_buf,
+                &g_points_y_buf,
+                &g_points_z_buf,
+                &params_buf,
+                &workgroup_size_buf,
+            ],
+            &[],
+            &stage1_group_count,
+            &stage1_group_size,
+        );
+    }
+
+    // Stage 2
+    let num_subtasks_per_bpr_2 = 16;
+    let b_2_num_x_workgroups = num_subtasks_per_bpr_2;
+
+    for subtask_chunk_idx in (0..num_subtasks).step_by(num_subtasks_per_bpr_2 as usize) {
+        println!("subtask_chunk_idx: {}", subtask_chunk_idx);
+        let params = vec![subtask_chunk_idx as u32, num_columns, b_2_num_x_workgroups];
+        let params_buf = helper.create_input_buffer(&params);
+        let workgroup_size_buf = helper.create_input_buffer(&vec![b_workgroup_size as u32]);
+
+        let stage2_group_count = helper.create_thread_group_size(b_2_num_x_workgroups as u64, 1, 1);
+        let stage2_group_size = helper.create_thread_group_size(b_workgroup_size as u64, 1, 1);
+
+        println!("executing stage2_config");
+        helper.execute_shader(
+            stage2_config,
+            &[
+                &bucket_sum_x_buf,
+                &bucket_sum_y_buf,
+                &bucket_sum_z_buf,
+                &g_points_x_buf,
+                &g_points_y_buf,
+                &g_points_z_buf,
+                &params_buf,
+                &workgroup_size_buf,
+            ],
+            &[],
+            &stage2_group_count,
+            &stage2_group_size,
+        );
+    }
+
+    // Read back final
+    let out_gx = helper.read_results(&g_points_x_buf, g_points_coord_bytelength);
+    let out_gy = helper.read_results(&g_points_y_buf, g_points_coord_bytelength);
+    let out_gz = helper.read_results(&g_points_z_buf, g_points_coord_bytelength);
+
+    (out_gx, out_gy, out_gz)
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rayon::prelude::*;
+
+    use ark_ec::CurveGroup;
+    use ark_ff::UniformRand;
+    use ark_std::test_rng;
+
+    #[test]
+    fn test_e2e_msm_pipeline() {
+        let log_input_size = 16;
+        let input_size = 1 << log_input_size;
+
+        let num_threads = rayon::current_num_threads();
+        let thread_chunk_size = (input_size + num_threads - 1) / num_threads;
+        println!(
+            "Generating {} elements using {} threads",
+            input_size, num_threads
+        );
+        let start = std::time::Instant::now();
+
+        // Generate bases and scalars in parallel
+        let (bases, scalars): (Vec<_>, Vec<_>) = (0..num_threads)
+            .into_par_iter()
+            .flat_map(|thread_id| {
+                let mut rng = test_rng();
+
+                let start_idx = thread_id * thread_chunk_size;
+                let end_idx = std::cmp::min(start_idx + thread_chunk_size, input_size);
+                let current_thread_size = end_idx - start_idx;
+
+                (0..current_thread_size)
+                    .map(|_| {
+                        let base = G::rand(&mut rng).into_affine();
+                        let scalar = ScalarField::rand(&mut rng);
+                        (base, scalar)
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .unzip();
+
+        println!("Generated {} elements in {:?}", input_size, start.elapsed());
+
+        println!("running metal_e2e_msm");
+        let start = std::time::Instant::now();
+        let result = metal_e2e_msm(&bases, &scalars).unwrap();
+        println!("metal_e2e_msm took {:?}", start.elapsed());
+
+        println!("running arkworks_msm");
+        let start = std::time::Instant::now();
+        let arkworks_msm = G::msm(&bases, &scalars).unwrap();
+        println!("arkworks_msm took {:?}", start.elapsed());
+
+        assert_eq!(
+            result, arkworks_msm,
+            "Mismatch between GPU e2e result and Arkworks reference"
+        );
+        println!("GPU e2e result matches Arkworks reference");
+    }
+}

--- a/mopro-msm/src/msm/metal_msm/tests/cuzk/e2e.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/cuzk/e2e.rs
@@ -8,7 +8,6 @@ use ark_ff::{BigInt, PrimeField};
 use ark_std::Zero;
 use std::error::Error;
 
-
 pub fn metal_e2e_msm(bases: &[Affine], scalars: &[ScalarField]) -> Result<G, Box<dyn Error>> {
     let input_size = bases.len();
     let chunk_size = 16;
@@ -595,7 +594,6 @@ fn pbpr_gpu(
 
     (out_gx, out_gy, out_gz)
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/mopro-msm/src/msm/metal_msm/tests/cuzk/mod.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/cuzk/mod.rs
@@ -3,6 +3,8 @@ pub mod barrett_reduction;
 #[cfg(test)]
 pub mod convert_point_coords_and_decompose_scalars;
 #[cfg(test)]
+pub mod e2e;
+#[cfg(test)]
 pub mod pbpr;
 #[cfg(test)]
 pub mod smvp;

--- a/mopro-msm/src/msm/metal_msm/tests/cuzk/smvp.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/cuzk/smvp.rs
@@ -1,274 +1,307 @@
 use ark_bn254::{Fq as BaseField, G1Projective as G};
 use ark_ec::CurveGroup;
 use ark_ff::{BigInt, PrimeField};
-use ark_std::{rand, One, UniformRand, Zero};
-use num_bigint::BigUint;
+use ark_std::{rand, UniformRand, Zero};
 use rand::Rng;
+use std::ops::Neg;
 
 use crate::msm::metal_msm::utils::limbs_conversion::GenericLimbConversion;
 use crate::msm::metal_msm::utils::metal_wrapper::*;
+use crate::msm::metal_msm::utils::mont_params::calc_mont_radix;
+use crate::msm::metal_msm::utils::mont_reduction::raw_reduction;
+use num_bigint::BigUint;
 
+fn smvp_gpu(
+    helper: &mut MetalHelper,
+    config: &MetalConfig,
+    gpu_csc_col_ptr: &Vec<u32>,
+    gpu_csc_val_idxs: &Vec<u32>,
+    gpu_point_x: &Vec<u32>,
+    gpu_point_y: &Vec<u32>,
+    input_size: usize,
+    num_subtasks: usize,
+    num_columns: u32,
+) -> (Vec<u32>, Vec<u32>, Vec<u32>) {
+    let half_columns = num_columns / 2;
+
+    // Work-group configuration heuristics (same as e2e.rs)
+    let mut s_workgroup_size = 256u32;
+    let mut s_num_x_workgroups = 64u32;
+    let mut s_num_y_workgroups = half_columns / s_workgroup_size / s_num_x_workgroups;
+    let mut s_num_z_workgroups = num_subtasks as u32;
+
+    if half_columns < 32768 {
+        s_workgroup_size = 32;
+        s_num_x_workgroups = 1;
+        s_num_y_workgroups = half_columns / s_workgroup_size / s_num_x_workgroups;
+    }
+
+    if num_columns < 256 {
+        s_workgroup_size = 1;
+        s_num_x_workgroups = half_columns;
+        s_num_y_workgroups = 1;
+        s_num_z_workgroups = 1;
+    }
+
+    // How many subtasks processed per shader invocation.
+    let num_subtask_chunk_size = 4u32;
+
+    let bucket_sum_coord_bytelength =
+        (num_columns / 2) as usize * config.num_limbs as usize * 4 * num_subtasks as usize;
+
+    // Input buffers
+    let row_ptr_buf = helper.create_input_buffer(gpu_csc_col_ptr);
+    let val_idx_buf = helper.create_input_buffer(gpu_csc_val_idxs);
+    let point_x_buf = helper.create_input_buffer(gpu_point_x);
+    let point_y_buf = helper.create_input_buffer(gpu_point_y);
+
+    // Output "bucket" buffers
+    let bucket_x_buf = helper.create_output_buffer(bucket_sum_coord_bytelength);
+    let bucket_y_buf = helper.create_output_buffer(bucket_sum_coord_bytelength);
+    let bucket_z_buf = helper.create_output_buffer(bucket_sum_coord_bytelength);
+
+    // Launch shader for each subtask chunk
+    for offset in (0..num_subtasks as u32).step_by(num_subtask_chunk_size as usize) {
+        // params => [input_size, num_y_workgroups, num_z_workgroups, offset]
+        let params = vec![
+            input_size as u32,
+            s_num_y_workgroups,
+            s_num_z_workgroups,
+            offset,
+        ];
+        let params_buf = helper.create_input_buffer(&params);
+
+        let adjusted_s_num_x_workgroups = if num_columns < 256 {
+            s_num_x_workgroups
+        } else if num_subtasks as u32 >= num_subtask_chunk_size {
+            std::cmp::max(
+                1,
+                s_num_x_workgroups / (num_subtasks as u32 / num_subtask_chunk_size),
+            )
+        } else {
+            s_num_x_workgroups
+        };
+
+        let thread_group_count = helper.create_thread_group_size(
+            adjusted_s_num_x_workgroups as u64,
+            s_num_y_workgroups as u64,
+            s_num_z_workgroups as u64,
+        );
+        let threads_per_group = helper.create_thread_group_size(s_workgroup_size as u64, 1, 1);
+
+        helper.execute_shader(
+            config,
+            &[
+                &row_ptr_buf,
+                &val_idx_buf,
+                &point_x_buf,
+                &point_y_buf,
+                &bucket_x_buf,
+                &bucket_y_buf,
+                &bucket_z_buf,
+                &params_buf,
+            ],
+            &[],
+            &thread_group_count,
+            &threads_per_group,
+        );
+    }
+
+    // Read back results
+    let out_x = helper.read_results(&bucket_x_buf, bucket_sum_coord_bytelength);
+    let out_y = helper.read_results(&bucket_y_buf, bucket_sum_coord_bytelength);
+    let out_z = helper.read_results(&bucket_z_buf, bucket_sum_coord_bytelength);
+
+    (out_x, out_y, out_z)
+}
+
+// ----------------------------------------------------------------------------------
+// Unit-test for the SMVP kernel
+// ----------------------------------------------------------------------------------
 #[test]
 #[serial_test::serial]
 fn test_smvp() {
-    let log_limb_size = 16;
-    let num_limbs = 16;
-    let num_columns = 16;
-    let half_columns = num_columns / 2;
-    let num_rows = 16; // Must match the size used in row_ptr_host
-    let max_entries = 20; // Maximum number of nonzero entries to generate
+    let log_limb_size: u32 = 16;
+    let num_limbs: usize = 16;
 
-    let config = MetalConfig {
+    // Constants that must match the shader build-time constants
+    let num_columns: u32 = 1u32 << 16; // CHUNK_SIZE = 16 -> 65536 columns
+    let half_columns: u32 = num_columns / 2;
+
+    // Use a small input to keep the test lightweight
+    let input_size: usize = 8;
+    let num_subtasks: usize = 1;
+
+    // ---------------------------------------------------------------------------
+    // 1. Generate random points and convert coordinates to Montgomery limbs
+    // ---------------------------------------------------------------------------
+    let mut rng = rand::thread_rng();
+
+    let mut points: Vec<G> = Vec::with_capacity(input_size);
+    let mut point_x_limbs: Vec<u32> = Vec::with_capacity(input_size * num_limbs);
+    let mut point_y_limbs: Vec<u32> = Vec::with_capacity(input_size * num_limbs);
+
+    // Calculate Montgomery radix for conversion
+    let r = calc_mont_radix(num_limbs, log_limb_size);
+    let p: BigUint = BaseField::MODULUS.try_into().unwrap();
+
+    for _ in 0..input_size {
+        // Random affine point then promote to projective (z = 1)
+        let affine = G::rand(&mut rng).into_affine();
+        let proj: G = affine.into();
+        points.push(proj);
+
+        // Convert x/y coordinates to Montgomery form, then to limbs
+        let x_std: BigUint = affine.x.into_bigint().try_into().unwrap();
+        let y_std: BigUint = affine.y.into_bigint().try_into().unwrap();
+
+        let x_mont = (&x_std * &r) % &p;
+        let y_mont = (&y_std * &r) % &p;
+
+        let x_mont_bigint: BigInt<4> = x_mont.try_into().unwrap();
+        let y_mont_bigint: BigInt<4> = y_mont.try_into().unwrap();
+
+        let x_limbs = x_mont_bigint.to_limbs(num_limbs, log_limb_size);
+        let y_limbs = y_mont_bigint.to_limbs(num_limbs, log_limb_size);
+
+        point_x_limbs.extend(x_limbs);
+        point_y_limbs.extend(y_limbs);
+    }
+
+    // ---------------------------------------------------------------------------
+    // 2. Create a sparse matrix in CSR form (row_ptr / val_idx)
+    //    Each row corresponds to a bucket; randomly assign each point to a row.
+    // ---------------------------------------------------------------------------
+    let mut row_to_indices: Vec<Vec<u32>> = vec![Vec::new(); num_columns as usize];
+    for (idx, _) in points.iter().enumerate() {
+        let row_idx = rng.gen_range(1..num_columns) as usize; // avoid row 0 for variety
+        row_to_indices[row_idx].push(idx as u32);
+    }
+
+    // Build row_ptr (size = num_columns + 1) and val_idx in row-major order
+    let mut row_ptr: Vec<u32> = vec![0u32; (num_columns + 1) as usize];
+    let mut val_idx: Vec<u32> = Vec::with_capacity(input_size);
+    let mut cumulative: u32 = 0;
+    for i in 0..num_columns as usize {
+        row_ptr[i] = cumulative;
+        val_idx.extend(&row_to_indices[i]);
+        cumulative += row_to_indices[i].len() as u32;
+    }
+    row_ptr[num_columns as usize] = cumulative;
+    assert_eq!(cumulative as usize, val_idx.len());
+
+    // ---------------------------------------------------------------------------
+    // 3. Execute the SMVP kernel on GPU
+    // ---------------------------------------------------------------------------
+    let mut helper = MetalHelper::new();
+    let smvp_config = MetalConfig {
         log_limb_size,
         num_limbs,
         shader_file: "cuzk/smvp.metal".to_string(),
         kernel_name: "smvp".to_string(),
     };
 
-    let mut helper = MetalHelper::new();
-    let constants = get_or_calc_constants(num_limbs, log_limb_size);
-    let p_biguint = &constants.p;
-    let rinv = &constants.rinv;
-
-    // ------------------------------------------------------------------
-    // Generate random sparse matrix structure
-    // ------------------------------------------------------------------
-    let (row_ptr_host, val_idx_host) = generate_random_matrix(num_rows, num_columns, max_entries);
-
-    // We need to ensure input_size is correct (total number of non-zero entries)
-    let input_size = *row_ptr_host.last().unwrap() as u32;
-
-    // We thus need new_point_x,y to hold columns from 0..(num_columns-1)
-    let mut rng = rand::thread_rng();
-    let mut new_point_x_host = Vec::with_capacity(num_columns);
-    let mut new_point_y_host = Vec::with_capacity(num_columns);
-
-    // For each column, create random X,Y in Mont form
-    for _ in 0..num_columns {
-        let new_point = G::rand(&mut rng).into_affine();
-        let x_mont = new_point.x.0;
-        let y_mont = new_point.y.0;
-        let x_mont_biguint: BigUint = x_mont.try_into().unwrap();
-        let y_mont_biguint: BigUint = y_mont.try_into().unwrap();
-        new_point_x_host.push(x_mont_biguint);
-        new_point_y_host.push(y_mont_biguint);
-    }
-
-    let new_point_x_limbs = new_point_x_host
-        .iter()
-        .map(|bi| {
-            let ark_form: BigInt<4> = bi.clone().try_into().unwrap();
-            ark_form.to_limbs(num_limbs, log_limb_size)
-        })
-        .flatten()
-        .collect::<Vec<u32>>();
-
-    let new_point_y_limbs = new_point_y_host
-        .iter()
-        .map(|bi| {
-            let ark_form: BigInt<4> = bi.clone().try_into().unwrap();
-            ark_form.to_limbs(num_limbs, log_limb_size)
-        })
-        .flatten()
-        .collect::<Vec<u32>>();
-
-    // ------------------------------------------------------------------
-    // Create Metal buffers
-    // ------------------------------------------------------------------
-    let row_ptr_buf = helper.create_input_buffer(&row_ptr_host);
-    let val_idx_buf = helper.create_input_buffer(&val_idx_host);
-    let new_point_x_buf = helper.create_input_buffer(&new_point_x_limbs);
-    let new_point_y_buf = helper.create_input_buffer(&new_point_y_limbs);
-
-    // half_columns final buckets => each is a Jacobian coordinate => 3 * num_limbs each
-    let bucket_x_buf = helper.create_output_buffer(half_columns * num_limbs);
-    let bucket_y_buf = helper.create_output_buffer(half_columns * num_limbs);
-    let bucket_z_buf = helper.create_output_buffer(half_columns * num_limbs);
-
-    // params: input_size, num_y_workgroups=1, num_z_workgroups=1, subtask_offset=0
-    let params = vec![input_size, 1u32, 1u32, 0u32];
-    let params_buf = helper.create_input_buffer(&params);
-
-    // ------------------------------------------------------------------
-    // Execute shader
-    // ------------------------------------------------------------------
-    // Each thread is 1D in x dimension => we have half_columns threads
-    let threads_per_grid = helper.create_thread_group_size(half_columns as u64, 1, 1);
-    let threads_per_threadgroup = helper.create_thread_group_size(1, 1, 1);
-
-    helper.execute_shader(
-        &config,
-        &[
-            &row_ptr_buf,
-            &val_idx_buf,
-            &new_point_x_buf,
-            &new_point_y_buf,
-            &bucket_x_buf,
-            &bucket_y_buf,
-            &bucket_z_buf,
-            &params_buf,
-        ],
-        &[],
-        &threads_per_grid,
-        &threads_per_threadgroup,
+    let (gpu_bucket_x, gpu_bucket_y, gpu_bucket_z) = smvp_gpu(
+        &mut helper,
+        &smvp_config,
+        &row_ptr,
+        &val_idx,
+        &point_x_limbs,
+        &point_y_limbs,
+        input_size,
+        num_subtasks,
+        num_columns,
     );
 
-    // ------------------------------------------------------------------
-    // Read back the results from bucket_x,y,z
-    // ------------------------------------------------------------------
-    // Each bucket coordinate is 16 limbs => the entire array is half_columns buckets * 16 limbs
-    let bucket_x_out_limbs = helper.read_results(&bucket_x_buf, half_columns * num_limbs);
-    let bucket_y_out_limbs = helper.read_results(&bucket_y_buf, half_columns * num_limbs);
-    let bucket_z_out_limbs = helper.read_results(&bucket_z_buf, half_columns * num_limbs);
-
-    // Clean up all Metal resources
     helper.drop_all_buffers();
 
-    // ------------------------------------------------------------------
-    // CPU reference check and smvp logic
-    //
-    // We'll replicate the logic from smvp: for each thread id in [0..half_columns-1],
-    // we do j=0..1 => find row_idx => accumulate => maybe negate => store in bucket[id].
-    //
-    // skipped constants:
-    //   subtask_idx= id/half_columns => always 0
-    //   rp_offset= 0*(half_columns+1)= 0
-    //
-    // ------------------------------------------------------------------
+    // ---------------------------------------------------------------------------
+    // 4. Convert GPU buckets back to projective points
+    // ---------------------------------------------------------------------------
+    let mut gpu_buckets: Vec<G> = Vec::with_capacity(half_columns as usize);
+    for id in 0..half_columns as usize {
+        let limb_start = id * num_limbs;
+        let limb_end = (id + 1) * num_limbs;
 
-    fn decode_mont(
-        limbs: &[u32],
-        r_inv: &num_bigint::BigUint,
-        p: &num_bigint::BigUint,
-    ) -> BaseField {
-        // Turn the "limbs" back into a BigUint
-        let big: BigUint = BigInt::<4>::from_limbs(limbs, 16) // 16 = log_limb_size
-            .try_into()
-            .unwrap();
-        let big = &big * r_inv % p;
-        // Then convert to ark_ff::BigInt -> BaseField
-        let ark_big: BigInt<4> = big.try_into().unwrap();
-        BaseField::from_bigint(ark_big).unwrap()
+        let xr_limbs = &gpu_bucket_x[limb_start..limb_end];
+        let yr_limbs = &gpu_bucket_y[limb_start..limb_end];
+        let zr_limbs = &gpu_bucket_z[limb_start..limb_end];
+
+        let xr_mont = BigInt::<4>::from_limbs(xr_limbs, log_limb_size);
+        let yr_mont = BigInt::<4>::from_limbs(yr_limbs, log_limb_size);
+        let zr_mont = BigInt::<4>::from_limbs(zr_limbs, log_limb_size);
+
+        // Convert from Montgomery form to standard form
+        let xr_std = raw_reduction(xr_mont);
+        let yr_std = raw_reduction(yr_mont);
+        let zr_std = raw_reduction(zr_mont);
+
+        let x = BaseField::from_bigint(xr_std).unwrap_or_else(|| BaseField::zero());
+        let y = BaseField::from_bigint(yr_std).unwrap_or_else(|| BaseField::zero());
+        let z = BaseField::from_bigint(zr_std).unwrap_or_else(|| BaseField::zero());
+
+        gpu_buckets.push(G::new(x, y, z));
     }
 
-    let neg = |mut pt: G| {
-        pt.y = -pt.y;
-        pt
+    // ---------------------------------------------------------------------------
+    // 5. CPU reference implementation of the kernel logic
+    // ---------------------------------------------------------------------------
+    let mut cpu_buckets: Vec<G> = vec![G::zero(); half_columns as usize];
+
+    // helper closure: sum points in a given row
+    let accumulate_row = |row_idx: usize, row_to_indices: &Vec<Vec<u32>>, points: &Vec<G>| -> G {
+        let mut acc = G::zero();
+        for &idx in &row_to_indices[row_idx] {
+            acc += points[idx as usize];
+        }
+        acc
     };
 
-    // Convert an "(x_mont, y_mont) in BN254 base field Mont form" to an Affine G1 with Z=1
-    let decode_affine = |xm: &num_bigint::BigUint, ym: &num_bigint::BigUint| {
-        let x_big = (xm * rinv) % p_biguint;
-        let y_big = (ym * rinv) % p_biguint;
-        let x_ark = <BaseField as PrimeField>::from_bigint(x_big.try_into().unwrap()).unwrap();
-        let y_ark = <BaseField as PrimeField>::from_bigint(y_big.try_into().unwrap()).unwrap();
-        G::new(x_ark, y_ark, BaseField::one())
-    };
+    for id in 0..half_columns as usize {
+        let id_mod = id % half_columns as usize;
 
-    // Put new_point_x_host,y_host (already Mont biguint) into an array of G in normal form
-    let mut new_points = Vec::with_capacity(num_columns);
-    for i in 0..num_columns {
-        let gx = decode_affine(&new_point_x_host[i], &new_point_y_host[i]);
-        new_points.push(gx);
-    }
+        // j = 0 (positive bucket mostly)
+        let mut row_idx = id_mod + half_columns as usize;
+        if id_mod == 0 {
+            row_idx = 0;
+        }
+        let mut sum = accumulate_row(row_idx, &row_to_indices, &points);
+        let bucket_idx = if half_columns as usize > row_idx {
+            // negative bucket -> negate the sum
+            sum = sum.neg();
+            half_columns as usize - row_idx
+        } else {
+            row_idx - half_columns as usize
+        };
+        if bucket_idx > 0 {
+            cpu_buckets[id] = sum;
+        }
 
-    let mut cpu_buckets = vec![G::default(); half_columns];
-    let identity = G::zero();
-
-    for id in 0..half_columns {
-        for j in 0..2 {
-            // row_idx = (id % half_columns) + half_columns => j=0
-            // row_idx = half_columns - (id % half_columns) => j=1
-            let mut row_idx = (id % half_columns) + half_columns;
-            if j == 1 {
-                row_idx = half_columns - (id % half_columns);
-            }
-            // special case override if j==0 && id%half_columns==0 => row_idx=0
-            if j == 0 && (id % half_columns) == 0 {
-                row_idx = 0;
-            }
-
-            let row_begin = row_ptr_host[row_idx as usize];
-            let row_end = row_ptr_host[row_idx as usize + 1];
-            // accumulate
-            let mut sum = identity;
-            for k in row_begin..row_end {
-                let col_idx = val_idx_host[k as usize] as usize;
-                sum += new_points[col_idx];
-            }
-            // check sign
-            let mut bucket_idx = 0;
-            if half_columns > row_idx {
-                // negative => flip sign
-                bucket_idx = half_columns - row_idx;
-                sum = neg(sum);
-            } else {
-                bucket_idx = row_idx - half_columns;
-            }
-            // store
-            if bucket_idx > 0 {
-                if j == 1 {
-                    sum += cpu_buckets[id as usize];
-                }
-                cpu_buckets[id as usize] = sum;
-            }
+        // j = 1 (negative bucket counterpart)
+        let mut row_idx2 = half_columns as usize - id_mod;
+        let mut sum2 = accumulate_row(row_idx2, &row_to_indices, &points);
+        let bucket_idx2 = if half_columns as usize > row_idx2 {
+            sum2 = sum2.neg();
+            half_columns as usize - row_idx2
+        } else {
+            row_idx2 - half_columns as usize
+        };
+        if bucket_idx2 > 0 {
+            cpu_buckets[id] += sum2;
         }
     }
 
-    for id in 0..half_columns {
-        let x_slice = &bucket_x_out_limbs[id * num_limbs..(id + 1) * num_limbs];
-        let y_slice = &bucket_y_out_limbs[id * num_limbs..(id + 1) * num_limbs];
-        let z_slice = &bucket_z_out_limbs[id * num_limbs..(id + 1) * num_limbs];
-
-        let gx = decode_mont(x_slice, rinv, p_biguint);
-        let gy = decode_mont(y_slice, rinv, p_biguint);
-        let gz = decode_mont(z_slice, rinv, p_biguint);
-        let gpu_point = G::new(gx, gy, gz);
-
-        // Compare to CPU
-        let cpu_point = cpu_buckets[id];
-
-        let diff = gpu_point - cpu_point;
-        assert!(
-            diff.is_zero(),
-            "Mismatch at id={}, GPU vs CPU. GPU={:?}, CPU={:?}",
-            id,
-            gpu_point,
-            cpu_point
+    // ---------------------------------------------------------------------------
+    // 6. Compare GPU vs CPU results on the non-empty buckets
+    // ---------------------------------------------------------------------------
+    for id in 0..half_columns as usize {
+        if cpu_buckets[id].is_zero() {
+            continue; // skip empty buckets
+        }
+        assert_eq!(
+            cpu_buckets[id], gpu_buckets[id],
+            "Mismatch at bucket {}",
+            id
         );
     }
-}
-
-/// Generate random sparse matrix structure
-fn generate_random_matrix(
-    num_rows: usize,
-    num_columns: usize,
-    max_nonzero_entries: usize,
-) -> (Vec<u32>, Vec<u32>) {
-    let mut rng = rand::thread_rng();
-
-    let nonzero_entries = rng.gen_range(1..=max_nonzero_entries);
-    let mut row_ptr = vec![0; num_rows + 1];
-    let mut entries_per_row = vec![0; num_rows];
-
-    // Distribute nonzero entries across rows randomly
-    for _ in 0..nonzero_entries {
-        let row = rng.gen_range(0..num_rows);
-        entries_per_row[row] += 1;
-    }
-
-    // Calculate row_ptr values based on entries_per_row
-    for i in 0..num_rows {
-        row_ptr[i + 1] = row_ptr[i] + entries_per_row[i];
-    }
-
-    // Generate random column indices for each nonzero entry
-    let mut val_idx = Vec::with_capacity(nonzero_entries);
-    for row in 0..num_rows {
-        for _ in 0..entries_per_row[row] {
-            val_idx.push(rng.gen_range(0..num_columns) as u32);
-        }
-    }
-
-    (row_ptr, val_idx)
 }


### PR DESCRIPTION
This PR introduces the complete pipeline for integrating cuzk metal shaders to produce valid MSM results (we use Arkworks as reference).

To run the pipeline, use this command
```sh
cargo test test_e2e_msm_pipeline -- --nocapture
```

To adjust the input size, check
https://github.com/zkmopro/gpu-acceleration/blob/01b289fc9d1040f6b6bba87014459ae4a8bdf634/mopro-msm/src/msm/metal_msm/tests/cuzk/e2e.rs#L609-L613

- related write-up: https://hackmd.io/HNH0DcSqSka4hAaIfJNHEA
- related repo: https://github.com/z-prize/2023-entries/tree/main/prize-2-msm-wasm/webgpu-only/tal-derei-koh-wei-jie