### PR TITLE
Refactor/msl level optimization

### DIFF
--- a/mopro-msm/src/msm/metal_msm/shader/bigint/bigint.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/bigint/bigint.metal
@@ -12,6 +12,8 @@ inline BigIntResult bigint_add_unsafe(
     BigIntResult res;
     res.carry = 0;
     uint mask = (1 << LOG_LIMB_SIZE) - 1;
+
+    #pragma unroll(16)
     for (uint i = 0; i < NUM_LIMBS; i++) {
         uint c = lhs.limbs[i] + rhs.limbs[i] + res.carry;
         res.value.limbs[i] = c & mask;
@@ -28,6 +30,8 @@ inline BigIntResultWide bigint_add_wide(
     res.carry = 0;
     uint mask = (1 << LOG_LIMB_SIZE) - 1;
     uint carry = 0;
+
+    #pragma unroll(16)
     for (uint i = 0; i < NUM_LIMBS; i++) {
         uint c = lhs.limbs[i] + rhs.limbs[i] + carry;
         res.value.limbs[i] = c & mask;
@@ -44,6 +48,8 @@ inline BigIntResult bigint_sub(
 ) {
     BigIntResult res;
     res.carry = 0;
+
+    #pragma unroll(16)
     for (uint i = 0; i < NUM_LIMBS; i++) {
         res.value.limbs[i] = lhs.limbs[i] - rhs.limbs[i] - res.carry;
         if (lhs.limbs[i] < rhs.limbs[i] + res.carry) {
@@ -63,6 +69,8 @@ inline BigIntResultWide bigint_sub_wide(
 ) {
     BigIntResultWide res;
     res.carry = 0;
+
+    #pragma unroll(16)
     for (uint i = 0; i < NUM_LIMBS; i++) {
         res.value.limbs[i] = lhs.limbs[i] - rhs.limbs[i] - res.carry;
         if (lhs.limbs[i] < rhs.limbs[i] + res.carry) {
@@ -79,7 +87,7 @@ inline bool bigint_gte(
     BigInt lhs,
     BigInt rhs
 ) {
-    // for (uint i = NUM_LIMBS-1; i >= 0; i--) is troublesome from unknown reason
+    #pragma unroll(16)
     for (uint idx = 0; idx < NUM_LIMBS; idx++) {
         uint i = NUM_LIMBS - 1 - idx;
         if (lhs.limbs[i] < rhs.limbs[i]) return false;
@@ -92,6 +100,7 @@ inline bool bigint_wide_gte(
     BigIntWide lhs,
     BigIntWide rhs
 ) {
+    #pragma unroll(17)
     for (uint idx = 0; idx < NUM_LIMBS_WIDE; idx++) {
         uint i = NUM_LIMBS_WIDE - 1 - idx;
         if (lhs.limbs[i] < rhs.limbs[i]) return false;
@@ -104,6 +113,7 @@ inline bool bigint_eq(
     BigInt lhs,
     BigInt rhs
 ) {
+    #pragma unroll(16)
     for (uint i = 0; i < NUM_LIMBS; i++) {
         if (lhs.limbs[i] != rhs.limbs[i]) return false;
     }
@@ -111,6 +121,7 @@ inline bool bigint_eq(
 }
 
 inline bool is_bigint_zero(BigInt x) {
+    #pragma unroll(16)
     for (uint i = 0; i < NUM_LIMBS; i++) {
         if (x.limbs[i] != 0) return false;
     }
@@ -120,6 +131,8 @@ inline bool is_bigint_zero(BigInt x) {
 // Conversion functions
 inline BigIntWide bigint_to_wide(BigInt x) {
     BigIntWide res = bigint_zero_wide();
+
+    #pragma unroll(16)
     for (uint i = 0; i < NUM_LIMBS; i++) {
         res.limbs[i] = x.limbs[i];
     }
@@ -128,7 +141,8 @@ inline BigIntWide bigint_to_wide(BigInt x) {
 
 inline BigInt bigint_from_wide(BigIntWide x) {
     BigInt res = bigint_zero();
-    // ignore the last limb
+
+    #pragma unroll(16)
     for (uint i = 0; i < NUM_LIMBS; i++) {
         res.limbs[i] = x.limbs[i];
     }

--- a/mopro-msm/src/msm/metal_msm/shader/curve/utils.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/curve/utils.metal
@@ -11,6 +11,7 @@ inline bool is_jacobian_zero(Jacobian a) {
 }
 
 inline bool jacobian_eq(Jacobian lhs, Jacobian rhs) {
+    #pragma unroll(16)
     for (uint i = 0; i < NUM_LIMBS; i++) {
         if (lhs.x.limbs[i] != rhs.x.limbs[i]) return false;
         else if (lhs.y.limbs[i] != rhs.y.limbs[i]) return false;

--- a/mopro-msm/src/msm/metal_msm/shader/cuzk/barrett_reduction.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/cuzk/barrett_reduction.metal
@@ -15,8 +15,10 @@ using namespace metal;
 
 BigIntExtraWide mul(BigIntWide a, BigIntWide b) {
     BigIntExtraWide res = bigint_zero_extra_wide();
-    
+
+    #pragma unroll(17)
     for (uint i = 0; i < NUM_LIMBS_WIDE; i++) {
+        #pragma unroll(17)
         for (uint j = 0; j < NUM_LIMBS_WIDE; j++) {
             ulong c = (ulong)a.limbs[i] * (ulong)b.limbs[j];
             res.limbs[i+j] += c & MASK;
@@ -25,6 +27,7 @@ BigIntExtraWide mul(BigIntWide a, BigIntWide b) {
     }
 
     // Start from 0 and carry the extra over to the next index.
+    #pragma unroll(32)
     for (uint i = 0; i < NUM_LIMBS_EXTRA_WIDE; i++) {
         res.limbs[i+1] += res.limbs[i] >> LOG_LIMB_SIZE;
         res.limbs[i] = res.limbs[i] & MASK;
@@ -37,6 +40,7 @@ BigIntResultExtraWide sub_512(BigIntExtraWide a, BigIntExtraWide b) {
     res.value = bigint_zero_extra_wide();
     res.carry = 0;
 
+    #pragma unroll(32)
     for (uint i = 0; i < NUM_LIMBS_EXTRA_WIDE; i++) {
         res.value.limbs[i] = a.limbs[i] - b.limbs[i] - res.carry;
         if (a.limbs[i] < (b.limbs[i] + res.carry)) {
@@ -55,6 +59,7 @@ BigIntResultExtraWide add_512(BigIntExtraWide a, BigIntExtraWide b) {
     res.value = bigint_zero_extra_wide();
     res.carry = 0;
 
+    #pragma unroll(32)
     for (uint i = 0; i < NUM_LIMBS_EXTRA_WIDE; i++) {
         ulong sum = (ulong)a.limbs[i] + (ulong)b.limbs[i] + res.carry;
         res.value.limbs[i] = sum & MASK;
@@ -65,6 +70,8 @@ BigIntResultExtraWide add_512(BigIntExtraWide a, BigIntExtraWide b) {
 
 BigInt get_higher_with_slack(BigIntExtraWide a) {
     BigInt out = bigint_zero();
+
+    #pragma unroll(16)
     for (uint i = 0; i < NUM_LIMBS; i++) {
         out.limbs[i] = ((a.limbs[i + NUM_LIMBS] << SLACK) + 
                         (a.limbs[i + NUM_LIMBS - 1] >> (LOG_LIMB_SIZE - SLACK))) & MASK;
@@ -92,6 +99,8 @@ BigInt barrett_reduce(BigIntExtraWide a) {
     }
 
     BigInt r = bigint_zero();
+
+    #pragma unroll(16)
     for (uint i = 0; i < NUM_LIMBS; i++) {
         r.limbs[i] = r_wide.limbs[i];
     }

--- a/mopro-msm/src/msm/metal_msm/shader/cuzk/convert_point_coords_and_decompose_scalars.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/cuzk/convert_point_coords_and_decompose_scalars.metal
@@ -42,6 +42,7 @@ kernel void convert_point_coords_and_decompose_scalars(
     //  so each point uses 16 x 32-bit = 16 indices.
     uint base_offset = id * 16u;
 
+    #pragma unroll(8)
     for (uint i = 0u; i < 8u; i++) {
         // coords[base_offset + i] is the i-th 32-bit chunk of x
         // coords[base_offset + 8 + i] is the i-th 32-bit chunk of y
@@ -58,6 +59,7 @@ kernel void convert_point_coords_and_decompose_scalars(
     BigInt x_bigint = bigint_zero();
     BigInt y_bigint = bigint_zero();
 
+    #pragma unroll(15)
     for (uint i = 0; i < NUM_LIMBS - 1u; i++) {
         x_bigint.limbs[i] = extract_word_from_bytes_le(x_bytes, i, LOG_LIMB_SIZE);
         y_bigint.limbs[i] = extract_word_from_bytes_le(y_bytes, i, LOG_LIMB_SIZE);
@@ -79,6 +81,8 @@ kernel void convert_point_coords_and_decompose_scalars(
 
     // 2) Decompose scalars: read 8 32-bit values => 16 halfwords in `scalar_bytes`.
     uint scalar_bytes[16];
+
+    #pragma unroll(8)
     for (uint i = 0; i < 8u; i++) {
         uint s = scalars[id * 8u + i];
         uint hi = s >> 16u;

--- a/mopro-msm/src/msm/metal_msm/shader/cuzk/convert_point_coords_and_decompose_scalars.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/cuzk/convert_point_coords_and_decompose_scalars.metal
@@ -14,12 +14,12 @@ using namespace metal;
 #endif
 
 kernel void convert_point_coords_and_decompose_scalars(
-    device const uint* coords               [[ buffer(0) ]],
-    device const uint* scalars              [[ buffer(1) ]],
-    device BigInt* point_x                  [[ buffer(2) ]],
-    device BigInt* point_y                  [[ buffer(3) ]],
-    device uint* chunks                     [[ buffer(4) ]],
-    constant uint4& params                  [[ buffer(5) ]],
+    device const uint* coords               [[ buffer(0), access(read) ]],
+    device const uint* scalars              [[ buffer(1), access(read) ]],
+    device BigInt* point_x                  [[ buffer(2), access(write) ]],
+    device BigInt* point_y                  [[ buffer(3), access(write) ]],
+    device uint* chunks                     [[ buffer(4), access(write) ]],
+    constant uint4& params                  [[ buffer(5), access(read) ]],
     uint3 gid                               [[ thread_position_in_grid ]],
     uint3 threadgroup_size                  [[ threadgroups_per_grid ]]
 ) {

--- a/mopro-msm/src/msm/metal_msm/shader/cuzk/pbpr.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/cuzk/pbpr.metal
@@ -30,13 +30,13 @@ static Jacobian double_and_add(Jacobian point, uint scalar) {
 }
 
 kernel void bpr_stage_1(
-    device BigInt* bucket_sum_x         [[ buffer(0) ]],
-    device BigInt* bucket_sum_y         [[ buffer(1) ]],
-    device BigInt* bucket_sum_z         [[ buffer(2) ]],
-    device BigInt* g_points_x           [[ buffer(3) ]],
-    device BigInt* g_points_y           [[ buffer(4) ]],
-    device BigInt* g_points_z           [[ buffer(5) ]],
-    constant uint3& params              [[ buffer(6) ]],
+    device BigInt* bucket_sum_x         [[ buffer(0), access(read_write) ]],
+    device BigInt* bucket_sum_y         [[ buffer(1), access(read_write) ]],
+    device BigInt* bucket_sum_z         [[ buffer(2), access(read_write) ]],
+    device BigInt* g_points_x           [[ buffer(3), access(write) ]],
+    device BigInt* g_points_y           [[ buffer(4), access(write) ]],
+    device BigInt* g_points_z           [[ buffer(5), access(write) ]],
+    constant uint3& params              [[ buffer(6), access(read) ]],
     uint tid                            [[ thread_position_in_grid ]],
     uint workgroup_size                 [[ dispatch_threads_per_threadgroup ]]
 ) {
@@ -71,8 +71,6 @@ kernel void bpr_stage_1(
     Jacobian g = m;
 
     for (uint i = 0; i < buckets_per_thread - 1u; i++) {
-        // LOG_DEBUG("[bpr_stage_1] i: %u, thread_id: %u, num_threads_per_subtask: %u, buckets_per_thread: %u, offset: %u", i, thread_id, num_threads_per_subtask, buckets_per_thread, offset);
-
         uint idx = (num_threads_per_subtask - (thread_id % num_threads_per_subtask)) * buckets_per_thread - 1u - i;
         uint bi = offset + idx;
         Jacobian b = {
@@ -89,12 +87,6 @@ kernel void bpr_stage_1(
     bucket_sum_z[idx] = m.z;
 
     uint g_rw_idx = (subtask_idx / num_subtasks_per_bpr) * (num_threads_per_subtask * num_subtasks_per_bpr) + thread_id;
-    // guard write into g_points buffers
-    if (g_rw_idx < num_threads_per_subtask * num_subtasks_per_bpr) {
-        g_points_x[g_rw_idx] = g.x;
-        g_points_y[g_rw_idx] = g.y;
-        g_points_z[g_rw_idx] = g.z;
-    }
     g_points_x[g_rw_idx] = g.x;
     g_points_y[g_rw_idx] = g.y;
     g_points_z[g_rw_idx] = g.z;
@@ -102,13 +94,13 @@ kernel void bpr_stage_1(
 
 
 kernel void bpr_stage_2(
-    device BigInt* bucket_sum_x         [[ buffer(0) ]],
-    device BigInt* bucket_sum_y         [[ buffer(1) ]],
-    device BigInt* bucket_sum_z         [[ buffer(2) ]],
-    device BigInt* g_points_x           [[ buffer(3) ]],
-    device BigInt* g_points_y           [[ buffer(4) ]],
-    device BigInt* g_points_z           [[ buffer(5) ]],
-    constant uint3& params              [[ buffer(6) ]],
+    device BigInt* bucket_sum_x         [[ buffer(0), access(read) ]],
+    device BigInt* bucket_sum_y         [[ buffer(1), access(read) ]],
+    device BigInt* bucket_sum_z         [[ buffer(2), access(read) ]],
+    device BigInt* g_points_x           [[ buffer(3), access(read_write) ]],
+    device BigInt* g_points_y           [[ buffer(4), access(read_write) ]],
+    device BigInt* g_points_z           [[ buffer(5), access(read_write) ]],
+    constant uint3& params              [[ buffer(6), access(read) ]],
     uint tid                            [[ thread_position_in_grid ]],
     uint workgroup_size                 [[ dispatch_threads_per_threadgroup ]]
 ) {

--- a/mopro-msm/src/msm/metal_msm/shader/cuzk/smvp.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/cuzk/smvp.metal
@@ -12,14 +12,14 @@ using namespace metal;
 #endif
 
 kernel void smvp(
-    device const uint*          row_ptr             [[ buffer(0) ]],
-    device const uint*          val_idx             [[ buffer(1) ]],
-    device const BigInt*        new_point_x         [[ buffer(2) ]],
-    device const BigInt*        new_point_y         [[ buffer(3) ]],
-    device BigInt*              bucket_x            [[ buffer(4) ]],
-    device BigInt*              bucket_y            [[ buffer(5) ]],
-    device BigInt*              bucket_z            [[ buffer(6) ]],
-    constant uint4&             params              [[ buffer(7) ]],
+    device const uint*          row_ptr             [[ buffer(0), access(read) ]],
+    device const uint*          val_idx             [[ buffer(1), access(read) ]],
+    device const BigInt*        new_point_x         [[ buffer(2), access(read) ]],
+    device const BigInt*        new_point_y         [[ buffer(3), access(read) ]],
+    device BigInt*              bucket_x            [[ buffer(4), access(read_write) ]],
+    device BigInt*              bucket_y            [[ buffer(5), access(read_write) ]],
+    device BigInt*              bucket_z            [[ buffer(6), access(read_write) ]],
+    constant uint4&             params              [[ buffer(7), access(read) ]],
     uint3                       tgid                [[ threadgroup_position_in_grid ]],
     uint3                       tid                 [[ thread_position_in_threadgroup ]],
     uint3                       workgroup_size      [[ dispatch_threads_per_threadgroup ]],

--- a/mopro-msm/src/msm/metal_msm/shader/cuzk/transpose.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/cuzk/transpose.metal
@@ -54,12 +54,11 @@ kernel void transpose(
         const uint col = all_csr_col_idx[cci_offset + j];
         
         // Get current position for this column
-        uint loc = atomic_load_explicit(
+        const uint loc = atomic_load_explicit(
             &all_csc_col_ptr[ccp_offset + col], 
             memory_order_relaxed
-        );
-
-        loc += all_curr[curr_offset + col];
+        ) + all_curr[curr_offset + col];
+        
         all_curr[curr_offset + col]++;
         
         // Store the value index in CSC format

--- a/mopro-msm/src/msm/metal_msm/shader/cuzk/transpose.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/cuzk/transpose.metal
@@ -6,12 +6,12 @@
 using namespace metal;
 
 kernel void transpose(
-    device const uint* all_csr_col_idx      [[buffer(0)]],
-    device atomic_uint* all_csc_col_ptr     [[buffer(1)]],
-    device uint* all_csc_val_idxs           [[buffer(2)]],
-    device uint* all_curr                   [[buffer(3)]],
-    constant uint2& params                  [[buffer(4)]],
-    uint gid                                [[thread_position_in_grid]]
+    device const uint* all_csr_col_idx      [[ buffer(0), access(read) ]],
+    device atomic_uint* all_csc_col_ptr     [[ buffer(1), access(read_write) ]],
+    device uint* all_csc_val_idxs           [[ buffer(2), access(read_write) ]],
+    device uint* all_curr                   [[ buffer(3), access(read_write) ]],
+    constant uint2& params                  [[ buffer(4), access(read) ]],
+    uint gid                                [[ thread_position_in_grid ]]
 ) {
     const uint subtask_idx = gid;
 

--- a/mopro-msm/src/msm/metal_msm/shader/misc/get_constant.metal
+++ b/mopro-msm/src/msm/metal_msm/shader/misc/get_constant.metal
@@ -37,6 +37,8 @@ constant BigInt MODULUS = {
 
 BigInt get_mu() {
     BigInt mu;
+
+    #pragma unroll(16)
     for (uint i = 0; i < NUM_LIMBS; i++) {
         mu.limbs[i] = BARRETT_MU[i];
     }
@@ -46,6 +48,8 @@ BigInt get_mu() {
 BigInt get_n0() {
     BigInt n0;
     uint tmp = N0;
+
+    #pragma unroll(16)
     for (uint i = 0; i < NUM_LIMBS; i++) {
         n0.limbs[i] = tmp & MASK;
         tmp >>= LOG_LIMB_SIZE;
@@ -55,6 +59,8 @@ BigInt get_n0() {
 
 BigIntWide get_r() {
     BigIntWide r;
+
+    #pragma unroll(17)
     for (uint i = 0; i < NUM_LIMBS_WIDE; i++) {
         r.limbs[i] = MONT_RADIX[i];
     }
@@ -63,6 +69,8 @@ BigIntWide get_r() {
 
 BigIntWide get_p_wide() {
     BigIntWide p;
+
+    #pragma unroll(16)
     for (uint i = 0; i < NUM_LIMBS; i++) {
         p.limbs[i] = BN254_BASEFIELD_MODULUS[i];
     }
@@ -71,6 +79,8 @@ BigIntWide get_p_wide() {
 
 BigIntExtraWide get_p_extra_wide() {
     BigIntExtraWide p;
+
+    #pragma unroll(16)
     for (uint i = 0; i < NUM_LIMBS; i++) {
         p.limbs[i] = BN254_BASEFIELD_MODULUS[i];
     }
@@ -79,6 +89,8 @@ BigIntExtraWide get_p_extra_wide() {
 
 BigInt bigint_zero() {
     BigInt s;
+
+    #pragma unroll(16)
     for (uint i = 0; i < NUM_LIMBS; i++) {
         s.limbs[i] = 0;
     }
@@ -87,6 +99,8 @@ BigInt bigint_zero() {
 
 BigIntWide bigint_zero_wide() {
     BigIntWide s;
+
+    #pragma unroll(17)
     for (uint i = 0; i < NUM_LIMBS_WIDE; i++) {
         s.limbs[i] = 0;
     }
@@ -95,6 +109,8 @@ BigIntWide bigint_zero_wide() {
 
 BigIntExtraWide bigint_zero_extra_wide() {
     BigIntExtraWide s;
+
+    #pragma unroll(32)
     for (uint i = 0; i < NUM_LIMBS_EXTRA_WIDE; i++) {
         s.limbs[i] = 0;
     }
@@ -103,6 +119,8 @@ BigIntExtraWide bigint_zero_extra_wide() {
 
 Jacobian get_bn254_zero() {
     Jacobian zero;
+
+    #pragma unroll(16)
     for (uint i = 0; i < NUM_LIMBS; i++) {
         zero.x.limbs[i] = BN254_ZERO_X[i];
         zero.y.limbs[i] = BN254_ZERO_Y[i];
@@ -113,6 +131,8 @@ Jacobian get_bn254_zero() {
 
 Jacobian get_bn254_one() {
     Jacobian one;
+
+    #pragma unroll(16)
     for (uint i = 0; i < NUM_LIMBS; i++) {
         one.x.limbs[i] = BN254_ONE_X[i];
         one.y.limbs[i] = BN254_ONE_Y[i];
@@ -123,6 +143,8 @@ Jacobian get_bn254_one() {
 
 Jacobian get_bn254_zero_mont() {
     Jacobian zero;
+
+    #pragma unroll(16)
     for (uint i = 0; i < NUM_LIMBS; i++) {
         zero.x.limbs[i] = BN254_ZERO_XR[i];
         zero.y.limbs[i] = BN254_ZERO_YR[i];
@@ -133,6 +155,8 @@ Jacobian get_bn254_zero_mont() {
 
 Jacobian get_bn254_one_mont() {
     Jacobian one;
+
+    #pragma unroll(16)
     for (uint i = 0; i < NUM_LIMBS; i++) {
         one.x.limbs[i] = BN254_ONE_XR[i];
         one.y.limbs[i] = BN254_ONE_YR[i];


### PR DESCRIPTION
related issue
- #2 

1. add explicit access qualifiers for shaders
2. optimize loop unrolling with `#pragma unroll`
3. update atomics load logics in `transpose.metal`

## Loop Unrolling benefits larger input sizes but make small & medium sizes slightly slower
one interesting thing is that for optimization of loop unrolling, it shows improvements for larger input sizes (> 2^20) but make the small & medium input sizes a bit slower.

### with_UNROLL
```
Input Size   Metal Time      Arkworks Time   Speedup         Correct   
---------------------------------------------------------------------------
2^12 (4096)  0.064s          0.006s          11.49x slower   ✓         
  └─ Data generation: 0.011s
2^13 (8192)  0.106s          0.011s          9.75x slower    ✓         
  └─ Data generation: 0.019s
2^14 (16384) 0.124s          0.018s          6.70x slower    ✓         
  └─ Data generation: 0.042s
2^15 (32768) 0.161s          0.035s          4.59x slower    ✓         
  └─ Data generation: 0.074s
2^16 (65536) 0.252s          0.067s          3.77x slower    ✓         
  └─ Data generation: 0.150s
2^17 (131072) 0.411s          0.128s          3.21x slower    ✓         
  └─ Data generation: 0.278s
2^18 (262144) 0.663s          0.240s          2.76x slower    ✓         
  └─ Data generation: 0.560s
2^19 (524288) 1.020s          0.457s          2.23x slower    ✓         
  └─ Data generation: 1.143s
2^20 (1048576) 1.687s          0.909s          1.86x slower    ✓         
  └─ Data generation: 2.218s
2^21 (2097152) 2.905s          1.521s          1.91x slower    ✓         
  └─ Data generation: 4.319s
2^22 (4194304) 5.405s          3.336s          1.62x slower    ✓         
  └─ Data generation: 8.757s
```

### without_UNROLL
```
Input Size   Metal Time      Arkworks Time   Speedup         Correct   
---------------------------------------------------------------------------
2^12 (4096)  0.056s             0.006s          8.89x slower    ✓         
  └─ Data generation: 0.011s
2^13 (8192)  0.095s             0.013s          7.58x slower    ✓         
  └─ Data generation: 0.022s
2^14 (16384) 0.120s             0.022s          5.40x slower    ✓         
  └─ Data generation: 0.046s
2^15 (32768) 0.155s             0.038s          4.06x slower    ✓         
  └─ Data generation: 0.082s
2^16 (65536) 0.228s             0.070s          3.28x slower    ✓         
  └─ Data generation: 0.151s
2^17 (131072) 0.390s            0.126s          3.10x slower    ✓         
  └─ Data generation: 0.298s
2^18 (262144) 0.627s            0.241s          2.61x slower    ✓         
  └─ Data generation: 0.553s
2^19 (524288) 1.065s            0.472s          2.26x slower    ✓         
  └─ Data generation: 1.153s
2^20 (1048576) 1.822s           0.908s          2.01x slower    ✓         
  └─ Data generation: 2.195s
2^21 (2097152) 3.281s           1.636s          2.01x slower    ✓         
  └─ Data generation: 4.700s
2^22 (4194304) 6.498s           3.532s          1.84x slower    ✓         
  └─ Data generation: 9.445s
```

another thing worth mentioning is SIMD ops optimization; as a result, the performance is slightly improved for larger input sizes as well. however, it will make the code very complicated. therefore, we tend to backlog this optimization direction.

`take bigint_gte()` as an example,

### original
```metal
inline bool bigint_gte(
    BigInt lhs,
    BigInt rhs
) {
    #pragma unroll(16)
    for (uint idx = 0; idx < NUM_LIMBS; idx++) {
        uint i = NUM_LIMBS - 1 - idx;
        if (lhs.limbs[i] < rhs.limbs[i]) return false;
        else if (lhs.limbs[i] > rhs.limbs[i]) return true;
    }
    return true;
}
```
### use SIMD ops
```metal
inline bool bigint_gte(
    BigInt lhs,
    BigInt rhs
) {
    // Process limbs in groups of 4 from most significant to least significant
    #pragma unroll(4)
    for (uint block = 0; block < NUM_LIMBS; block += 4) {
        uint base_idx = NUM_LIMBS - 1 - block;
        
        if (base_idx >= 3) {
            // Load 4 limbs at once using SIMD (in reverse order for MSB first)
            uint4 lhs_vec = uint4(lhs.limbs[base_idx], lhs.limbs[base_idx-1], 
                                  lhs.limbs[base_idx-2], lhs.limbs[base_idx-3]);
            uint4 rhs_vec = uint4(rhs.limbs[base_idx], rhs.limbs[base_idx-1], 
                                  rhs.limbs[base_idx-2], rhs.limbs[base_idx-3]);
            
            // Check each component (MSB first)
            if (lhs_vec.x < rhs_vec.x) return false;
            else if (lhs_vec.x > rhs_vec.x) return true;
            
            if (lhs_vec.y < rhs_vec.y) return false;
            else if (lhs_vec.y > rhs_vec.y) return true;
            
            if (lhs_vec.z < rhs_vec.z) return false;
            else if (lhs_vec.z > rhs_vec.z) return true;
            
            if (lhs_vec.w < rhs_vec.w) return false;
            else if (lhs_vec.w > rhs_vec.w) return true;
        } else {
            // Handle remaining limbs
            for (uint idx = 0; idx <= base_idx; idx++) {
                uint i = base_idx - idx;
                if (lhs.limbs[i] < rhs.limbs[i]) return false;
                else if (lhs.limbs[i] > rhs.limbs[i]) return true;
            }
            break;
        }
    }
    return true;
}
```