### PR TITLE
Fine-tune Window Size with Input Size

### DIFF
--- a/mopro-msm/src/msm/metal_msm/host/shader.rs
+++ b/mopro-msm/src/msm/metal_msm/host/shader.rs
@@ -47,11 +47,6 @@ pub fn write_constants(
     let num_limbs_wide = num_limbs + 1;
     let num_limbs_extra_wide = num_limbs * 2;
 
-    // MSM instance params
-    let chunk_size = 16;
-    let num_columns = 2u32.pow(chunk_size);
-    let num_subtasks = (256 as f32 / chunk_size as f32).ceil() as u32;
-
     let basefield_modulus = BaseField::MODULUS.to_limbs(num_limbs, log_limb_size);
     let r = calc_mont_radix(num_limbs, log_limb_size);
     let p: BigUint = BaseField::MODULUS.try_into().unwrap();
@@ -77,9 +72,6 @@ pub fn write_constants(
     data += format!("#define N0 {}\n", n0).as_str();
     data += format!("#define NSAFE {}\n", nsafe).as_str();
     data += format!("#define SLACK {}\n", slack).as_str();
-    data += format!("#define CHUNK_SIZE {}\n", chunk_size).as_str();
-    data += format!("#define NUM_COLUMNS {}\n", num_columns).as_str();
-    data += format!("#define NUM_SUBTASKS {}\n", num_subtasks).as_str();
 
     let mu_limbs = mu_in_ark.to_limbs(num_limbs, log_limb_size);
     write_constant_array!(data, "BARRETT_MU", mu_limbs, "NUM_LIMBS");

--- a/mopro-msm/src/msm/metal_msm/metal_msm.rs
+++ b/mopro-msm/src/msm/metal_msm/metal_msm.rs
@@ -74,28 +74,20 @@ impl MetalMSMPipeline {
     }
 
     /// Execute the complete MSM pipeline on GPU
-    fn execute(&self, bases: &[Affine], scalars: &[ScalarField]) -> Result<G, Box<dyn Error>> {
-        let input_size = bases.len();
-        let window_size = 16; // for 2^20 inputs, need to add to shader manager stage?
-
+    fn execute_pipeline(
+        &self,
+        bases: &[Affine],
+        scalars: &[ScalarField],
+        input_size: usize,
+        window_size: usize,
+        scale_factor: usize,
+    ) -> Result<G, Box<dyn Error>> {
+        // these params are set based on the Alogorithm 3 in the cuZK paper (https://eprint.iacr.org/2022/1321.pdf)
         let num_columns = 1 << window_size;
-        let num_subtasks = 256 / window_size as usize;
+        let num_subtasks =
+            (ScalarField::MODULUS_BIT_SIZE as f32 / window_size as f32).ceil() as usize;
 
-        // input-related workgroup size will be adjusted based on the scale factor
-        let scale_factor;
-        if input_size <= 4096 {
-            scale_factor = 1;
-        } else if input_size > 4096 && input_size <= 65536 {
-            scale_factor = 2;
-        } else if input_size > 65536 && input_size <= 1048576 {
-            scale_factor = 1 << 2;
-        } else if input_size > 1048576 && input_size <= 33554432 {
-            scale_factor = 1 << 3;
-        } else {
-            scale_factor = 1 << 4;
-        }
         println!("scale_factor: {:?}", scale_factor);
-
         println!("window_size: {:?}", window_size);
         println!("num_columns: {:?}", num_columns);
         println!("num_subtasks: {:?}", num_subtasks);
@@ -173,7 +165,7 @@ impl MetalMSMPipeline {
         // after testing, 1D dim config is better than 3D dim config
         let s_workgroup_size = self.simd_width * scale_factor;
         let s_num_y_workgroups = self.simd_width;
-        let s_num_z_workgroups = num_subtasks / 2;
+        let s_num_z_workgroups = (num_subtasks + 1) / 2; // round up
         let s_num_x_workgroups = input_size / s_workgroup_size / s_num_y_workgroups;
 
         println!("s_workgroup_size: {:?}", s_workgroup_size);
@@ -194,8 +186,7 @@ impl MetalMSMPipeline {
             input_size,
             num_subtasks,
             num_columns,
-            s_num_y_workgroups,
-            s_num_z_workgroups,
+            self.simd_width,
             s_workgroup_size,
         )?;
         let stage3_time = start.elapsed();
@@ -209,8 +200,7 @@ impl MetalMSMPipeline {
         let num_subtasks_per_bpr_1 = num_subtasks;
         let num_subtasks_per_bpr_2 = num_subtasks;
 
-        let b_workgroup_size = self.simd_width * scale_factor; // 128 is best for 2^20 inputs
-
+        let b_workgroup_size = self.simd_width * scale_factor;
         let b_num_x_workgroups = num_subtasks_per_bpr_1;
         let b_num_y_workgroups = 1;
         let b_num_z_workgroups = 1;
@@ -259,7 +249,7 @@ impl MetalMSMPipeline {
             &g_points_y,
             &g_points_z,
             num_subtasks,
-            self.config.log_limb_size as usize,
+            window_size,
             b_workgroup_size,
         )?;
         let stage5_time = start.elapsed();
@@ -275,7 +265,7 @@ impl MetalMSMPipeline {
         g_points_y: &[u32],
         g_points_z: &[u32],
         num_subtasks: usize,
-        log_limb_size: usize,
+        window_size: usize,
         pbpr_workgroup_size: usize,
     ) -> Result<G, Box<dyn Error>> {
         // Parallel processing of subtasks
@@ -314,7 +304,7 @@ impl MetalMSMPipeline {
             .collect();
 
         // Horner's method
-        let m = ScalarField::from(1u64 << log_limb_size);
+        let m = ScalarField::from(1u64 << window_size);
         let mut result = gpu_points[gpu_points.len() - 1];
 
         if gpu_points.len() > 1 {
@@ -498,8 +488,7 @@ impl<'a> SMVP<'a> {
         input_size: usize,
         num_subtasks: usize,
         num_columns: usize,
-        s_num_y_workgroups: usize,
-        s_num_z_workgroups: usize,
+        simd_width: usize,
         s_workgroup_size: usize,
     ) -> Result<(Vec<u32>, Vec<u32>, Vec<u32>), Box<dyn Error>> {
         let mut helper = MetalHelper::with_device(self.shader_manager.device().clone());
@@ -508,8 +497,10 @@ impl<'a> SMVP<'a> {
             .get_shader(&ShaderType::SMVP)
             .ok_or("SMVP shader not found")?;
 
+        let half_columns = num_columns / 2;
+
         let bucket_size =
-            (num_columns / 2) as usize * self.shader_manager.config().num_limbs * 4 * num_subtasks;
+            half_columns as usize * self.shader_manager.config().num_limbs * 4 * num_subtasks;
 
         // Create buffers
         let row_ptr_buf = helper.create_buffer(&csc_col_ptr.to_vec());
@@ -525,14 +516,25 @@ impl<'a> SMVP<'a> {
         let num_subtask_chunk_size = 4u32;
         for offset in (0..num_subtasks as u32).step_by(num_subtask_chunk_size as usize) {
             let remaining_subtasks = (num_subtasks as u32 - offset).min(num_subtask_chunk_size);
-            let threads_this_chunk = (num_columns / 2) as u64 * remaining_subtasks as u64;
+            let threads_this_chunk = half_columns as u64 * remaining_subtasks as u64;
+            let valid_threads = half_columns as u64 * remaining_subtasks as u64;
 
-            let adjusted_x_workgroups = std::cmp::max(
-                1,
-                threads_this_chunk
-                    / s_workgroup_size as u64
-                    / (s_num_y_workgroups * s_num_z_workgroups) as u64,
-            );
+            let max_y = ((valid_threads as usize)
+                / (s_workgroup_size * remaining_subtasks as usize)) // remaining_subtasks == Z
+                .max(1);
+
+            println!("valid_threads: {:?}", valid_threads);
+            println!("remaining_subtasks: {:?}", remaining_subtasks);
+            println!("s_workgroup_size: {:?}", s_workgroup_size);
+            println!("max_y: {:?}", max_y);
+
+            let s_num_y_workgroups = simd_width.min(max_y);
+            println!("s_num_y_workgroups: {:?}", s_num_y_workgroups);
+            let s_num_z_workgroups = remaining_subtasks as usize;
+
+            let threads_per_grid =
+                (s_workgroup_size * s_num_y_workgroups * s_num_z_workgroups) as u64;
+            let adjusted_x_workgroups = (valid_threads + threads_per_grid - 1) / threads_per_grid; // ceil div
 
             let params_buf = helper.create_buffer(&vec![
                 input_size as u32,
@@ -744,8 +746,8 @@ impl<'a> PBPR<'a> {
 /// Convenient wrapper that mimics the Arkworks VariableBaseMSM interface
 /// Usage: metal_variable_base_msm(&bases, &scalars)
 pub fn metal_variable_base_msm(
-    bases: &[ark_bn254::G1Affine],
-    scalars: &[ark_bn254::Fr],
+    mut bases: &[ark_bn254::G1Affine],
+    mut scalars: &[ark_bn254::Fr],
 ) -> Result<ark_bn254::G1Projective, Box<dyn Error>> {
     // Handle empty input case
     if bases.is_empty() || scalars.is_empty() {
@@ -754,11 +756,47 @@ pub fn metal_variable_base_msm(
 
     // Ensure bases and scalars have the same length
     if bases.len() != scalars.len() {
-        return Err("Bases and scalars must have the same length".into());
+        let min_len = std::cmp::min(bases.len(), scalars.len());
+        bases = &bases[..min_len];
+        scalars = &scalars[..min_len];
     }
 
+    let input_size = bases.len();
+
+    // window_size is determined by experiment results
+    let window_size = if input_size < 16384 {
+        // 2^14
+        8
+    } else if input_size < 524288 {
+        // 2^19
+        13
+    } else if input_size <= 16777216 {
+        // 2^24
+        15
+    } else {
+        16
+    };
+
+    // workgroup size will be adjusted based on the scale factor
+    let scale_factor = if input_size <= 4096 {
+        // 2^0
+        1
+    } else if input_size > 4096 && input_size <= 65536 {
+        // 2^1
+        2
+    } else if input_size > 65536 && input_size <= 1048576 {
+        // 2^2
+        1 << 2
+    } else if input_size > 1048576 && input_size <= 33554432 {
+        // 2^3
+        1 << 3
+    } else {
+        // 2^4
+        1 << 4
+    };
+
     let pipeline = MetalMSMPipeline::with_default_config()?;
-    pipeline.execute(bases, scalars)
+    pipeline.execute_pipeline(bases, scalars, input_size, window_size, scale_factor)
 }
 
 /// Test utilities module - available for both unit tests and integration tests
@@ -805,7 +843,7 @@ mod tests {
 
     #[test]
     fn test_metal_msm_pipeline() {
-        let log_input_size = 20;
+        let log_input_size = 15;
         let input_size = 1 << log_input_size;
 
         println!("Generating {} elements", input_size);
@@ -830,13 +868,11 @@ mod tests {
     #[ignore]
     fn benchmark_metal_vs_arkworks_msm() {
         println!("\n=== MSM Benchmark: Metal vs Arkworks ===");
-        println!(
-            "{:<12} {:<15} {:<15} {:<15} {:<10}",
-            "Input Size", "Metal Time", "Arkworks Time", "Speedup", "Correct"
-        );
-        println!("{}", "-".repeat(75));
 
-        for log_input_size in 23..=24 {
+        // Store results for each size
+        let mut results = Vec::new();
+
+        for log_input_size in 10..=24 {
             let input_size = 1 << log_input_size;
 
             // Generate test data
@@ -860,7 +896,42 @@ mod tests {
             // Verify correctness
             let is_correct = metal_result == arkworks_result;
 
-            // Format output
+            // Store results
+            results.push((
+                log_input_size,
+                input_size,
+                metal_time,
+                arkworks_time,
+                speedup,
+                is_correct,
+                generation_time,
+            ));
+
+            // Assert correctness for all sizes
+            assert_eq!(
+                metal_result, arkworks_result,
+                "Results don't match for input size 2^{}",
+                log_input_size
+            );
+        }
+
+        // Print all results at once
+        println!(
+            "{:<12} {:<15} {:<15} {:<15} {:<10}",
+            "Input Size", "Metal Time", "Arkworks Time", "Speedup", "Correct"
+        );
+        println!("{}", "-".repeat(75));
+
+        for (
+            log_input_size,
+            input_size,
+            metal_time,
+            arkworks_time,
+            speedup,
+            is_correct,
+            generation_time,
+        ) in results
+        {
             let input_size_str = format!("2^{} ({})", log_input_size, input_size);
             let metal_time_str = format!("{:.3}s", metal_time.as_secs_f64());
             let arkworks_time_str = format!("{:.3}s", arkworks_time.as_secs_f64());
@@ -880,13 +951,6 @@ mod tests {
             println!(
                 "  └─ Data generation: {:.3}s",
                 generation_time.as_secs_f64()
-            );
-
-            // Assert correctness for all sizes
-            assert_eq!(
-                metal_result, arkworks_result,
-                "Results don't match for input size 2^{}",
-                log_input_size
             );
         }
 

--- a/mopro-msm/src/msm/metal_msm/shader/constants.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/constants.metal
@@ -9,9 +9,6 @@
 #define N0 25481
 #define NSAFE 1
 #define SLACK 2
-#define CHUNK_SIZE 16
-#define NUM_COLUMNS 65536
-#define NUM_SUBTASKS 16
 constant uint32_t BARRETT_MU[NUM_LIMBS] = {
     37093,
     6591,

--- a/mopro-msm/src/msm/metal_msm/shader/cuzk/barrett_reduction.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/cuzk/barrett_reduction.metal
@@ -73,10 +73,6 @@ BigInt get_higher_with_slack(BigIntExtraWide a) {
 }
 
 BigInt barrett_reduce(BigIntExtraWide a) {
-    for (uint i = 0; i < NUM_LIMBS; i++) {
-        LOG_DEBUG_DUPL("res.limbs[%u] = %u", i, a.limbs[i]);
-    }
-
     BigInt p = MODULUS;
     BigInt mu = get_mu();
 

--- a/mopro-msm/src/msm/metal_msm/shader/cuzk/convert_point_coords_and_decompose_scalars.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/cuzk/convert_point_coords_and_decompose_scalars.metal
@@ -14,18 +14,23 @@ using namespace metal;
 #endif
 
 kernel void convert_point_coords_and_decompose_scalars(
-    device const uint* coords           [[buffer(0)]],
-    device const uint* scalars          [[buffer(1)]],
-    constant uint& input_size           [[buffer(2)]],
-    device BigInt* point_x              [[buffer(3)]],
-    device BigInt* point_y              [[buffer(4)]],
-    device uint* chunks                 [[buffer(5)]],
-    device const uint* num_y_workgroups [[buffer(6)]],
-    uint3 gid                           [[thread_position_in_grid]]
+    device const uint* coords               [[ buffer(0) ]],
+    device const uint* scalars              [[ buffer(1) ]],
+    device BigInt* point_x                  [[ buffer(2) ]],
+    device BigInt* point_y                  [[ buffer(3) ]],
+    device uint* chunks                     [[ buffer(4) ]],
+    constant uint4& params                  [[ buffer(5) ]],
+    uint3 gid                               [[ thread_position_in_grid ]],
+    uint3 threadgroup_size                  [[ threadgroups_per_grid ]]
 ) {
+    const uint input_size = params[0];
+    const uint window_size = params[1];
+    const uint num_columns = params[2];
+    const uint num_subtask = params[3];
+
     uint gidx = gid.x;
     uint gidy = gid.y;
-    uint id   = gidx * (*num_y_workgroups) + gidy;
+    uint id   = gidx * threadgroup_size.y + gidy;
 
     // 1) Convert coords to BigInt in Montgomery form
     // We read 16 halfwords for x and 16 halfwords for y. 
@@ -82,38 +87,32 @@ kernel void convert_point_coords_and_decompose_scalars(
         scalar_bytes[15u - (i * 2u) - 1u] = hi;
     }
 
-    // Extract wNAF representation. each chunk is CHUNK_SIZE bits from the scalar.
-    uint chunks_arr[NUM_SUBTASKS];
-    for (uint i = 0; i < NUM_SUBTASKS - 1u; i++) {
-        chunks_arr[i] = extract_word_from_bytes_le(scalar_bytes, i, CHUNK_SIZE);
-    }
-
-    // The last chunk is special if (NUM_SUBTASKS * CHUNK_SIZE > 256)
-    chunks_arr[NUM_SUBTASKS - 1] =
-        scalar_bytes[0] >> (((NUM_SUBTASKS * CHUNK_SIZE - 256u) + 16u) - CHUNK_SIZE);
-
-    // 3) Signed wNAF in the range [−(l−1), (l−1)]
-    uint l = NUM_COLUMNS;
+    // Extract wNAF representation. each chunk is window_size bits from the scalar.
+    uint l = num_columns;
     uint s = l / 2u;
-
-    int signed_slices[NUM_SUBTASKS];
     uint carry = 0;
-    for (uint i = 0; i < NUM_SUBTASKS; i++) {
-        int slice_val = int(chunks_arr[i] + carry);
+
+    for (uint i = 0; i < num_subtask; i++) {
+        // Extract chunk on-demand
+        uint chunk_val;
+        if (i < num_subtask - 1u) {
+            chunk_val = extract_word_from_bytes_le(scalar_bytes, i, window_size);
+        } else {
+            // The last chunk is special
+            chunk_val = scalar_bytes[0] >> (((num_subtask * window_size - 256u) + 16u) - window_size);
+        }
+        
+        // Process signed wNAF directly
+        int slice_val = int(chunk_val + carry);
         if (slice_val >= int(s)) {
             slice_val = (int(l) - slice_val) * (-1);
             carry = 1u;
-        }
-        else {
+        } else {
             carry = 0u;
         }
-        signed_slices[i] = slice_val;
-    }
-
-    // Store final values into chunks
-    for (uint i = 0; i < NUM_SUBTASKS; i++) {
+        
+        // Store final value directly
         uint offset = i * input_size;
-        // shift negative slices by +s to keep them in [0, l) range
-        chunks[id + offset] = uint(signed_slices[i]) + s;
+        chunks[id + offset] = uint(slice_val) + s;
     }
 }

--- a/mopro-msm/src/msm/metal_msm/shader/cuzk/extract_word_from_bytes_le.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/cuzk/extract_word_from_bytes_le.metal
@@ -7,14 +7,14 @@ using namespace metal;
 inline uint32_t extract_word_from_bytes_le(
     const thread uint32_t* input,
     uint32_t word_idx,
-    uint32_t chunk_size
+    uint32_t window_size
 ) {
     uint32_t word = 0;
-    const uint32_t start_byte_idx = 15 - ((word_idx * chunk_size + chunk_size) / 16);
-    const uint32_t end_byte_idx = 15 - ((word_idx * chunk_size) / 16);
+    const uint32_t start_byte_idx = 15 - ((word_idx * window_size + window_size) / 16);
+    const uint32_t end_byte_idx = 15 - ((word_idx * window_size) / 16);
     
-    const uint32_t start_byte_offset = (word_idx * chunk_size + chunk_size) % 16;
-    const uint32_t end_byte_offset = (word_idx * chunk_size) % 16;
+    const uint32_t start_byte_offset = (word_idx * window_size + window_size) % 16;
+    const uint32_t end_byte_offset = (word_idx * window_size) % 16;
     
     uint32_t mask = 0;
     if (start_byte_offset > 0) {

--- a/mopro-msm/src/msm/metal_msm/shader/cuzk/smvp.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/cuzk/smvp.metal
@@ -25,27 +25,17 @@ kernel void smvp(
     uint3                       workgroup_size      [[ dispatch_threads_per_threadgroup ]],
     uint3                       threadgroup_size    [[ threadgroups_per_grid ]]
 ) {
+    const uint group_id = (tgid.x * threadgroup_size.y + tgid.y) * threadgroup_size.z + tgid.z;
+    const uint id = group_id * workgroup_size.x + tid.x;
+
     const uint input_size        = params[0];
     const uint num_columns       = params[1];
     const uint num_subtasks      = params[2];
     const uint subtask_offset    = params[3];
 
-    const uint tgidx = tgid.x;
-    const uint tgidy = tgid.y;
-    const uint tgidz = tgid.z;
-
-    const uint group_id = (tgidx * threadgroup_size.y + tgidy) * threadgroup_size.z + tgidz;
-    const uint id = group_id * workgroup_size.x + tid.x;
-
     const uint half_columns = num_columns / 2;
 
     const uint subtask_idx = id / half_columns;
-
-    // Add bounds checking to prevent out-of-bounds access
-    if (subtask_idx + subtask_offset >= num_subtasks) {
-        LOG_DEBUG("tgidx %u, tgidy %u, tgidz %u, tid.x %u, workgroup_size.x %u, group_id %u, id %u, subtask_idx %u, subtask_offset %u", tgidx, tgidy, tgidz, tid.x, workgroup_size.x, group_id, id, subtask_idx, subtask_offset);
-        return;
-    }
 
     Jacobian inf = get_bn254_zero_mont();
 
@@ -62,54 +52,16 @@ kernel void smvp(
             row_idx = 0;
         }
 
-        // Add bounds checking for row_ptr access
-        if (rp_offset + row_idx + 1 >= (16 * (num_columns + 1) * 4)) { // Total row_ptr buffer size
-            LOG_DEBUG("SMVP: row_ptr bounds exceeded at offset %u, row_idx %u", rp_offset, row_idx);
-            return;
-        }
-
         const uint row_begin = row_ptr[rp_offset + row_idx];
         const uint row_end = row_ptr[rp_offset + row_idx + 1];
-
-        // Add safety check to prevent infinite loops
-        if (row_end > input_size || row_begin > row_end) {
-            LOG_DEBUG("SMVP: Invalid row range [%u, %u) for subtask %u, offset %u", 
-                     row_begin, row_end, subtask_idx, subtask_offset);
-            continue; // Skip this bucket instead of hanging
-        }
-
-        // Add another safety check to prevent very large loops
-        if (row_end - row_begin > input_size / 2) {
-            LOG_DEBUG("SMVP: Suspiciously large bucket size %u for subtask %u", 
-                     row_end - row_begin, subtask_idx + subtask_offset);
-            continue; // Skip this bucket
-        }
 
         // Accumulate all the points for that bucket
         Jacobian sum = inf;
 
-        LOG_DEBUG("SMVP: row_begin %u, row_end %u, subtask_idx %u, subtask_offset %u", row_begin, row_end, subtask_idx, subtask_offset);
-        if (row_begin > row_end) {
-            LOG_DEBUG("SMVP: row_begin %u is greater than row_end %u", row_begin, row_end);
-            continue;
-        }
-
         for (uint k = row_begin; k < row_end; k++) {
-            // Add bounds checking for val_idx access
             const uint val_idx_offset = (subtask_idx + subtask_offset) * input_size + k;
-            if (val_idx_offset >= (16 * input_size)) { // Total val_idx buffer size
-                LOG_DEBUG("SMVP: val_idx bounds exceeded at offset %u", val_idx_offset);
-                break;
-            }
-            
             const uint idx = val_idx[val_idx_offset];
-            
-            // Add bounds checking for point array access
-            if (idx >= input_size) {
-                LOG_DEBUG("SMVP: Point index %u exceeds input_size %u", idx, input_size);
-                continue;
-            }
-            
+
             Jacobian b = {
                 .x = new_point_x[idx],
                 .y = new_point_y[idx],
@@ -135,12 +87,7 @@ kernel void smvp(
         const uint bi = id + subtask_offset * half_columns;
         
         // Add bounds checking for bucket array access
-        const uint bucket_size = half_columns * NUM_LIMBS * num_subtasks;
-        if (bi >= bucket_size) {
-            LOG_DEBUG("SMVP: Bucket index %u exceeds buffer size %u", bi, bucket_size);
-            return;
-        }
-        
+        const uint bucket_size = half_columns * NUM_LIMBS * num_subtasks;        
         if (bucket_idx > 0) {
             // If j == 1, add to the existing bucket at index `bi`.
             if (j == 1) {

--- a/mopro-msm/src/msm/metal_msm/tests/cuzk/smvp.rs
+++ b/mopro-msm/src/msm/metal_msm/tests/cuzk/smvp.rs
@@ -59,11 +59,11 @@ fn smvp_gpu(
 
     // Launch shader for each subtask chunk
     for offset in (0..num_subtasks as u32).step_by(num_subtask_chunk_size as usize) {
-        // params => [input_size, num_y_workgroups, num_z_workgroups, offset]
+        // params => [input_size, num_columns, num_subtasks, offset]
         let params = vec![
             input_size as u32,
-            s_num_y_workgroups,
-            s_num_z_workgroups,
+            num_columns as u32,
+            num_subtasks as u32,
             offset,
         ];
         let params_buf = helper.create_buffer(&params);

--- a/mopro-msm/src/msm/metal_msm/utils/window_size_optimizer.rs
+++ b/mopro-msm/src/msm/metal_msm/utils/window_size_optimizer.rs
@@ -71,29 +71,6 @@ pub fn find_optimal_window_size(params: &MsmParameters) -> CostResult {
         })
 }
 
-/// Find the optimal window size for given MSM parameters
-///
-/// This function evaluates all feasible window sizes and returns the one
-/// with minimum computational cost.
-pub fn find_optimal_window_size_serial(params: &MsmParameters) -> CostResult {
-    let max_window_size = 30;
-    let mut best_result = CostResult {
-        window_size: 1,
-        cost: f64::INFINITY,
-    };
-
-    // Evaluate window sizes from 1 to max_window_size
-    for window_size in 1..=max_window_size {
-        let cost = calculate_cost(params, window_size);
-
-        if cost < best_result.cost {
-            best_result = CostResult { window_size, cost };
-        }
-    }
-
-    best_result
-}
-
 /// Fetch GPU core count from existing Metal device (more efficient)
 pub fn fetch_gpu_core_count_and_simd_width_from_device(device: &Device) -> (usize, usize) {
     // fetch the number of parallel cores from the SMVP kernel as example

--- a/mopro-msm/src/msm/metal_msm/utils/window_size_optimizer.rs
+++ b/mopro-msm/src/msm/metal_msm/utils/window_size_optimizer.rs
@@ -1,8 +1,12 @@
-use metal::*;
 /// Window size optimizer for MSM computation
 ///
-/// This module implements the cost function described in Section 3.2 to determine
-/// the optimal window size for parallel MSM algorithms.
+/// This module implements for finding the optimal window size for Metal MSM described in
+/// https://eprint.iacr.org/2022/1321.pdf
+///
+/// However, in the experiments on the real device,
+/// the optimal size is not always the same as the one in the paper.
+/// So this module is only used as a reference.
+use metal::*;
 use rayon::prelude::*;
 // Embed the precompiled Metal library
 include!(concat!(env!("OUT_DIR"), "/built_shaders.rs"));


### PR DESCRIPTION
related issues
- #79 
- #2 

The PR adds dynamic `window_size` support to MSM, right-sizing each column to eliminate waste. As a result, small and medium inputs (2^14 to 2^18) run 2–8× faster (the smaller the input size, the greater the acceleration), while large inputs (2^20) see roughly a 20 % speed-up (1.836 s vs 2.238 s).

Interestingly, in f5c3fcd2dd1e32766e5713a5d8e6e19ebe00f6f6 we create `mopro-msm/src/msm/metal_msm/utils/window_size_optimizer.rs` to calculate the theoretically optimal window sizes for each input size according to the cost function described in Section 4.1 of [cuZK](https://eprint.iacr.org/2022/1321.pdf) paper. The result shows that the optimal size on a real device is not always the same as the one in the paper.

For example, for input size = 16, different window sizes show very different performances.

Window Size | Time (ms) | Num Subtasks
-- | -- | --
16 | 581 | 16
15 | 432 | 17
14 | 1431 | 19
13 | `**304**` | 20
12 | 1353 | 22
11 | wrong MSM result | 24
10 | 508 | 26
9 | 1372 | 29
8 | 418 | 32

So, we chose window sizes matching the BN254 scalar and tested inputs from 2^12 to 2^24 in a mobile proving setup to pinpoint the best-performing window size.

```
=== Window Size Optimization Results ===
Input Size   w=8          w=10         w=13         w=15         w=16         Optimal        
------------------------------------------------------------------------------------------
2^10         0.034s       0.035s       0.056s       0.152s       0.234s       w=8 (0.034s)   
2^11         0.040s       0.044s       0.060s       0.143s       0.247s       w=8 (0.040s)   
2^12         0.052s       0.057s       0.069s       0.161s       0.263s       w=8 (0.052s)   
2^13         0.085s       0.095s       0.085s       0.175s       0.278s       w=8 (0.085s)   
2^14         0.124s       0.148s       0.115s       0.207s       0.323s       w=13 (0.115s)  
2^15         0.200s       0.281s       0.164s       0.264s       0.435s       w=13 (0.164s)  
2^16         0.349s       0.456s       0.224s       0.318s       0.454s       w=13 (0.224s)  
2^17         0.713s       0.864s       0.373s       0.461s       0.613s       w=13 (0.373s)  
2^18         1.291s       1.614s       0.618s       0.690s       0.859s       w=13 (0.618s)  
2^19         N/A          N/A          1.107s       1.069s       1.319s       w=15 (1.069s)  
2^20         N/A          N/A          2.038s       1.834s       2.054s       w=15 (1.834s)  
2^21         N/A          N/A          3.977s       3.212s       3.474s       w=15 (3.212s)  
2^22         N/A          N/A          7.692s       6.066s       6.519s       w=15 (6.066s)
2^23         N/A          N/A          N/A          11.416s      12.040s      w=15 (11.416s) 
2^24         N/A          N/A          N/A          22.348s      22.799s      w=15 (22.348s)
------------------------------------------------------------------------------------------
```
*(N/A means it was too slow, so we didn’t test that window size on larger inputs)*

After fine-tuning with `window_sizes = [8, 13, 15, 16]` properly for different input sizes, we got the following benchmark.
- please refer to all of the previous benchmarks here: #73

```
Input Size   Metal Time      Arkworks Time   Speedup         Correct   
---------------------------------------------------------------------------
2^12 (4096)  0.056s             0.006s          8.89x slower    ✓         
  └─ Data generation: 0.011s
2^13 (8192)  0.095s             0.013s          7.58x slower    ✓         
  └─ Data generation: 0.022s
2^14 (16384) 0.120s             0.022s          5.40x slower    ✓         
  └─ Data generation: 0.046s
2^15 (32768) 0.155s             0.038s          4.06x slower    ✓         
  └─ Data generation: 0.082s
2^16 (65536) 0.228s             0.070s          3.28x slower    ✓         
  └─ Data generation: 0.151s
2^17 (131072) 0.390s            0.126s          3.10x slower    ✓         
  └─ Data generation: 0.298s
2^18 (262144) 0.627s            0.241s          2.61x slower    ✓         
  └─ Data generation: 0.553s
2^19 (524288) 1.065s            0.472s          2.26x slower    ✓         
  └─ Data generation: 1.153s
2^20 (1048576) 1.822s           0.908s          2.01x slower    ✓         
  └─ Data generation: 2.195s
2^21 (2097152) 3.281s           1.636s          2.01x slower    ✓         
  └─ Data generation: 4.700s
2^22 (4194304) 6.498s           3.532s          1.84x slower    ✓         
  └─ Data generation: 9.445s
2^23 (8388608) 11.722s          6.648s          1.76x slower    ✓         
  └─ Data generation: 17.851s
2^24 (16777216) 25.200s         14.767s         1.71x slower    ✓         
  └─ Data generation: 36.486s
---------------------------------------------------------------------------
```